### PR TITLE
test(logql): Add log-selection query support to the logqltest DSL

### DIFF
--- a/pkg/logql/internal/logqltest/AGENTS.md
+++ b/pkg/logql/internal/logqltest/AGENTS.md
@@ -1,8 +1,8 @@
 # Working on the logqltest DSL
 
-This package defines the declarative test DSL for LogQL metric queries. For **writing** `.logqltest`
-scripts see [`testdata/AGENTS.md`](testdata/AGENTS.md); this file is about **changing the DSL
-itself**.
+This package defines the declarative test DSL for LogQL metric and log-selection queries. For
+**writing** `.logqltest` scripts see [`testdata/AGENTS.md`](testdata/AGENTS.md); this file is about
+**changing the DSL itself**.
 
 The DSL is described in four places that must stay in sync:
 

--- a/pkg/logql/internal/logqltest/README.md
+++ b/pkg/logql/internal/logqltest/README.md
@@ -1,10 +1,10 @@
 # LogQL declarative test scripts syntax
 
 The `testdata/*.logqltest` scripts alongside this package are declarative correctness tests for LogQL
-**metric** queries. Each `.logqltest` file loads some log streams and evaluates queries against
-absolute, hand-specified expected results. Scripts are run by `TestLogQLScripts` through the real
-`logql.Engine` over a filesystem-backed chunk store (TSDB index), so the full storage read path and
-parsing/extraction pipeline are exercised end to end.
+**metric and log-selection** queries. Each `.logqltest` file loads some log streams and evaluates
+queries against absolute, hand-specified expected results. Scripts are run by `TestLogQLScripts`
+through the real `logql.Engine` over a filesystem-backed chunk store (TSDB index), so the full
+storage read path and parsing/extraction pipeline are exercised end to end.
 
 The format is adapted from Prometheus' [`promqltest`](https://github.com/prometheus/prometheus/tree/main/promql/promqltest)
 DSL.
@@ -49,7 +49,7 @@ load
 
 ### `eval`
 
-Evaluates a metric query and checks its result.
+Evaluates a query (metric or log-selection) and checks its result.
 
 ```
 eval instant at <time> <logql>
@@ -62,6 +62,8 @@ eval range from <t0> to <t1> step <step> <logql>
 - Times (`<time>`, `<t0>`, `<t1>`, `<step>`) are Go durations offset from the script epoch.
 - Expected results follow on indented lines. The block ends at a blank line, a dedented line,
   or EOF.
+- `<step>` is required by the grammar even for a log-selection query, which has no notion of a
+  step; give it any positive duration.
 
 ## Expected results
 
@@ -69,6 +71,11 @@ eval range from <t0> to <t1> step <step> <logql>
 - **Scalar** (e.g. `1 + 2`): a single line with just the number.
 - **Matrix** (range queries): one line per series, `{labels} <p0> <p1> …`, one point per step
   from `<t0>` to `<t1>`. Use `_` for a step with no point.
+- **Streams** (log-selection queries, e.g. `{app="foo"} |= "bar"`): one line per log entry,
+  `{labels} "<line>" @ <ts>` (or `` `<line>` `` for a raw line). Several lines sharing the same
+  `{labels}` belong to one stream and are checked as an exact, ordered sequence — a stream's line
+  order is meaningful, unlike the set of series in a vector/matrix. Distinct label sets are
+  compared as a set (order-independent), like series.
 
 Point syntax (from promqltest):
 
@@ -86,14 +93,33 @@ An **empty-value label is significant**: `{app="a", age=""}` asserts that `age` 
 empty value (e.g. from a `json` expression whose path is missing, or `logfmt --keep-empty`), which is
 distinct from omitting `age` entirely.
 
-Every `eval` must assert exactly one kind of result — series, a scalar, `expect empty`, or
-`expect fail`; otherwise the harness errors (a forgotten expected block would otherwise pass
-vacuously on an empty result).
+Every `eval` must assert exactly one kind of result — series, log streams, a scalar,
+`expect empty`, or `expect fail`; otherwise the harness errors (a forgotten expected block would
+otherwise pass vacuously on an empty result).
+
+### Log-selection window
+
+A log-selection query's window is **start-inclusive, end-exclusive**: `[t0, t1)` for
+`eval range`, and `[T−30s, T)` for `eval instant at T` (a fixed 30s look-back). This is the
+opposite of a metric range vector's `(start, end]` — a line exactly at `t1` (or at the instant
+`T`) falls **outside** the window:
+
+```
+load
+  {app="foo"} "in range"    @ 10s
+  {app="foo"} "at boundary" @ 20s
+
+eval range from 0 to 20s step 10s {app="foo"}
+  {app="foo"} "in range" @ 10s
+```
+
+A log-selection `eval` always runs in the default `FORWARD` direction with a fixed 1000-line
+limit; direction and limit are not yet configurable from the DSL.
 
 ### Empty results
 
-To assert that a query returns no series — e.g. `absent_over_time` over present data, or a
-comparison whose sides never match — use `expect empty`:
+To assert that a query returns no series or streams — e.g. `absent_over_time` over present data,
+a comparison whose sides never match, or a selector matching no stream — use `expect empty`:
 
 ```
 eval instant at 60s count_over_time({app="missing"}[1m])
@@ -139,8 +165,9 @@ eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) 
 ```
 
 - `<stack>` is the exact stack name, in double quotes.
-- The named stack still runs the query, must not error, and is still checked for series count,
-  sample count, and timestamps. Only the float value comparison is skipped.
+- The named stack still runs the query, must not error, and is still checked for series/stream
+  count, sample/line count, and timestamps. Only the float value comparison (or, for a
+  log-selection query, the log line text) is skipped.
 
 ## Execution stacks
 
@@ -163,9 +190,17 @@ eval instant at 60s sum by (app) (count_over_time({app=~"foo|bar"}[1m]))
 
 eval range from 0 to 60s step 30s count_over_time({app="foo"}[30s])
   {app="foo"} _ 3 3
+
+eval range from 0 to 60s step 30s {app="foo"} |= "status=200"
+  {app="foo"} "level=info status=200" @ 10s
+  {app="foo"} "level=info status=200" @ 20s
+  {app="foo"} "level=info status=200" @ 30s
+  {app="foo"} "level=info status=200" @ 40s
+  {app="foo"} "level=info status=200" @ 50s
 ```
 
 ## Scope
 
-Metric queries only (results of type vector / scalar / matrix). Log queries (streams) are not
-yet supported.
+Metric queries (results of type vector / scalar / matrix) and log-selection queries (results of
+type streams — a stream selector with optional line/label filters, parsers, and formatters).
+Tailing and `expect ordered` for streams are not yet supported.

--- a/pkg/logql/internal/logqltest/README.md
+++ b/pkg/logql/internal/logqltest/README.md
@@ -49,7 +49,9 @@ load
 
 ### `eval`
 
-Evaluates a query (metric or log-selection) and checks its result.
+Evaluates a query and checks its result. `instant`/`range` are for a metric query (results of
+type vector/scalar/matrix); `select` is for a log-selection query (results of type streams — see
+"Log-selection window" below), which has no notion of a step.
 
 ```
 eval instant at <time> <logql>
@@ -57,13 +59,14 @@ eval instant at <time> <logql>
 
 eval range from <t0> to <t1> step <step> <logql>
   <expected series...>
+
+eval select from <t0> to <t1> <logql>
+  <expected streams...>
 ```
 
 - Times (`<time>`, `<t0>`, `<t1>`, `<step>`) are Go durations offset from the script epoch.
 - Expected results follow on indented lines. The block ends at a blank line, a dedented line,
   or EOF.
-- `<step>` is required by the grammar even for a log-selection query, which has no notion of a
-  step; give it any positive duration.
 
 ## Expected results
 
@@ -100,7 +103,7 @@ otherwise pass vacuously on an empty result).
 ### Log-selection window
 
 A log-selection query's window is **start-inclusive, end-exclusive**: `[t0, t1)` for
-`eval range`, and `[T−30s, T)` for `eval instant at T` (a fixed 30s look-back). This is the
+`eval select`, and `[T−30s, T)` for `eval instant at T` (a fixed 30s look-back). This is the
 opposite of a metric range vector's `(start, end]` — a line exactly at `t1` (or at the instant
 `T`) falls **outside** the window:
 
@@ -109,7 +112,7 @@ load
   {app="foo"} "in range"    @ 10s
   {app="foo"} "at boundary" @ 20s
 
-eval range from 0 to 20s step 10s {app="foo"}
+eval select from 0 to 20s {app="foo"}
   {app="foo"} "in range" @ 10s
 ```
 
@@ -191,7 +194,7 @@ eval instant at 60s sum by (app) (count_over_time({app=~"foo|bar"}[1m]))
 eval range from 0 to 60s step 30s count_over_time({app="foo"}[30s])
   {app="foo"} _ 3 3
 
-eval range from 0 to 60s step 30s {app="foo"} |= "status=200"
+eval select from 0 to 60s {app="foo"} |= "status=200"
   {app="foo"} "level=info status=200" @ 10s
   {app="foo"} "level=info status=200" @ 20s
   {app="foo"} "level=info status=200" @ 30s

--- a/pkg/logql/internal/logqltest/exec.go
+++ b/pkg/logql/internal/logqltest/exec.go
@@ -44,7 +44,7 @@ type executionStack interface {
 
 // isQueryShardingSupported reports whether the shard mapper fans a query out into >= 2 shards.
 func isQueryShardingSupported(query string) bool {
-	expr, err := syntax.ParseSampleExpr(query)
+	expr, err := syntax.ParseExpr(query)
 	if err != nil {
 		return false
 	}

--- a/pkg/logql/internal/logqltest/exec_query_frontend.go
+++ b/pkg/logql/internal/logqltest/exec_query_frontend.go
@@ -218,7 +218,7 @@ func (s *queryFrontendExecutionStack) querier() logql.Querier {
 
 func (s *queryFrontendExecutionStack) eval(cmd evalCmd) (logqlmodel.Result, error) {
 	var lokiReq queryrangebase.Request
-	if cmd.instant {
+	if cmd.mode == evalInstant {
 		lokiReq = &queryrange.LokiInstantRequest{
 			Query:     cmd.query,
 			Limit:     1000,

--- a/pkg/logql/internal/logqltest/exec_test.go
+++ b/pkg/logql/internal/logqltest/exec_test.go
@@ -11,12 +11,14 @@ func TestIsQueryShardingSupported(t *testing.T) {
 		query string
 		want  bool
 	}{
-		"shardable vector aggregation":     {`sum(rate({app="a"}[1m]))`, true},
-		"top-level quantile shards":        {`quantile_over_time(0.99, {app="a"} | unwrap v [1m]) by (pod)`, true},
-		"nested quantile does not shard":   {`max(quantile_over_time(0.99, {app="a"} | unwrap v [1m]))`, false},
-		"non-shardable range op":           {`stddev_over_time({app="a"} | unwrap v [1m])`, false},
-		"vector() literal does not shard":  {`vector(1)`, false},
-		"unparseable query is unsupported": {`}{ not a query`, false},
+		"shardable vector aggregation":         {`sum(rate({app="a"}[1m]))`, true},
+		"top-level quantile shards":            {`quantile_over_time(0.99, {app="a"} | unwrap v [1m]) by (pod)`, true},
+		"nested quantile does not shard":       {`max(quantile_over_time(0.99, {app="a"} | unwrap v [1m]))`, false},
+		"non-shardable range op":               {`stddev_over_time({app="a"} | unwrap v [1m])`, false},
+		"vector() literal does not shard":      {`vector(1)`, false},
+		"unparseable query is unsupported":     {`}{ not a query`, false},
+		"bare log selector shards":             {`{app="a"}`, true},
+		"log selector with line filter shards": {`{app="a"} |= "100"`, true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.Equal(t, tc.want, isQueryShardingSupported(tc.query))

--- a/pkg/logql/internal/logqltest/parser.go
+++ b/pkg/logql/internal/logqltest/parser.go
@@ -26,10 +26,11 @@ import (
 var epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 var (
-	// reInstant and reRange match the remainder of an `eval instant`/`eval range` line (after the
-	// mode keyword), capturing the trailing query to end of line.
+	// reInstant, reRange, and reSelect match the remainder of an `eval instant`/`eval range`/
+	// `eval select` line (after the mode keyword), capturing the trailing query to end of line.
 	reInstant = regexp.MustCompile(`^at\s+(\S+)\s+(.+)$`)
 	reRange   = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+step\s+(\S+)\s+(.+)$`)
+	reSelect  = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+(.+)$`)
 
 	// reAt, reRepeat and reMetadata are anchored to the head so each load-line directive matches
 	// only its own leading segment and can never reach into a later [metadata …] value.
@@ -202,19 +203,35 @@ func parseMetadata(rest string) ([]logproto.LabelAdapter, string, error) {
 	return out, rest[len(m[0]):], nil
 }
 
+// evalMode is the kind of `eval` command: `instant`, `range` (both metric queries), or `select`
+// (a log-selection query, which has no notion of a step).
+type evalMode int
+
+const (
+	evalInstant evalMode = iota
+	evalRange
+	evalSelect
+)
+
 type evalCmd struct {
-	instant          bool
+	mode             evalMode
 	ts               time.Duration // instant queries
-	start, end, step time.Duration // range queries
+	start, end, step time.Duration // range and select queries
 	query            string
 }
 
 // getTimeRange returns the query's [start, end] range and step.
 func (c evalCmd) getTimeRange() (start, end, step time.Duration) {
-	if c.instant {
+	switch c.mode {
+	case evalInstant:
 		return c.ts, c.ts, 0
+	case evalRange:
+		return c.start, c.end, c.step
+	case evalSelect:
+		return c.start, c.end, c.step
+	default:
+		panic(fmt.Sprintf("unknown eval mode %v", c.mode))
 	}
-	return c.start, c.end, c.step
 }
 
 func parseEval(line string) (evalCmd, error) {
@@ -229,7 +246,7 @@ func parseEval(line string) (evalCmd, error) {
 		if err != nil {
 			return evalCmd{}, fmt.Errorf("invalid instant time %q: %w", m[1], err)
 		}
-		return evalCmd{instant: true, ts: ts, query: strings.TrimSpace(m[2])}, nil
+		return evalCmd{mode: evalInstant, ts: ts, query: strings.TrimSpace(m[2])}, nil
 	case strings.HasPrefix(rest, "range"):
 		m := reRange.FindStringSubmatch(strings.TrimSpace(strings.TrimPrefix(rest, "range")))
 		if m == nil {
@@ -253,9 +270,29 @@ func parseEval(line string) (evalCmd, error) {
 		if end < start {
 			return evalCmd{}, fmt.Errorf("range end %q is before start %q", m[2], m[1])
 		}
-		return evalCmd{start: start, end: end, step: step, query: strings.TrimSpace(m[4])}, nil
+		return evalCmd{mode: evalRange, start: start, end: end, step: step, query: strings.TrimSpace(m[4])}, nil
+	case strings.HasPrefix(rest, "select"):
+		m := reSelect.FindStringSubmatch(strings.TrimSpace(strings.TrimPrefix(rest, "select")))
+		if m == nil {
+			return evalCmd{}, fmt.Errorf("malformed 'eval select': %q", line)
+		}
+		start, err := time.ParseDuration(m[1])
+		if err != nil {
+			return evalCmd{}, fmt.Errorf("invalid select start %q: %w", m[1], err)
+		}
+		end, err := time.ParseDuration(m[2])
+		if err != nil {
+			return evalCmd{}, fmt.Errorf("invalid select end %q: %w", m[2], err)
+		}
+		if end <= start {
+			return evalCmd{}, fmt.Errorf("select end %q must be after start %q", m[2], m[1])
+		}
+		// A log-selection query has no notion of a step; use one step covering the whole
+		// window so a query that unexpectedly turns out to be a metric query fails fast
+		// (wrong result shape) instead of hanging the step evaluator on a zero step.
+		return evalCmd{mode: evalSelect, start: start, end: end, step: end - start, query: strings.TrimSpace(m[3])}, nil
 	default:
-		return evalCmd{}, fmt.Errorf("expected 'instant' or 'range' after eval: %q", line)
+		return evalCmd{}, fmt.Errorf("expected 'instant', 'range', or 'select' after eval: %q", line)
 	}
 }
 

--- a/pkg/logql/internal/logqltest/parser.go
+++ b/pkg/logql/internal/logqltest/parser.go
@@ -274,16 +274,17 @@ const (
 )
 
 // expectations is the parsed expected result of an `eval` command: either a failure
-// assertion, a scalar value, an empty-result assertion, or a set of series (for
-// vector/matrix results).
+// assertion, a scalar value, an empty-result assertion, a set of series (for vector/matrix
+// results), or a set of log streams (for log-selection results).
 type expectations struct {
 	fail     bool
 	failKind failMatch
 	failText string
-	empty    bool // when set, the result must contain no series (`expect empty`)
+	empty    bool // when set, the result must contain no series/streams (`expect empty`)
 	ordered  bool // when set, series are compared positionally (for sort/sort_desc); instant only
 	scalar   *float64
 	series   []expectedSeries
+	streams  []expectedStream
 
 	// isValueComparisonSkipped holds the execution stacks (by name) whose result values are not
 	// compared, set by a `skip values-comparison on "<stack>"` directive. The stack still runs and
@@ -291,12 +292,13 @@ type expectations struct {
 	isValueComparisonSkipped map[string]bool
 }
 
-// validate ensures an eval asserts exactly one result kind: series, a scalar, `expect empty`,
-// or `expect fail`. This catches a forgotten expectation block (which would otherwise pass
-// vacuously on an empty result) and contradictory combinations that would be silently ignored.
+// validate ensures an eval asserts exactly one result kind: series, log streams, a scalar,
+// `expect empty`, or `expect fail`. This catches a forgotten expectation block (which would
+// otherwise pass vacuously on an empty result) and contradictory combinations that would be
+// silently ignored.
 func (e expectations) validate() error {
 	kinds := 0
-	for _, set := range []bool{e.fail, e.empty, e.scalar != nil, len(e.series) > 0} {
+	for _, set := range []bool{e.fail, e.empty, e.scalar != nil, len(e.series) > 0, len(e.streams) > 0} {
 		if set {
 			kinds++
 		}
@@ -305,9 +307,9 @@ func (e expectations) validate() error {
 	case e.failKind != failAny && !e.fail:
 		return fmt.Errorf("failure qualifier set without `expect fail`")
 	case kinds == 0:
-		return fmt.Errorf("eval has no expectation: provide series, a scalar, `expect empty`, or `expect fail`")
+		return fmt.Errorf("eval has no expectation: provide series, log streams, a scalar, `expect empty`, or `expect fail`")
 	case kinds > 1:
-		return fmt.Errorf("conflicting expectations: use exactly one of series, a scalar, `expect empty`, or `expect fail`")
+		return fmt.Errorf("conflicting expectations: use exactly one of series, log streams, a scalar, `expect empty`, or `expect fail`")
 	case e.ordered && len(e.series) == 0:
 		return fmt.Errorf("`expect ordered` requires series")
 	}
@@ -321,6 +323,20 @@ type expectedSeries struct {
 	samples []sample
 }
 
+// expectedLogEntry is one expected log line within an expectedStream: its timestamp (as a
+// duration offset from the script epoch) and text.
+type expectedLogEntry struct {
+	ts   time.Duration
+	line string
+}
+
+// expectedStream is one expected output log stream (for a log-selection query): its label set
+// (in `{a="b"}` string form) and its expected log lines, in order.
+type expectedStream struct {
+	labels  string
+	entries []expectedLogEntry
+}
+
 type expectationsParser struct {
 	exp expectations
 }
@@ -330,7 +346,8 @@ func newExpectationsParser() *expectationsParser {
 }
 
 // parse consumes one expectation line: an `expect` annotation (`fail [msg:|regex:]` / `empty` /
-// `ordered`), a `{labels} p0 p1 ...` series line, or a bare scalar value.
+// `ordered`), a `{labels} p0 p1 ...` series line, a `{labels} "line" @ <ts>` log-stream line, or a
+// bare scalar value.
 func (p *expectationsParser) parse(line string) error {
 	switch {
 	case strings.HasPrefix(line, "expect fail"):
@@ -356,7 +373,7 @@ func (p *expectationsParser) parse(line string) error {
 			return fmt.Errorf("unsupported `expect fail` qualifier %q (use `msg:` or `regex:`)", body)
 		}
 	case line == "expect empty":
-		// The result must contain no series.
+		// The result must contain no series or streams.
 		p.exp.empty = true
 	case line == "expect ordered":
 		// Compare the following series positionally rather than as a set (for sort/sort_desc).
@@ -381,6 +398,12 @@ func (p *expectationsParser) parse(line string) error {
 			p.exp.isValueComparisonSkipped = map[string]bool{}
 		}
 		p.exp.isValueComparisonSkipped[stack] = true
+	case strings.HasPrefix(line, "{") && isLogLine(line):
+		lbls, ts, text, err := parseLogLine(line)
+		if err != nil {
+			return err
+		}
+		p.addLogEntry(lbls.String(), ts, text)
 	case strings.HasPrefix(line, "{"):
 		lbls, samples, err := parseSeriesLine(line)
 		if err != nil {
@@ -395,6 +418,19 @@ func (p *expectationsParser) parse(line string) error {
 		p.exp.scalar = &v
 	}
 	return nil
+}
+
+// addLogEntry appends one expected log line to the stream keyed by labels, creating it on first
+// use. Streams are compared as a set (see compareStreams), so a linear scan to find the matching
+// stream is fine for the handful of expected lines a test script ever has.
+func (p *expectationsParser) addLogEntry(labels string, ts time.Duration, line string) {
+	for i := range p.exp.streams {
+		if p.exp.streams[i].labels == labels {
+			p.exp.streams[i].entries = append(p.exp.streams[i].entries, expectedLogEntry{ts: ts, line: line})
+			return
+		}
+	}
+	p.exp.streams = append(p.exp.streams, expectedStream{labels: labels, entries: []expectedLogEntry{{ts: ts, line: line}}})
 }
 
 // get returns the accumulated expectations.
@@ -428,6 +464,54 @@ func parseSeriesLine(line string) (labels.Labels, []sample, error) {
 		return labels.EmptyLabels(), nil, fmt.Errorf("series line %q has no sample values", line)
 	}
 	return lbls, samples, nil
+}
+
+// isLogLine reports whether an expectation line starting with '{' is a log-stream result line
+// (`{labels} "line" @ <ts>`) rather than a numeric series line (`{labels} p0 p1 ...`). The two
+// are unambiguous: no sample token (a float, `_`, `NaN`, `Inf`, or a `x`-expansion) can start
+// with a quote.
+func isLogLine(line string) bool {
+	_, rest, ok := strings.Cut(line, "}")
+	if !ok {
+		return false
+	}
+	rest = strings.TrimSpace(rest)
+	return strings.HasPrefix(rest, `"`) || strings.HasPrefix(rest, "`")
+}
+
+// parseLogLine parses an expected log-stream result line: `{labels} "line" @ <ts>` (or a
+// backtick-delimited raw line). Mirrors the `load` line format (selector, quoted line,
+// timestamp), minus the load-only `[repeat ...]` / `[metadata ...]` clauses.
+func parseLogLine(line string) (labels.Labels, time.Duration, string, error) {
+	line = strings.TrimSpace(line)
+	end := strings.IndexByte(line, '}')
+	if end < 0 {
+		return labels.EmptyLabels(), 0, "", fmt.Errorf("unterminated label set")
+	}
+	lbls, err := parseSeriesLabels(line[:end+1])
+	if err != nil {
+		return labels.EmptyLabels(), 0, "", err
+	}
+
+	text, rest, err := splitQuoted(line[end+1:])
+	if err != nil {
+		return labels.EmptyLabels(), 0, "", err
+	}
+
+	m := reAt.FindStringSubmatch(rest)
+	if m == nil {
+		return labels.EmptyLabels(), 0, "", fmt.Errorf("missing '@ <ts>' timestamp")
+	}
+	ts, err := time.ParseDuration(m[1])
+	if err != nil {
+		return labels.EmptyLabels(), 0, "", fmt.Errorf("invalid timestamp %q: %w", m[1], err)
+	}
+	rest = rest[len(m[0]):]
+
+	if leftover := strings.TrimSpace(rest); leftover != "" {
+		return labels.EmptyLabels(), 0, "", fmt.Errorf("unexpected content after log line: %q", leftover)
+	}
+	return lbls, ts, text, nil
 }
 
 func parseSeriesLabels(s string) (labels.Labels, error) {

--- a/pkg/logql/internal/logqltest/parser_test.go
+++ b/pkg/logql/internal/logqltest/parser_test.go
@@ -291,10 +291,12 @@ func TestExpectationsParser(t *testing.T) {
 func TestExpectationsValidate(t *testing.T) {
 	scalar := 1.0
 	series := []expectedSeries{{labels: `{a="b"}`, samples: []sample{{present: true, value: 1}}}}
+	streams := []expectedStream{{labels: `{a="b"}`, entries: []expectedLogEntry{{ts: 0, line: "x"}}}}
 
 	// Valid: exactly one result kind (plus ordered alongside series).
 	require.NoError(t, expectations{scalar: &scalar}.validate())
 	require.NoError(t, expectations{series: series}.validate())
+	require.NoError(t, expectations{streams: streams}.validate())
 	require.NoError(t, expectations{empty: true}.validate())
 	require.NoError(t, expectations{fail: true}.validate())
 	require.NoError(t, expectations{ordered: true, series: series}.validate())
@@ -305,9 +307,55 @@ func TestExpectationsValidate(t *testing.T) {
 	require.Error(t, expectations{fail: true, series: series}.validate())
 	require.Error(t, expectations{scalar: &scalar, series: series}.validate())
 	require.Error(t, expectations{empty: true, series: series}.validate())
+	require.Error(t, expectations{series: series, streams: streams}.validate())
 	require.Error(t, expectations{ordered: true}.validate())
 	require.Error(t, expectations{ordered: true, scalar: &scalar}.validate()) // ordered needs series
 	require.Error(t, expectations{failKind: failMsg}.validate())              // qualifier without fail
+}
+
+func TestIsLogLine(t *testing.T) {
+	require.True(t, isLogLine(`{app="foo"} "line" @ 10s`))
+	require.True(t, isLogLine("{app=\"foo\"} `raw line` @ 10s"))
+	require.False(t, isLogLine(`{app="foo"} 1 2 3`))
+	require.False(t, isLogLine(`{app="foo"} _ 5`))
+	require.False(t, isLogLine(`no braces`))
+}
+
+func TestParseLogLine(t *testing.T) {
+	lbls, ts, text, err := parseLogLine(`{app="foo", env="prod"} "hello world" @ 90s`)
+	require.NoError(t, err)
+	require.Equal(t, `{app="foo", env="prod"}`, lbls.String())
+	require.Equal(t, 90*time.Second, ts)
+	require.Equal(t, "hello world", text)
+
+	// A backtick raw line keeps its double quotes.
+	bt := "`"
+	_, _, text, err = parseLogLine(`{app="foo"} ` + bt + `{"a":"b"}` + bt + ` @ 0s`)
+	require.NoError(t, err)
+	require.Equal(t, `{"a":"b"}`, text)
+
+	_, _, _, err = parseLogLine(`{app="foo"} "line"`) // missing timestamp
+	require.Error(t, err)
+
+	_, _, _, err = parseLogLine(`{app="foo"} "line" @ 0s trailing junk`)
+	require.Error(t, err)
+}
+
+func TestExpectationsParser_LogStreams(t *testing.T) {
+	p := newExpectationsParser()
+	require.NoError(t, p.parse(`{app="foo"} "1st" @ 0s`))
+	require.NoError(t, p.parse(`{app="foo"} "2nd" @ 10s`))
+	require.NoError(t, p.parse(`{app="bar"} "x" @ 5s`))
+	exp := p.get()
+
+	require.Len(t, exp.streams, 2)
+	require.Equal(t, `{app="foo"}`, exp.streams[0].labels)
+	require.Equal(t, []expectedLogEntry{{ts: 0, line: "1st"}, {ts: 10 * time.Second, line: "2nd"}}, exp.streams[0].entries)
+	require.Equal(t, `{app="bar"}`, exp.streams[1].labels)
+	require.Equal(t, []expectedLogEntry{{ts: 5 * time.Second, line: "x"}}, exp.streams[1].entries)
+
+	// A malformed log line (missing timestamp) is surfaced, not silently dropped.
+	require.Error(t, newExpectationsParser().parse(`{app="foo"} "no timestamp"`))
 }
 
 func TestParseSeriesLabels(t *testing.T) {

--- a/pkg/logql/internal/logqltest/parser_test.go
+++ b/pkg/logql/internal/logqltest/parser_test.go
@@ -154,17 +154,25 @@ func TestStreamsParser_RejectsMalformedDirectives(t *testing.T) {
 func TestParseEval(t *testing.T) {
 	cmd, err := parseEval(`eval instant at 60s sum(rate({app="foo"}[1m]))`)
 	require.NoError(t, err)
-	require.True(t, cmd.instant)
+	require.Equal(t, evalInstant, cmd.mode)
 	require.Equal(t, time.Minute, cmd.ts)
 	require.Equal(t, `sum(rate({app="foo"}[1m]))`, cmd.query)
 
 	cmd, err = parseEval(`eval range from 0 to 10m step 1m count_over_time({app="foo"}[1m])`)
 	require.NoError(t, err)
-	require.False(t, cmd.instant)
+	require.Equal(t, evalRange, cmd.mode)
 	require.Equal(t, time.Duration(0), cmd.start)
 	require.Equal(t, 10*time.Minute, cmd.end)
 	require.Equal(t, time.Minute, cmd.step)
 	require.Equal(t, `count_over_time({app="foo"}[1m])`, cmd.query)
+
+	cmd, err = parseEval(`eval select from 0 to 10m {app="foo"}`)
+	require.NoError(t, err)
+	require.Equal(t, evalSelect, cmd.mode)
+	require.Equal(t, time.Duration(0), cmd.start)
+	require.Equal(t, 10*time.Minute, cmd.end)
+	require.Equal(t, 10*time.Minute, cmd.step)
+	require.Equal(t, `{app="foo"}`, cmd.query)
 
 	_, err = parseEval(`eval sideways at 0s foo`)
 	require.Error(t, err)
@@ -178,6 +186,12 @@ func TestParseEval(t *testing.T) {
 
 	// A backwards range (end before start) would produce an empty step window.
 	_, err = parseEval(`eval range from 10s to 0s step 1s count_over_time({app="foo"}[1m])`)
+	require.Error(t, err)
+
+	// An empty or backwards select window has no valid step to derive.
+	_, err = parseEval(`eval select from 10s to 10s {app="foo"}`)
+	require.Error(t, err)
+	_, err = parseEval(`eval select from 10s to 0s {app="foo"}`)
 	require.Error(t, err)
 }
 

--- a/pkg/logql/internal/logqltest/runner.go
+++ b/pkg/logql/internal/logqltest/runner.go
@@ -9,6 +9,8 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/push"
+
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
@@ -207,8 +209,10 @@ func consumeBlock(lines []string, i int, fn func(content string)) int {
 // first mismatch (nil on success). Keeping the comparators pure (error-returning rather than
 // asserting on a *testing.T) lets the tests exercise the failure path directly.
 //
-// With skipValues true the comparators check result shape only — series count, timestamps, and
-// present/absent samples — and skip float value equality.
+// Each compare* function below self-guards against every other expectation kind (so it gives a
+// clear "expected X, got Y" error even when called directly, as the tests do). With skipValues
+// true the comparators check result shape only — series count, timestamps, and present/absent
+// samples (or log lines) — and skip value equality.
 func compareResult(name string, cmd evalCmd, exp expectations, data any, skipValues bool) error {
 	switch v := data.(type) {
 	case promql.Scalar:
@@ -223,9 +227,6 @@ func compareResult(name string, cmd evalCmd, exp expectations, data any, skipVal
 			}
 			return nil
 		}
-		if exp.scalar != nil {
-			return fmt.Errorf("%s: expected a scalar, got a vector", name)
-		}
 		return compareVector(name, cmd, exp, v, skipValues)
 	case promql.Matrix:
 		if exp.empty {
@@ -234,16 +235,27 @@ func compareResult(name string, cmd evalCmd, exp expectations, data any, skipVal
 			}
 			return nil
 		}
-		if exp.scalar != nil {
-			return fmt.Errorf("%s: expected a scalar, got a matrix", name)
-		}
 		return compareMatrix(name, cmd, exp, v, skipValues)
+	case logqlmodel.Streams:
+		if exp.empty {
+			if len(v) != 0 {
+				return fmt.Errorf("%s: expected an empty result, got %d streams", name, len(v))
+			}
+			return nil
+		}
+		return compareStreams(name, exp, v, skipValues)
 	default:
-		return fmt.Errorf("%s: unsupported result type %T (only metric queries are supported)", name, data)
+		return fmt.Errorf("%s: unsupported result type %T", name, data)
 	}
 }
 
 func compareScalar(name string, exp expectations, s promql.Scalar, skipValues bool) error {
+	if len(exp.series) > 0 {
+		return fmt.Errorf("%s: expected series, got a scalar", name)
+	}
+	if len(exp.streams) > 0 {
+		return fmt.Errorf("%s: expected log streams, got a scalar", name)
+	}
 	if exp.scalar == nil {
 		return fmt.Errorf("%s: scalar result but no scalar value expected", name)
 	}
@@ -254,6 +266,13 @@ func compareScalar(name string, exp expectations, s promql.Scalar, skipValues bo
 }
 
 func compareVector(name string, cmd evalCmd, exp expectations, v promql.Vector, skipValues bool) error {
+	if exp.scalar != nil {
+		return fmt.Errorf("%s: expected a scalar, got a vector", name)
+	}
+	if len(exp.streams) > 0 {
+		return fmt.Errorf("%s: expected log streams, got a vector", name)
+	}
+
 	// Instant results carry a single timestamp: the query's evaluation time.
 	wantTS := epoch.Add(cmd.ts).UnixMilli()
 
@@ -324,6 +343,12 @@ func compareVector(name string, cmd evalCmd, exp expectations, v promql.Vector, 
 }
 
 func compareMatrix(name string, cmd evalCmd, exp expectations, m promql.Matrix, skipValues bool) error {
+	if exp.scalar != nil {
+		return fmt.Errorf("%s: expected a scalar, got a matrix", name)
+	}
+	if len(exp.streams) > 0 {
+		return fmt.Errorf("%s: expected log streams, got a matrix", name)
+	}
 	if exp.ordered {
 		return fmt.Errorf("%s: `expect ordered` is only supported for instant queries", name)
 	}
@@ -397,6 +422,67 @@ func compareMatrix(name string, cmd evalCmd, exp expectations, m promql.Matrix, 
 		}
 	}
 	return nil
+}
+
+// compareStreams checks a log-selection result against the expected streams. Streams are
+// matched as a set keyed by label string (like vector/matrix series); the log lines within a
+// matched stream are compared as an exact, ordered sequence, since a stream's line order is
+// meaningful (chronological, per the query direction) rather than incidental.
+func compareStreams(name string, exp expectations, got logqlmodel.Streams, skipValues bool) error {
+	if exp.scalar != nil {
+		return fmt.Errorf("%s: expected a scalar, got log streams", name)
+	}
+	if len(exp.series) > 0 {
+		return fmt.Errorf("%s: expected series, got log streams", name)
+	}
+
+	want := map[string][]expectedLogEntry{}
+	for _, es := range exp.streams {
+		if _, dup := want[es.labels]; dup {
+			return fmt.Errorf("%s: duplicate expected stream %s", name, es.labels)
+		}
+		want[es.labels] = es.entries
+	}
+
+	gotByLabels := map[string][]push.Entry{}
+	for _, s := range got {
+		if _, dup := gotByLabels[s.Labels]; dup {
+			return fmt.Errorf("%s: engine returned duplicate stream %s", name, s.Labels)
+		}
+		gotByLabels[s.Labels] = s.Entries
+	}
+
+	if len(gotByLabels) != len(want) {
+		return fmt.Errorf("%s: stream count mismatch: want %d, got %d (%v)", name, len(want), len(gotByLabels), streamKeys(gotByLabels))
+	}
+	for lbls, wantEntries := range want {
+		gotEntries, ok := gotByLabels[lbls]
+		if !ok {
+			return fmt.Errorf("%s: missing expected stream %s; got streams %v", name, lbls, streamKeys(gotByLabels))
+		}
+		if len(gotEntries) != len(wantEntries) {
+			return fmt.Errorf("%s: stream %s has %d lines, expected %d", name, lbls, len(gotEntries), len(wantEntries))
+		}
+		for i, we := range wantEntries {
+			ge := gotEntries[i]
+			wantTS := epoch.Add(we.ts).UnixMilli()
+			if gotTS := ge.Timestamp.UnixMilli(); gotTS != wantTS {
+				return fmt.Errorf("%s: stream %s line %d has timestamp %dms, expected %dms", name, lbls, i, gotTS, wantTS)
+			}
+			if !skipValues && ge.Line != we.line {
+				return fmt.Errorf("%s: stream %s line %d mismatch: want %q, got %q", name, lbls, i, we.line, ge.Line)
+			}
+		}
+	}
+	return nil
+}
+
+func streamKeys(m map[string][]push.Entry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 func floatsEqual(a, b float64) bool {

--- a/pkg/logql/internal/logqltest/runner.go
+++ b/pkg/logql/internal/logqltest/runner.go
@@ -107,10 +107,15 @@ func RunScript(t *testing.T, name, script string) {
 func runEval(t *testing.T, name string, stacks []executionStack, cmd evalCmd, exp expectations) {
 	t.Helper()
 	label := cmd.query
-	if cmd.instant {
+	switch cmd.mode {
+	case evalInstant:
 		label = "instant: " + label
-	} else {
+	case evalRange:
 		label = "range: " + label
+	case evalSelect:
+		label = "select: " + label
+	default:
+		panic(fmt.Sprintf("unknown eval mode %v", cmd.mode))
 	}
 
 	t.Run(label, func(t *testing.T) {

--- a/pkg/logql/internal/logqltest/runner_test.go
+++ b/pkg/logql/internal/logqltest/runner_test.go
@@ -97,8 +97,8 @@ eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bo
 // extra matrix points, and a non-empty result against `expect empty`.
 func TestComparators_DetectMismatches(t *testing.T) {
 	foo := labels.FromStrings("app", "a")
-	rangeCmd := evalCmd{start: time.Minute, end: time.Minute, step: time.Minute}
-	instantCmd := evalCmd{instant: true, ts: time.Minute}
+	rangeCmd := evalCmd{mode: evalRange, start: time.Minute, end: time.Minute, step: time.Minute}
+	instantCmd := evalCmd{mode: evalInstant, ts: time.Minute}
 	ts := epoch.Add(time.Minute).UnixMilli()
 	scalar := func(v float64) expectations { return expectations{scalar: &v} }
 
@@ -158,11 +158,11 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			want: `engine returned duplicate point for series {app="a"}`,
 		},
 		"empty expected but non-empty result": {
-			err:  compareResult("n", evalCmd{instant: true, ts: time.Minute}, expectations{empty: true}, promql.Vector{{Metric: foo, F: 5}}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Vector{{Metric: foo, F: 5}}, false),
 			want: "expected an empty result",
 		},
 		"scalar expected but empty vector": {
-			err:  compareResult("n", evalCmd{instant: true, ts: time.Minute}, scalar(5), promql.Vector{}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, scalar(5), promql.Vector{}, false),
 			want: "expected a scalar, got a vector",
 		},
 		"scalar expected but empty matrix": {
@@ -170,7 +170,7 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			want: "expected a scalar, got a matrix",
 		},
 		"empty expected but scalar result": {
-			err:  compareResult("n", evalCmd{instant: true, ts: time.Minute}, expectations{empty: true}, promql.Scalar{V: 5}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Scalar{V: 5}, false),
 			want: "expected an empty result, got scalar 5",
 		},
 		"empty expected but non-empty matrix": {
@@ -225,7 +225,7 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			want: "`expect ordered` is only supported for instant queries",
 		},
 		"unsupported result type": {
-			err:  compareResult("n", evalCmd{instant: true, ts: time.Minute}, oneSeries(5), nil, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, oneSeries(5), nil, false),
 			want: "unsupported result type",
 		},
 		"streams line mismatch": {
@@ -286,7 +286,7 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			want: `engine returned duplicate stream {app="a"}`,
 		},
 		"vector expected but got streams": {
-			err:  compareResult("n", evalCmd{instant: true, ts: time.Minute}, oneSeries(5), logqlmodel.Streams{}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, oneSeries(5), logqlmodel.Streams{}, false),
 			want: "expected series, got log streams",
 		},
 		"streams expected but got vector": {
@@ -312,7 +312,7 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			want: "expected a scalar, got log streams",
 		},
 		"empty expected but non-empty streams": {
-			err: compareResult("n", evalCmd{instant: true, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{
+			err: compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{
 				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
 			}, false),
 			want: "expected an empty result, got 1 streams",
@@ -327,18 +327,18 @@ func TestComparators_DetectMismatches(t *testing.T) {
 func TestComparators_AcceptMatches(t *testing.T) {
 	foo := labels.FromStrings("app", "a")
 	scalar := 5.0
-	rangeCmd := evalCmd{start: time.Minute, end: time.Minute, step: time.Minute}
-	instantCmd := evalCmd{instant: true, ts: time.Minute}
+	rangeCmd := evalCmd{mode: evalRange, start: time.Minute, end: time.Minute, step: time.Minute}
+	instantCmd := evalCmd{mode: evalInstant, ts: time.Minute}
 	ts := epoch.Add(time.Minute).UnixMilli()
 
 	require.NoError(t, compareScalar("n", expectations{scalar: &scalar}, promql.Scalar{V: 5}, false))
 	require.NoError(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: ts}}, false))
 	require.NoError(t, compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false))
-	require.NoError(t, compareResult("n", evalCmd{instant: true, ts: time.Minute}, expectations{empty: true}, promql.Vector{}, false))
+	require.NoError(t, compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Vector{}, false))
 
 	// A matrix gap (`_`) matches a step the engine legitimately omitted.
 	require.NoError(t, compareMatrix("n",
-		evalCmd{start: time.Minute, end: 2 * time.Minute, step: time.Minute},
+		evalCmd{mode: evalRange, start: time.Minute, end: 2 * time.Minute, step: time.Minute},
 		expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}, {present: false}}}}},
 		promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false))
 
@@ -360,15 +360,15 @@ func TestComparators_AcceptMatches(t *testing.T) {
 			{Labels: `{app="b"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "x"}}},
 			{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "1st"}, {Timestamp: epoch.Add(time.Second), Line: "2nd"}}},
 		}, false))
-	require.NoError(t, compareResult("n", evalCmd{instant: true, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{}, false))
+	require.NoError(t, compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{}, false))
 }
 
 func TestComparators_SkipValues(t *testing.T) {
 	var (
 		foo        = labels.FromStrings("app", "a")
 		bar        = labels.FromStrings("app", "b")
-		instantCmd = evalCmd{instant: true, ts: time.Minute}
-		rangeCmd   = evalCmd{start: time.Minute, end: time.Minute, step: time.Minute}
+		instantCmd = evalCmd{mode: evalInstant, ts: time.Minute}
+		rangeCmd   = evalCmd{mode: evalRange, start: time.Minute, end: time.Minute, step: time.Minute}
 		ts         = epoch.Add(time.Minute).UnixMilli()
 		scalar     = func(v float64) expectations { return expectations{scalar: &v} }
 	)

--- a/pkg/logql/internal/logqltest/runner_test.go
+++ b/pkg/logql/internal/logqltest/runner_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
 // TestLogQLScripts runs every declarative `.logqltest` script under testdata/ through the
@@ -224,6 +228,95 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			err:  compareResult("n", evalCmd{instant: true, ts: time.Minute}, oneSeries(5), nil, false),
 			want: "unsupported result type",
 		},
+		"streams line mismatch": {
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "b"}}},
+			}, false),
+			want: `stream {app="a"} line 0 mismatch: want "a", got "b"`,
+		},
+		"streams timestamp mismatch": {
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch.Add(time.Second), Line: "a"}}},
+			}, false),
+			want: fmt.Sprintf(`stream {app="a"} line 0 has timestamp %dms, expected %dms`, epoch.Add(time.Second).UnixMilli(), epoch.UnixMilli()),
+		},
+		"streams missing stream": {
+			err:  compareStreams("n", oneStream("a"), logqlmodel.Streams{}, false),
+			want: `stream count mismatch: want 1, got 0`,
+		},
+		"streams extra stream": {
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
+				{Labels: `{app="b"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "x"}}},
+			}, false),
+			want: `stream count mismatch: want 1, got 2`,
+		},
+		"streams missing stream (count matches)": {
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="b"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "x"}}},
+			}, false),
+			want: `missing expected stream {app="a"}`,
+		},
+		"streams extra line": {
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}, {Timestamp: epoch, Line: "extra"}}},
+			}, false),
+			want: `stream {app="a"} has 2 lines, expected 1`,
+		},
+		"streams missing line": {
+			err: compareStreams("n", expectations{streams: []expectedStream{
+				{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: "a"}, {ts: time.Second, line: "b"}}},
+			}}, logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
+			}, false),
+			want: `stream {app="a"} has 1 lines, expected 2`,
+		},
+		"streams duplicate expected stream": {
+			err: compareStreams("n", expectations{streams: []expectedStream{
+				{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: "a"}}},
+				{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: "a"}}},
+			}}, logqlmodel.Streams{{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}}}, false),
+			want: `duplicate expected stream {app="a"}`,
+		},
+		"streams duplicate result stream": {
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
+			}, false),
+			want: `engine returned duplicate stream {app="a"}`,
+		},
+		"vector expected but got streams": {
+			err:  compareResult("n", evalCmd{instant: true, ts: time.Minute}, oneSeries(5), logqlmodel.Streams{}, false),
+			want: "expected series, got log streams",
+		},
+		"streams expected but got vector": {
+			err:  compareVector("n", instantCmd, oneStream("a"), promql.Vector{{Metric: foo, F: 5}}, false),
+			want: "expected log streams, got a vector",
+		},
+		"streams expected but got matrix": {
+			err:  compareMatrix("n", rangeCmd, oneStream("a"), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			want: "expected log streams, got a matrix",
+		},
+		"streams expected but got scalar": {
+			err:  compareScalar("n", oneStream("a"), promql.Scalar{V: 5}, false),
+			want: "expected log streams, got a scalar",
+		},
+		"series expected but got scalar": {
+			err:  compareScalar("n", oneSeries(5), promql.Scalar{V: 5}, false),
+			want: "expected series, got a scalar",
+		},
+		"scalar expected but got streams": {
+			err: compareStreams("n", scalar(5), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
+			}, false),
+			want: "expected a scalar, got log streams",
+		},
+		"empty expected but non-empty streams": {
+			err: compareResult("n", evalCmd{instant: true, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
+			}, false),
+			want: "expected an empty result, got 1 streams",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.ErrorContains(t, tc.err, tc.want)
@@ -256,6 +349,18 @@ func TestComparators_AcceptMatches(t *testing.T) {
 			{labels: `{app="b"}`, samples: []sample{{present: true, value: 2}}},
 		}},
 		promql.Vector{{Metric: foo, F: 1, T: ts}, {Metric: labels.FromStrings("app", "b"), F: 2, T: ts}}, false))
+
+	// Log streams: matched as a set by label, lines compared in order within each stream.
+	require.NoError(t, compareStreams("n",
+		expectations{streams: []expectedStream{
+			{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: "1st"}, {ts: time.Second, line: "2nd"}}},
+			{labels: `{app="b"}`, entries: []expectedLogEntry{{ts: 0, line: "x"}}},
+		}},
+		logqlmodel.Streams{
+			{Labels: `{app="b"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "x"}}},
+			{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "1st"}, {Timestamp: epoch.Add(time.Second), Line: "2nd"}}},
+		}, false))
+	require.NoError(t, compareResult("n", evalCmd{instant: true, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{}, false))
 }
 
 func TestComparators_SkipValues(t *testing.T) {
@@ -272,6 +377,8 @@ func TestComparators_SkipValues(t *testing.T) {
 		require.NoError(t, compareScalar("n", scalar(5), promql.Scalar{V: 6}, true))
 		require.NoError(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 6, T: ts}}, true))
 		require.NoError(t, compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 6}}}}, true))
+		require.NoError(t, compareStreams("n", oneStream("a"),
+			logqlmodel.Streams{{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "wrong line"}}}}, true))
 	})
 
 	// The values below are deliberately wrong (6, not 5): the shape check must still fire.
@@ -289,6 +396,15 @@ func TestComparators_SkipValues(t *testing.T) {
 		require.ErrorContains(t, compareMatrix("n", rangeCmd,
 			expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: false}}}}},
 			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, true), "should be empty")
+
+		// Streams: a missing stream, or a missing line within one, still errors even though a
+		// present line's text would have been skipped.
+		require.ErrorContains(t, compareStreams("n", oneStream("a"), logqlmodel.Streams{}, true), "stream count mismatch")
+		require.ErrorContains(t, compareStreams("n", expectations{streams: []expectedStream{
+			{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: "a"}, {ts: time.Second, line: "b"}}},
+		}}, logqlmodel.Streams{
+			{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
+		}, true), "has 1 lines, expected 2")
 	})
 
 	t.Run("timestamp mismatches still error", func(t *testing.T) {
@@ -296,7 +412,14 @@ func TestComparators_SkipValues(t *testing.T) {
 			promql.Vector{{Metric: foo, F: 6, T: 1000}}, true), "has timestamp 1000ms")
 		require.ErrorContains(t, compareMatrix("n", rangeCmd, oneSeries(5),
 			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts + 1000, F: 6}}}}, true), "unexpected timestamp")
+		require.ErrorContains(t, compareStreams("n", oneStream("a"),
+			logqlmodel.Streams{{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch.Add(time.Second), Line: "a"}}}}, true),
+			fmt.Sprintf("has timestamp %dms", epoch.Add(time.Second).UnixMilli()))
 	})
+}
+
+func oneStream(line string) expectations {
+	return expectations{streams: []expectedStream{{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: line}}}}}
 }
 
 func TestFloatsEqual(t *testing.T) {

--- a/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
+++ b/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
@@ -7,6 +7,7 @@
     { "include": "#clear-command" },
     { "include": "#eval-instant" },
     { "include": "#eval-range" },
+    { "include": "#eval-select" },
     { "include": "#eval-fallback" },
     { "include": "#expect-annotation" },
     { "include": "#skip-directive" },
@@ -79,9 +80,26 @@
       ]
     },
 
+    "eval-select": {
+      "name": "meta.command.eval.logqltest",
+      "begin": "^[ \\t]*(eval)[ \\t]+(select)[ \\t]+(from)[ \\t]+(\\S+)[ \\t]+(to)[ \\t]+(\\S+)[ \\t]+",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.eval.logqltest" },
+        "2": { "name": "keyword.other.eval-mode.logqltest" },
+        "3": { "name": "keyword.other.eval-argument.logqltest" },
+        "4": { "name": "constant.numeric.duration.logqltest" },
+        "5": { "name": "keyword.other.eval-argument.logqltest" },
+        "6": { "name": "constant.numeric.duration.logqltest" }
+      },
+      "end": "$",
+      "patterns": [
+        { "include": "#query" }
+      ]
+    },
+
     "eval-fallback": {
       "comment": "Colors the keyword on an eval line the stricter rules above did not match, e.g. while it is still being typed.",
-      "match": "^[ \\t]*(eval)\\b[ \\t]*(instant|range)?\\b",
+      "match": "^[ \\t]*(eval)\\b[ \\t]*(instant|range|select)?\\b",
       "captures": {
         "1": { "name": "keyword.control.eval.logqltest" },
         "2": { "name": "keyword.other.eval-mode.logqltest" }

--- a/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
+++ b/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
@@ -10,7 +10,7 @@
     { "include": "#eval-fallback" },
     { "include": "#expect-annotation" },
     { "include": "#skip-directive" },
-    { "include": "#series-expectation" },
+    { "include": "#result-expectation" },
     { "include": "#scalar-expectation" },
     { "include": "#comment" }
   ],
@@ -124,13 +124,17 @@
       }
     },
 
-    "series-expectation": {
-      "name": "meta.expectation.series.logqltest",
+    "result-expectation": {
+      "comment": "A series line (`{labels} p0 p1 ...`) or a log-stream line (`{labels} \"line\" @ ts`); both start with a label set, so both token kinds are included here.",
+      "name": "meta.expectation.result.logqltest",
       "begin": "^[ \\t]*(?=\\{)",
       "end": "$",
       "patterns": [
         { "include": "#label-set" },
         { "include": "#comment" },
+        { "include": "#at-clause" },
+        { "include": "#log-line" },
+        { "include": "#raw-log-line" },
         { "include": "#sample" }
       ]
     },

--- a/pkg/logql/internal/logqltest/testdata/AGENTS.md
+++ b/pkg/logql/internal/logqltest/testdata/AGENTS.md
@@ -138,8 +138,18 @@ only what they can't show, and prefer a trailing `# …` on the relevant line ov
   needs it — not per scenario.
 - Never restate the query; no line-by-line narration.
 
+## Log-selection scenarios
+
+A log-selection query (e.g. `{app="foo"} |= "bar"`) returns streams, not series — see README.md
+"Streams" expected results. The instant/range cross-check in the checklist above doesn't apply the
+same way: a log-selection `eval range` has no per-step matrix, just one window's worth of lines, so
+there's no "last step equals the instant" to size for. Instead cross-check by picking an `eval
+range` window and an `eval instant` time that should return the *same* lines (accounting for the
+default 30s look-back — see README.md "Log-selection window" for the exact boundary rule).
+
 ## Files
 
 One feature per file: `range_aggregations`, `vector_aggregations`, `binary_operations`,
-`functions` (`label_replace`, `vector`), `conversions`, … add more as coverage grows
-(`line_filters`, `label_filters`, `parsers`, `formatters`, …).
+`functions` (`label_replace`, `vector`), `conversions`, `log_selection` (stream selectors, line
+filters, as opposed to a metric aggregation), … add more as coverage grows (`line_filters`,
+`label_filters`, `parsers`, `formatters`, …).

--- a/pkg/logql/internal/logqltest/testdata/AGENTS.md
+++ b/pkg/logql/internal/logqltest/testdata/AGENTS.md
@@ -140,12 +140,13 @@ only what they can't show, and prefer a trailing `# …` on the relevant line ov
 
 ## Log-selection scenarios
 
-A log-selection query (e.g. `{app="foo"} |= "bar"`) returns streams, not series — see README.md
-"Streams" expected results. The instant/range cross-check in the checklist above doesn't apply the
-same way: a log-selection `eval range` has no per-step matrix, just one window's worth of lines, so
-there's no "last step equals the instant" to size for. Instead cross-check by picking an `eval
-range` window and an `eval instant` time that should return the *same* lines (accounting for the
-default 30s look-back — see README.md "Log-selection window" for the exact boundary rule).
+A log-selection query (e.g. `{app="foo"} |= "bar"`) uses `eval select`, not `eval range`/`eval
+instant`, and returns streams, not series — see README.md "Streams" expected results. The
+instant/range cross-check in the checklist above doesn't apply the same way: `eval select` has no
+per-step matrix, just one window's worth of lines, so there's no "last step equals the instant" to
+size for. Instead cross-check by picking an `eval select` window and an `eval instant` time that
+should return the *same* lines (accounting for the default 30s look-back — see README.md
+"Log-selection window" for the exact boundary rule).
 
 ## Files
 

--- a/pkg/logql/internal/logqltest/testdata/AGENTS.md
+++ b/pkg/logql/internal/logqltest/testdata/AGENTS.md
@@ -142,11 +142,7 @@ only what they can't show, and prefer a trailing `# …` on the relevant line ov
 
 A log-selection query (e.g. `{app="foo"} |= "bar"`) uses `eval select`, not `eval range`/`eval
 instant`, and returns streams, not series — see README.md "Streams" expected results. The
-instant/range cross-check in the checklist above doesn't apply the same way: `eval select` has no
-per-step matrix, just one window's worth of lines, so there's no "last step equals the instant" to
-size for. Instead cross-check by picking an `eval select` window and an `eval instant` time that
-should return the *same* lines (accounting for the default 30s look-back — see README.md
-"Log-selection window" for the exact boundary rule).
+instant/range cross-check in the checklist above doesn't apply to log selection.
 
 ## Files
 

--- a/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
@@ -35,15 +35,6 @@ load
 eval select from 0 to 20s {app="foo"}
   {app="foo"} "in range" @ 10s
 
-# `eval instant at T` looks back a default 30s window: [T-30s, T).
-clear
-load
-  {app="foo"} "too old" @ 0s
-  {app="foo"} "recent"  @ 39s
-
-eval instant at 40s {app="foo"}
-  {app="foo"} "recent" @ 39s
-
 # A `|=` line filter drops lines that don't contain the substring.
 clear
 load

--- a/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
@@ -8,7 +8,8 @@ clear
 load
   {app="foo"} "1st line" @ 10s
   {app="foo"} "2nd line" @ 20s
-  {app="bar"} "noise"    @ 15s   # different stream: the selector must drop it
+  {app="bar"} "bar line" @ 15s
+  {app="baz"} "noise"    @ 15s
 
 eval select from 0 to 30s {app="foo"}
   {app="foo"} "1st line" @ 10s
@@ -18,7 +19,7 @@ eval select from 0 to 30s {app="foo"}
 eval select from 0 to 30s {app=~"foo|bar"}
   {app="foo"} "1st line" @ 10s
   {app="foo"} "2nd line" @ 20s
-  {app="bar"} "noise"    @ 15s
+  {app="bar"} "bar line" @ 15s
 
 # A selector matching nothing returns no streams.
 eval select from 0 to 30s {app="missing"}

--- a/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
@@ -10,18 +10,18 @@ load
   {app="foo"} "2nd line" @ 20s
   {app="bar"} "noise"    @ 15s   # different stream: the selector must drop it
 
-eval range from 0 to 30s step 10s {app="foo"}
+eval select from 0 to 30s {app="foo"}
   {app="foo"} "1st line" @ 10s
   {app="foo"} "2nd line" @ 20s
 
 # A regex selector across streams returns one result stream per match.
-eval range from 0 to 30s step 10s {app=~"foo|bar"}
+eval select from 0 to 30s {app=~"foo|bar"}
   {app="foo"} "1st line" @ 10s
   {app="foo"} "2nd line" @ 20s
   {app="bar"} "noise"    @ 15s
 
 # A selector matching nothing returns no streams.
-eval range from 0 to 30s step 10s {app="missing"}
+eval select from 0 to 30s {app="missing"}
   expect empty
 
 # The query window is start-inclusive, end-exclusive: unlike a metric range vector's (start,end],
@@ -31,7 +31,7 @@ load
   {app="foo"} "in range"    @ 10s
   {app="foo"} "at boundary" @ 20s
 
-eval range from 0 to 20s step 10s {app="foo"}
+eval select from 0 to 20s {app="foo"}
   {app="foo"} "in range" @ 10s
 
 # `eval instant at T` looks back a default 30s window: [T-30s, T).
@@ -49,5 +49,5 @@ load
   {app="foo"} "status=200" @ 10s
   {app="foo"} "status=500" @ 20s   # noise: same stream, the filter must drop it
 
-eval range from 0 to 30s step 10s {app="foo"} |= "200"
+eval select from 0 to 30s {app="foo"} |= "200"
   {app="foo"} "status=200" @ 10s

--- a/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
@@ -1,0 +1,53 @@
+#
+# Log-selection queries: stream selectors and line filters, asserted against the raw log lines
+# (as opposed to metric queries, which aggregate them). See README.md "Streams" expected results.
+#
+
+# A stream selector returns every line of the matching stream, in order.
+clear
+load
+  {app="foo"} "1st line" @ 10s
+  {app="foo"} "2nd line" @ 20s
+  {app="bar"} "noise"    @ 15s   # different stream: the selector must drop it
+
+eval range from 0 to 30s step 10s {app="foo"}
+  {app="foo"} "1st line" @ 10s
+  {app="foo"} "2nd line" @ 20s
+
+# A regex selector across streams returns one result stream per match.
+eval range from 0 to 30s step 10s {app=~"foo|bar"}
+  {app="foo"} "1st line" @ 10s
+  {app="foo"} "2nd line" @ 20s
+  {app="bar"} "noise"    @ 15s
+
+# A selector matching nothing returns no streams.
+eval range from 0 to 30s step 10s {app="missing"}
+  expect empty
+
+# The query window is start-inclusive, end-exclusive: unlike a metric range vector's (start,end],
+# a line exactly at `end` falls outside the window.
+clear
+load
+  {app="foo"} "in range"    @ 10s
+  {app="foo"} "at boundary" @ 20s
+
+eval range from 0 to 20s step 10s {app="foo"}
+  {app="foo"} "in range" @ 10s
+
+# `eval instant at T` looks back a default 30s window: [T-30s, T).
+clear
+load
+  {app="foo"} "too old" @ 0s
+  {app="foo"} "recent"  @ 39s
+
+eval instant at 40s {app="foo"}
+  {app="foo"} "recent" @ 39s
+
+# A `|=` line filter drops lines that don't contain the substring.
+clear
+load
+  {app="foo"} "status=200" @ 10s
+  {app="foo"} "status=500" @ 20s   # noise: same stream, the filter must drop it
+
+eval range from 0 to 30s step 10s {app="foo"} |= "200"
+  {app="foo"} "status=200" @ 10s


### PR DESCRIPTION
Adds support for LogQL selection queries to the logqltest DSL.

Basic smoke tests have also been added. We can expand on these further in future PRs.