### PR TITLE
chore(querier): Ensure Plan is set in test QueryRequest/SampleQueryRequest

### DIFF
--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -39,6 +40,7 @@ func ensureIngesterData(ctx context.Context, t *testing.T, start, end time.Time,
 		Limit:    100,
 		Start:    start,
 		End:      end,
+		Plan:     testutil.MustPlan(`{foo="bar"}`),
 	}, &result)
 
 	ln := int(end.Sub(start) / time.Second)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/fetcher"
@@ -250,6 +250,7 @@ func TestIngester(t *testing.T) {
 		Limit:    100,
 		Start:    time.Unix(0, 0),
 		End:      time.Unix(1, 0),
+		Plan:     testutil.MustPlan(`{foo="bar"}`),
 	}, &result)
 	require.NoError(t, err)
 	// We always send an empty batch to make sure stats are sent, so there will always be one empty response.
@@ -264,6 +265,7 @@ func TestIngester(t *testing.T) {
 		Limit:    100,
 		Start:    time.Unix(0, 0),
 		End:      time.Unix(1, 0),
+		Plan:     testutil.MustPlan(`{foo="bar",bar="baz1"}`),
 	}, &result)
 	require.NoError(t, err)
 	// We always send an empty batch to make sure stats are sent, so there will always be one empty response.
@@ -279,6 +281,7 @@ func TestIngester(t *testing.T) {
 		Limit:    100,
 		Start:    time.Unix(0, 0),
 		End:      time.Unix(1, 0),
+		Plan:     testutil.MustPlan(`{foo="bar",bar="baz2"}`),
 	}, &result)
 	require.NoError(t, err)
 	// We always send an empty batch to make sure stats are sent, so there will always be one empty response.
@@ -1015,9 +1018,7 @@ func Test_DedupeIngester(t *testing.T) {
 				End:       time.Unix(0, requests+1),
 				Limit:     uint32(requests * streamCount),
 				Direction: logproto.BACKWARD,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{foo="bar"} | label_format bar=""`),
-				},
+				Plan:      testutil.MustPlan(`{foo="bar"} | label_format bar=""`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewQueryClientIterator(stream, logproto.BACKWARD))
@@ -1048,6 +1049,7 @@ func Test_DedupeIngester(t *testing.T) {
 				End:       time.Unix(0, requests+1),
 				Limit:     uint32(requests * streamCount),
 				Direction: logproto.FORWARD,
+				Plan:      testutil.MustPlan(`{foo="bar"} | label_format bar=""`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewQueryClientIterator(stream, logproto.FORWARD))
@@ -1076,9 +1078,7 @@ func Test_DedupeIngester(t *testing.T) {
 				Selector: `sum(rate({foo="bar"}[1m])) by (bar)`,
 				Start:    time.Unix(0, 0),
 				End:      time.Unix(0, requests+1),
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(rate({foo="bar"}[1m])) by (bar)`),
-				},
+				Plan:     testutil.MustPlan(`sum(rate({foo="bar"}[1m])) by (bar)`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
@@ -1114,9 +1114,7 @@ func Test_DedupeIngester(t *testing.T) {
 				Selector: `sum(rate({foo="bar"}[1m]))`,
 				Start:    time.Unix(0, 0),
 				End:      time.Unix(0, requests+1),
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(rate({foo="bar"}[1m]))`),
-				},
+				Plan:     testutil.MustPlan(`sum(rate({foo="bar"}[1m]))`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
@@ -1177,9 +1175,7 @@ func Test_DedupeIngesterParser(t *testing.T) {
 				End:       time.Unix(0, int64(requests+1)),
 				Limit:     uint32(requests * streamCount * 2),
 				Direction: logproto.BACKWARD,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{foo="bar"} | json`),
-				},
+				Plan:      testutil.MustPlan(`{foo="bar"} | json`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewQueryClientIterator(stream, logproto.BACKWARD))
@@ -1207,9 +1203,7 @@ func Test_DedupeIngesterParser(t *testing.T) {
 				End:       time.Unix(0, int64(requests+1)),
 				Limit:     uint32(requests * streamCount * 2),
 				Direction: logproto.FORWARD,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{foo="bar"} | json`),
-				},
+				Plan:      testutil.MustPlan(`{foo="bar"} | json`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewQueryClientIterator(stream, logproto.FORWARD))
@@ -1234,9 +1228,7 @@ func Test_DedupeIngesterParser(t *testing.T) {
 				Selector: `rate({foo="bar"} | json [1m])`,
 				Start:    time.Unix(0, 0),
 				End:      time.Unix(0, int64(requests+1)),
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`rate({foo="bar"} | json [1m])`),
-				},
+				Plan:     testutil.MustPlan(`rate({foo="bar"} | json [1m])`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
@@ -1262,9 +1254,7 @@ func Test_DedupeIngesterParser(t *testing.T) {
 				Selector: `sum by (c,d,e,foo) (rate({foo="bar"} | json [1m]))`,
 				Start:    time.Unix(0, 0),
 				End:      time.Unix(0, int64(requests+1)),
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (c,d,e,foo) (rate({foo="bar"} | json [1m]))`),
-				},
+				Plan:     testutil.MustPlan(`sum by (c,d,e,foo) (rate({foo="bar"} | json [1m]))`),
 			})
 			require.NoError(t, err)
 			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -10,33 +10,30 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/compactor/retention"
-	"github.com/grafana/loki/v3/pkg/storage/types"
-	"github.com/grafana/loki/v3/pkg/util"
-	"github.com/grafana/loki/v3/pkg/util/httpreq"
-
-	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/dskit/user"
-
-	"github.com/grafana/loki/v3/pkg/logql/log"
-
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/compactor/retention"
 	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/querier/astmapper"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	loki_runtime "github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
+	"github.com/grafana/loki/v3/pkg/storage/types"
+	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -625,9 +622,7 @@ func Test_Iterator(t *testing.T) {
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(0, 100000000),
 				Direction: logproto.BACKWARD,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{job="3"} | logfmt`),
-				},
+				Plan:      testutil.MustPlan(`{job="3"} | logfmt`),
 			},
 		},
 	)
@@ -684,9 +679,7 @@ func Test_ChunkFilter(t *testing.T) {
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(0, 100000000),
 				Direction: logproto.BACKWARD,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{job="3"}`),
-				},
+				Plan:      testutil.MustPlan(`{job="3"}`),
 			},
 		},
 	)
@@ -723,9 +716,7 @@ func Test_PipelineWrapper(t *testing.T) {
 				End:       time.Unix(0, 100000000),
 				Direction: logproto.BACKWARD,
 				Shards:    []string{astmapper.ShardAnnotation{Shard: 0, Of: 2}.String()},
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{job="3"}`),
-				},
+				Plan:      testutil.MustPlan(`{job="3"}`),
 			},
 		},
 	)
@@ -764,9 +755,7 @@ func Test_PipelineWrapper_disabled(t *testing.T) {
 				End:       time.Unix(0, 100000000),
 				Direction: logproto.BACKWARD,
 				Shards:    []string{astmapper.ShardAnnotation{Shard: 0, Of: 2}.String()},
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{job="3"}`),
-				},
+				Plan:      testutil.MustPlan(`{job="3"}`),
 			},
 		},
 	)
@@ -856,9 +845,7 @@ func Test_ExtractorWrapper(t *testing.T) {
 					Start:    time.Unix(0, 0),
 					End:      time.Unix(0, 100000000),
 					Shards:   []string{astmapper.ShardAnnotation{Shard: 0, Of: 2}.String()},
-					Plan: &plan.QueryPlan{
-						AST: syntax.MustParseExpr(`sum(count_over_time({job="3"}[1m]))`),
-					},
+					Plan:     testutil.MustPlan(`sum(count_over_time({job="3"}[1m]))`),
 				},
 			},
 		)
@@ -897,9 +884,7 @@ func Test_ExtractorWrapper_disabled(t *testing.T) {
 					Start:    time.Unix(0, 0),
 					End:      time.Unix(0, 100000000),
 					Shards:   []string{astmapper.ShardAnnotation{Shard: 0, Of: 2}.String()},
-					Plan: &plan.QueryPlan{
-						AST: syntax.MustParseExpr(`sum(count_over_time({job="3"}[1m]))`),
-					},
+					Plan:     testutil.MustPlan(`sum(count_over_time({job="3"}[1m]))`),
 				},
 			},
 		)
@@ -1000,9 +985,7 @@ func Test_QueryWithDelete(t *testing.T) {
 						End:      10 * 1e6,
 					},
 				},
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{job="3"}`),
-				},
+				Plan: testutil.MustPlan(`{job="3"}`),
 			},
 		},
 	)
@@ -1043,9 +1026,7 @@ func Test_QuerySampleWithDelete(t *testing.T) {
 						End:      10 * 1e6,
 					},
 				},
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`count_over_time({job="3"}[5m])`),
-				},
+				Plan: testutil.MustPlan(`count_over_time({job="3"}[5m])`),
 			},
 		},
 	)
@@ -1083,9 +1064,7 @@ func Test_QuerySampleWithoutExtractor(t *testing.T) {
 							Start:    time.Unix(0, 0),
 							End:      time.Unix(0, 110000000),
 							Deletes:  deletes,
-							Plan: &plan.QueryPlan{
-								AST: syntax.MustParseExpr(query),
-							},
+							Plan:     testutil.MustPlan(query),
 						},
 					},
 				)

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/ingester/wal"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	loki_runtime "github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -284,6 +285,7 @@ func TestSeriesRecoveryNoDuplicates(t *testing.T) {
 		Limit:    100,
 		Start:    time.Unix(0, 0),
 		End:      time.Unix(10, 0),
+		Plan:     testutil.MustPlan(`{foo="bar",bar="baz1"}`),
 	}, &result)
 	require.NoError(t, err)
 	// We always send an empty batch to make sure stats are sent, so there will always be one empty response.

--- a/pkg/loghttp/tail_test.go
+++ b/pkg/loghttp/tail_test.go
@@ -9,8 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 )
 
 func TestParseTailQuery(t *testing.T) {
@@ -40,9 +39,7 @@ func TestParseTailQuery(t *testing.T) {
 				DelayFor: 5,
 				Start:    time.Date(2017, 06, 10, 21, 42, 24, 760738998, time.UTC),
 				Limit:    1000,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{foo="bar"}`),
-				},
+				Plan:     testutil.MustPlan(`{foo="bar"}`),
 			}, false},
 	}
 	for _, tt := range tests {

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/logqlmodel/metadata"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
@@ -106,9 +106,7 @@ func TestEngine_LogsRateUnwrap(t *testing.T) {
 						Start:    time.Unix(30, 0),
 						End:      time.Unix(60, 0),
 						Selector: `rate({app="foo"} | unwrap foo[30s])`,
-						Plan: &plan.QueryPlan{
-							AST: syntax.MustParseExpr(`rate({app="foo"} | unwrap foo[30s])`),
-						},
+						Plan:     testutil.MustPlan(`rate({app="foo"} | unwrap foo[30s])`),
 					},
 				},
 			},
@@ -132,9 +130,7 @@ func TestEngine_LogsRateUnwrap(t *testing.T) {
 					Start:    time.Unix(30, 0),
 					End:      time.Unix(60, 0),
 					Selector: `rate({app="foo"} | unwrap foo[30s])`,
-					Plan: &plan.QueryPlan{
-						AST: syntax.MustParseExpr(`rate({app="foo"} | unwrap foo[30s])`),
-					},
+					Plan:     testutil.MustPlan(`rate({app="foo"} | unwrap foo[30s])`),
 				}},
 			},
 			// there are 15 samples (from 47 to 61) matched from the generated series
@@ -157,9 +153,7 @@ func TestEngine_LogsRateUnwrap(t *testing.T) {
 					Start:    time.Unix(30, 0),
 					End:      time.Unix(60, 0),
 					Selector: `rate_counter({app="foo"} | unwrap foo[30s])`,
-					Plan: &plan.QueryPlan{
-						AST: syntax.MustParseExpr(`rate_counter({app="foo"} | unwrap foo[30s])`),
-					},
+					Plan:     testutil.MustPlan(`rate_counter({app="foo"} | unwrap foo[30s])`),
 				}},
 			},
 			// there are 15 samples (from 47 to 61) matched from the generated series
@@ -177,7 +171,7 @@ func TestEngine_LogsRateUnwrap(t *testing.T) {
 				{newSeries(testSize, offset(46, incValue(1)), `{app="foo"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(30, 0), End: time.Unix(60, 0), Selector: `rate_counter({app="foo"} | unwrap foo[30s])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(30, 0), End: time.Unix(60, 0), Selector: `rate_counter({app="foo"} | unwrap foo[30s])`, Plan: testutil.MustPlan(`rate_counter({app="foo"} | unwrap foo[30s])`)}},
 			},
 			// 15 samples match the window (30s, 60s]: t=46..60 with values 47..61, so the
 			// counter increases by 14 over a 14s sampled interval (avg 1s between samples).
@@ -232,7 +226,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newStream(testSize, identity, `{app="foo"}`)},
 			},
 			[]SelectLogParams{
-				{&logproto.QueryRequest{Direction: logproto.FORWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="foo"}`}},
+				{&logproto.QueryRequest{Direction: logproto.FORWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="foo"}`, Plan: testutil.MustPlan(`{app="foo"}`)}},
 			},
 			logqlmodel.Streams([]logproto.Stream{newStream(10, identity, `{app="foo"}`)}),
 		},
@@ -242,7 +236,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newStream(testSize, identity, `{app="food"}`)},
 			},
 			[]SelectLogParams{
-				{&logproto.QueryRequest{Direction: logproto.FORWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="food"}`}},
+				{&logproto.QueryRequest{Direction: logproto.FORWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="food"}`, Plan: testutil.MustPlan(`{app="food"}`)}},
 			},
 			logqlmodel.Streams([]logproto.Stream{newIntervalStream(10, 2*time.Second, identity, `{app="food"}`)}),
 		},
@@ -252,7 +246,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newBackwardStream(testSize, identity, `{app="fed"}`)},
 			},
 			[]SelectLogParams{
-				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="fed"}`}},
+				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="fed"}`, Plan: testutil.MustPlan(`{app="fed"}`)}},
 			},
 			logqlmodel.Streams([]logproto.Stream{newBackwardIntervalStream(testSize, 10, 2*time.Second, identity, `{app="fed"}`)}),
 		},
@@ -262,7 +256,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newStream(testSize, identity, `{app="bar"}`)},
 			},
 			[]SelectLogParams{
-				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 30, Selector: `{app="bar"}|="foo"|~".+bar"`}},
+				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 30, Selector: `{app="bar"}|="foo"|~".+bar"`, Plan: testutil.MustPlan(`{app="bar"}|="foo"|~".+bar"`)}},
 			},
 			logqlmodel.Streams([]logproto.Stream{newStream(30, identity, `{app="bar"}`)}),
 		},
@@ -272,7 +266,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newBackwardStream(testSize, identity, `{app="barf"}`)},
 			},
 			[]SelectLogParams{
-				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 30, Selector: `{app="barf"}|="foo"|~".+bar"`}},
+				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 30, Selector: `{app="barf"}|="foo"|~".+bar"`, Plan: testutil.MustPlan(`{app="barf"}|="foo"|~".+bar"`)}},
 			},
 			logqlmodel.Streams([]logproto.Stream{newBackwardIntervalStream(testSize, 30, 3*time.Second, identity, `{app="barf"}`)}),
 		},
@@ -776,9 +770,7 @@ func newQuerierRecorder(t *testing.T, data interface{}, params interface{}) *que
 	if streamsIn, ok := data.([][]logproto.Stream); ok {
 		if paramsIn, ok2 := params.([]SelectLogParams); ok2 {
 			for i, p := range paramsIn {
-				p.Plan = &plan.QueryPlan{
-					AST: syntax.MustParseExpr(p.Selector),
-				}
+				p.Plan = testutil.MustPlan(p.Selector)
 				streams[paramsID(p)] = streamsIn[i]
 			}
 		}
@@ -789,9 +781,7 @@ func newQuerierRecorder(t *testing.T, data interface{}, params interface{}) *que
 		if paramsIn, ok2 := params.([]SelectSampleParams); ok2 {
 			for i, p := range paramsIn {
 				if p.Plan == nil {
-					p.Plan = &plan.QueryPlan{
-						AST: syntax.MustParseExpr(p.Selector),
-					}
+					p.Plan = testutil.MustPlan(p.Selector)
 				}
 				series[paramsID(p)] = seriesIn[i]
 			}

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -19,11 +19,10 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v2/frontendv2pb"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	"github.com/grafana/loki/v3/pkg/querier/stats"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/scheduler/schedulerpb"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/test"
@@ -130,9 +129,7 @@ func TestFrontendBasicWorkflowProto(t *testing.T) {
 
 	req := &queryrange.LokiRequest{
 		Query: `{foo="bar"} | json`,
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{foo="bar"} | json`),
-		},
+		Plan:  testutil.MustPlan(`{foo="bar"} | json`),
 	}
 
 	resp, err := queryrange.NewEmptyResponse(req)

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 )
 
 func TestMultiTenantQuerier_SelectLogs(t *testing.T) {
@@ -89,9 +89,7 @@ func TestMultiTenantQuerier_SelectLogs(t *testing.T) {
 				Shards:    nil,
 				Start:     time.Unix(0, 1),
 				End:       time.Unix(0, time.Now().UnixNano()),
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(tc.selector),
-				},
+				Plan:      testutil.MustPlan(tc.selector),
 			}}
 			iter, err := multiTenantQuerier.SelectLogs(ctx, params)
 			require.NoError(t, err)
@@ -161,9 +159,7 @@ func TestMultiTenantQuerier_SelectSamples(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), tc.orgID)
 			params := logql.SelectSampleParams{SampleQueryRequest: &logproto.SampleQueryRequest{
 				Selector: tc.selector,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(tc.selector),
-				},
+				Plan:     testutil.MustPlan(tc.selector),
 			}}
 			iter, err := multiTenantQuerier.SelectSamples(ctx, params)
 			require.NoError(t, err)
@@ -194,9 +190,7 @@ func TestMultiTenantQuerier_TenantFilter(t *testing.T) {
 		t.Run(tc.selector, func(t *testing.T) {
 			params := logql.SelectSampleParams{SampleQueryRequest: &logproto.SampleQueryRequest{
 				Selector: tc.selector,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(tc.selector),
-				},
+				Plan:     testutil.MustPlan(tc.selector),
 			}}
 			_, updatedSelector, err := removeTenantSelector(params, []string{})
 			require.NoError(t, err)

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -24,8 +24,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
@@ -117,9 +116,7 @@ func TestQuerier_validateQueryRequest(t *testing.T) {
 		Start:     time.Now().Add(-1 * time.Minute),
 		End:       time.Now(),
 		Direction: logproto.FORWARD,
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{type="test", fail="yes"} |= "foo"`),
-		},
+		Plan:      testutil.MustPlan(`{type="test", fail="yes"} |= "foo"`),
 	}
 
 	store := newStoreMock()
@@ -153,9 +150,7 @@ func TestQuerier_validateQueryRequest(t *testing.T) {
 	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, "max streams matchers per query exceeded, matchers-count > limit (2 > 1)"), err)
 
 	request.Selector = `{type="test"}`
-	request.Plan = &plan.QueryPlan{
-		AST: syntax.MustParseExpr(`{type="test"}`),
-	}
+	request.Plan = testutil.MustPlan(`{type="test"}`)
 	_, err = q.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: &request})
 	require.NoError(t, err)
 
@@ -375,9 +370,7 @@ func TestQuerier_IngesterMaxQueryLookback(t *testing.T) {
 				Start:     tc.end.Add(-6 * time.Hour),
 				End:       tc.end,
 				Direction: logproto.FORWARD,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{app="foo"}`),
-				},
+				Plan:      testutil.MustPlan(`{app="foo"}`),
 			}
 
 			queryClient := newQueryClientMock()
@@ -783,9 +776,7 @@ func TestQuerier_RequestingIngesters(t *testing.T) {
 						Start:     start,
 						End:       end,
 						Direction: logproto.FORWARD,
-						Plan: &plan.QueryPlan{
-							AST: syntax.MustParseExpr(`{type="test", fail="yes"} |= "foo"`),
-						},
+						Plan:      testutil.MustPlan(`{type="test", fail="yes"} |= "foo"`),
 					},
 				})
 
@@ -800,9 +791,7 @@ func TestQuerier_RequestingIngesters(t *testing.T) {
 						Selector: `count_over_time({foo="bar"}[5m])`,
 						Start:    start,
 						End:      end,
-						Plan: &plan.QueryPlan{
-							AST: syntax.MustParseExpr(`count_over_time({foo="bar"}[5m])`),
-						},
+						Plan:     testutil.MustPlan(`count_over_time({foo="bar"}[5m])`),
 					},
 				})
 				return err
@@ -1071,9 +1060,7 @@ func TestQuerier_SelectLogWithDeletes(t *testing.T) {
 		Start:     time.Unix(0, 300000000),
 		End:       time.Unix(0, 600000000),
 		Direction: logproto.FORWARD,
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{type="test"} |= "foo"`),
-		},
+		Plan:      testutil.MustPlan(`{type="test"} |= "foo"`),
 	}
 
 	_, err = q.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: &request})
@@ -1090,9 +1077,7 @@ func TestQuerier_SelectLogWithDeletes(t *testing.T) {
 			{Selector: "2", Start: 400000000, End: 500000000},
 			{Selector: "3", Start: 500000000, End: 700000000},
 		},
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(request.Selector),
-		},
+		Plan: testutil.MustPlan(request.Selector),
 	}
 
 	require.Contains(t, store.Calls[0].Arguments, logql.SelectLogParams{QueryRequest: expectedRequest})
@@ -1137,9 +1122,7 @@ func TestQuerier_SelectSamplesWithDeletes(t *testing.T) {
 		Selector: `count_over_time({foo="bar"}[5m])`,
 		Start:    time.Unix(0, 300000000),
 		End:      time.Unix(0, 600000000),
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`count_over_time({foo="bar"}[5m])`),
-		},
+		Plan:     testutil.MustPlan(`count_over_time({foo="bar"}[5m])`),
 	}
 
 	_, err = q.SelectSamples(ctx, logql.SelectSampleParams{SampleQueryRequest: &request})
@@ -1155,9 +1138,7 @@ func TestQuerier_SelectSamplesWithDeletes(t *testing.T) {
 				{Selector: "2", Start: 400000000, End: 500000000},
 				{Selector: "3", Start: 500000000, End: 700000000},
 			},
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(request.Selector),
-			},
+			Plan: testutil.MustPlan(request.Selector),
 		},
 	}
 

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/detected"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
@@ -70,9 +71,7 @@ func Test_codec_EncodeDecodeRequest(t *testing.T) {
 			Path:      "/query_range",
 			StartTs:   start,
 			EndTs:     end,
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(`{foo="bar"}`),
-			},
+			Plan:      testutil.MustPlan(`{foo="bar"}`),
 		}, false},
 		{"query_range", func() (*http.Request, error) {
 			return http.NewRequest(http.MethodGet,
@@ -86,9 +85,7 @@ func Test_codec_EncodeDecodeRequest(t *testing.T) {
 			Path:      "/query_range",
 			StartTs:   start,
 			EndTs:     end,
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(`{foo="bar"}`),
-			},
+			Plan:      testutil.MustPlan(`{foo="bar"}`),
 		}, false},
 		{"legacy query_range with refexp", func() (*http.Request, error) {
 			return http.NewRequest(http.MethodGet,
@@ -102,9 +99,7 @@ func Test_codec_EncodeDecodeRequest(t *testing.T) {
 			Path:      "/api/prom/query",
 			StartTs:   start,
 			EndTs:     end,
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(`{foo="bar"} |~ "foo"`),
-			},
+			Plan:      testutil.MustPlan(`{foo="bar"} |~ "foo"`),
 		}, false},
 		{"series", func() (*http.Request, error) {
 			return http.NewRequest(http.MethodGet,
@@ -334,9 +329,7 @@ func Test_codec_DecodeRequest_cacheHeader(t *testing.T) {
 				Direction: logproto.FORWARD,
 				Path:      "/v1/query",
 				TimeTs:    start,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{foo="bar"}`),
-				},
+				Plan:      testutil.MustPlan(`{foo="bar"}`),
 				CachingOptions: queryrangebase.CachingOptions{
 					Disabled: true,
 				},
@@ -363,9 +356,7 @@ func Test_codec_DecodeRequest_cacheHeader(t *testing.T) {
 				Path:      "/query_range",
 				StartTs:   start,
 				EndTs:     end,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{foo="bar"}`),
-				},
+				Plan:      testutil.MustPlan(`{foo="bar"}`),
 				CachingOptions: queryrangebase.CachingOptions{
 					Disabled: true,
 				},

--- a/pkg/querier/queryrange/downstreamer_test.go
+++ b/pkg/querier/queryrange/downstreamer_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
@@ -357,9 +357,7 @@ func TestParamsToLokiRequest(t *testing.T) {
 				Path:        "/loki/api/v1/query",
 				Shards:      nil,
 				StoreChunks: nil,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(qs),
-				},
+				Plan:        testutil.MustPlan(qs),
 				CachingOptions: resultscache.CachingOptions{
 					Disabled: false,
 				},
@@ -378,9 +376,7 @@ func TestParamsToLokiRequest(t *testing.T) {
 				Path:        "/loki/api/v1/query",
 				Shards:      nil,
 				StoreChunks: nil,
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(qs),
-				},
+				Plan:        testutil.MustPlan(qs),
 				CachingOptions: resultscache.CachingOptions{
 					Disabled: true,
 				},

--- a/pkg/querier/queryrange/engine_router_test.go
+++ b/pkg/querier/queryrange/engine_router_test.go
@@ -14,10 +14,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 )
 
 func TestEngineRouter_split(t *testing.T) {
@@ -29,9 +28,7 @@ func TestEngineRouter_split(t *testing.T) {
 		Step:      1000, // 1 second step
 		Direction: logproto.BACKWARD,
 		Path:      "/query",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{app="foo"}`),
-		},
+		Plan:      testutil.MustPlan(`{app="foo"}`),
 	}
 
 	tests := []struct {
@@ -161,9 +158,7 @@ func TestEngineRouter_stepAlignment(t *testing.T) {
 			Step:      step,
 			Direction: logproto.BACKWARD,
 			Path:      "/query",
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(`{app="foo"}`),
-			},
+			Plan:      testutil.MustPlan(`{app="foo"}`),
 		}
 	}
 
@@ -337,9 +332,7 @@ func Test_engineRouter_Do(t *testing.T) {
 				Step:      1000,
 				Direction: logproto.BACKWARD,
 				Path:      "/api/prom/query_range",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`{foo="bar"}`),
-				},
+				Plan:      testutil.MustPlan(`{foo="bar"}`),
 			},
 			&LokiResponse{
 				Status:     loghttp.QueryStatusSuccess,

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -20,11 +20,10 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/metadata"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -169,9 +168,7 @@ func Test_seriesLimiter(t *testing.T) {
 		EndTs:     testTime,
 		Direction: logproto.FORWARD,
 		Path:      "/query_range",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`rate({app="foo"} |= "foo"[1m])`),
-		},
+		Plan:      testutil.MustPlan(`rate({app="foo"} |= "foo"[1m])`),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")
@@ -527,9 +524,7 @@ func Test_MaxQueryLookBack(t *testing.T) {
 		EndTs:     testTime,
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query_range",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{app="foo"} |= "foo"`),
-		},
+		Plan:      testutil.MustPlan(`{app="foo"} |= "foo"`),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")
@@ -860,9 +855,7 @@ func Test_MaxQuerySize(t *testing.T) {
 				EndTs:     tc.queryEnd,
 				Direction: logproto.FORWARD,
 				Path:      "/query_range",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(tc.query),
-				},
+				Plan:      testutil.MustPlan(tc.query),
 			}
 
 			ctx := user.InjectOrgID(context.Background(), "foo")
@@ -991,9 +984,7 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 				EndTs:     tc.queryEnd,
 				Direction: logproto.FORWARD,
 				Path:      "/query_range",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(tc.query),
-				},
+				Plan:      testutil.MustPlan(tc.query),
 			}
 
 			ctx := user.InjectOrgID(context.Background(), "foo")

--- a/pkg/querier/queryrange/querysharding_partial_test.go
+++ b/pkg/querier/queryrange/querysharding_partial_test.go
@@ -17,11 +17,10 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -110,7 +109,7 @@ func TestASTMapperware_PartialStatsOnError(t *testing.T) {
 	query := `count_over_time({app="left"}[1h]) / count_over_time({app="right"}[1h])`
 	req := defaultReq()
 	req.Query = query
-	req.Plan = &plan.QueryPlan{AST: syntax.MustParseExpr(query)}
+	req.Plan = testutil.MustPlan(query)
 
 	data := &queryData{}
 	ctx := user.InjectOrgID(context.WithValue(context.Background(), ctxKey, data), "1")
@@ -178,7 +177,7 @@ func TestASTMapperware_QuerierBytesLimitIsClassifiedAsLimit(t *testing.T) {
 	query := `avg_over_time({app="foo"} | json busy="utilization" | unwrap busy [5m])`
 	req := defaultReq()
 	req.Query = query
-	req.Plan = &plan.QueryPlan{AST: syntax.MustParseExpr(query)}
+	req.Plan = testutil.MustPlan(query)
 
 	_, err := mware.Do(user.InjectOrgID(context.Background(), "1"), req)
 	require.Error(t, err)

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -187,9 +188,7 @@ func Test_astMapper(t *testing.T) {
 
 	req := defaultReq()
 	req.Query = `{foo="bar"}`
-	req.Plan = &plan.QueryPlan{
-		AST: syntax.MustParseExpr(req.Query),
-	}
+	req.Plan = testutil.MustPlan(req.Query)
 	resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), req)
 	require.Nil(t, err)
 
@@ -332,9 +331,7 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 
 			req := defaultReq()
 			req.Query = tc.query
-			req.Plan = &plan.QueryPlan{
-				AST: syntax.MustParseExpr(tc.query),
-			}
+			req.Plan = testutil.MustPlan(tc.query)
 			_, err := mware.Do(user.InjectOrgID(context.Background(), "1"), req)
 			if err != nil {
 				require.ErrorContains(t, err, tc.err)
@@ -394,9 +391,7 @@ func Test_astMapper_TSDBShardingStrategyUsesContext(t *testing.T) {
 
 	req := defaultReq()
 	req.Query = `{app="foo"}`
-	req.Plan = &plan.QueryPlan{
-		AST: syntax.MustParseExpr(req.Query),
-	}
+	req.Plan = testutil.MustPlan(req.Query)
 	ctx := context.WithValue(context.Background(), strategyContextKey{}, "strategy-context")
 	ctx = user.InjectOrgID(ctx, "tenant-a")
 
@@ -431,9 +426,7 @@ func Test_ShardingByPass(t *testing.T) {
 
 	req := defaultReq()
 	req.Query = `1+1`
-	req.Plan = &plan.QueryPlan{
-		AST: syntax.MustParseExpr(req.Query),
-	}
+	req.Plan = testutil.MustPlan(req.Query)
 
 	_, err := mware.Do(user.InjectOrgID(context.Background(), "1"), req)
 	require.Nil(t, err)
@@ -540,9 +533,7 @@ func Test_InstantSharding(t *testing.T) {
 		Query:  `rate({app="foo"}[1m])`,
 		TimeTs: util.TimeFromMillis(10),
 		Path:   "/v1/query",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`rate({app="foo"}[1m])`),
-		},
+		Plan:   testutil.MustPlan(`rate({app="foo"}[1m])`),
 	})
 	require.NoError(t, err)
 	require.Equal(t, 3, called, "expected 3 calls but got {}", called)
@@ -950,9 +941,7 @@ func Test_ASTMapper_MaxLookBackPeriod(t *testing.T) {
 		TimeTs:    testTime,
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(q),
-		},
+		Plan:      testutil.MustPlan(q),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "foo")

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -23,11 +23,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	base "github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
 	"github.com/grafana/loki/v3/pkg/storage/config"
@@ -209,9 +208,7 @@ func TestMetricsTripperware(t *testing.T) {
 		EndTs:     testTime,
 		Direction: logproto.FORWARD,
 		Path:      "/query_range",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`rate({app="foo"} |= "foo"[1m])`),
-		},
+		Plan:      testutil.MustPlan(`rate({app="foo"} |= "foo"[1m])`),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")
@@ -295,9 +292,7 @@ func TestLogFilterTripperware(t *testing.T) {
 		EndTs:     testTime,
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query_range",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{app="foo"} |= "foo"`),
-		},
+		Plan:      testutil.MustPlan(`{app="foo"} |= "foo"`),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")
@@ -370,9 +365,7 @@ func TestInstantQueryTripperwareResultCaching(t *testing.T) {
 		TimeTs:    testTime.Add(-4 * time.Hour),
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(q),
-		},
+		Plan:      testutil.MustPlan(q),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")
@@ -485,9 +478,7 @@ func TestInstantQueryTripperware(t *testing.T) {
 		TimeTs:    testTime.Add(-4 * time.Hour), // because vector data we return from mock handler has that time.
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(q),
-		},
+		Plan:      testutil.MustPlan(q),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")
@@ -954,9 +945,7 @@ func TestLogNoFilter(t *testing.T) {
 		EndTs:     testTime,
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query_range",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{app="foo"}`),
-		},
+		Plan:      testutil.MustPlan(`{app="foo"}`),
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")
@@ -970,9 +959,7 @@ func TestLogNoFilter(t *testing.T) {
 func TestPostQueries(t *testing.T) {
 	lreq := &LokiRequest{
 		Query: `{app="foo"} |~ "foo"`,
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{app="foo"} |~ "foo"`),
-		},
+		Plan:  testutil.MustPlan(`{app="foo"} |~ "foo"`),
 	}
 	ctx := user.InjectOrgID(context.Background(), "1")
 	handler := base.HandlerFunc(func(context.Context, base.Request) (base.Response, error) {
@@ -1014,9 +1001,7 @@ func TestTripperware_EntriesLimit(t *testing.T) {
 		EndTs:     testTime,
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query_range",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{app="foo"}`),
-		},
+		Plan:      testutil.MustPlan(`{app="foo"}`),
 	}
 
 	// The queryData value statsHTTPMiddleware installs marks this as a real user
@@ -1087,9 +1072,7 @@ func TestTripperware_RequiredLabels(t *testing.T) {
 				EndTs:     testTime,
 				Direction: logproto.FORWARD,
 				Path:      "/loki/api/v1/query_range",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(test.qs),
-				},
+				Plan:      testutil.MustPlan(test.qs),
 			}
 			// See loghttp.step
 			step := time.Duration(int(math.Max(math.Floor(lreq.EndTs.Sub(lreq.StartTs).Seconds()/250), 1))) * time.Second
@@ -1194,9 +1177,7 @@ func TestTripperware_RequiredNumberLabels(t *testing.T) {
 				EndTs:     testTime,
 				Direction: logproto.FORWARD,
 				Path:      "/loki/api/v1/query_range",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(tc.query),
-				},
+				Plan:      testutil.MustPlan(tc.query),
 			}
 			// See loghttp.step
 			step := time.Duration(int(math.Max(math.Floor(lreq.EndTs.Sub(lreq.StartTs).Seconds()/250), 1))) * time.Second
@@ -1327,9 +1308,7 @@ func TestMetricsTripperware_SplitShardStats(t *testing.T) {
 				TimeTs:    testTime,
 				Direction: logproto.FORWARD,
 				Path:      "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (app) (rate({app="foo"} |= "foo"[2h]))`),
-				},
+				Plan:      testutil.MustPlan(`sum by (app) (rate({app="foo"} |= "foo"[2h]))`),
 			},
 			// [2h] interval split by 1h configured split interval.
 			// Also since we split align(testConfig.InstantQuerySplitAlign=true) with split interval (1h).
@@ -1345,9 +1324,7 @@ func TestMetricsTripperware_SplitShardStats(t *testing.T) {
 				TimeTs:    testTime,
 				Direction: logproto.FORWARD,
 				Path:      "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (app) (rate({app="foo"} |= "foo"[1h]))`),
-				},
+				Plan:      testutil.MustPlan(`sum by (app) (rate({app="foo"} |= "foo"[1h]))`),
 			},
 			expectedSplitStats: 0, // [1h] interval not split
 			expectedShardStats: 4, // 4 row shards
@@ -1362,9 +1339,7 @@ func TestMetricsTripperware_SplitShardStats(t *testing.T) {
 				EndTs:     testTime,
 				Direction: logproto.FORWARD,
 				Path:      "/query_range",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (app) (rate({app="foo"} |= "foo"[1h]))`),
-				},
+				Plan:      testutil.MustPlan(`sum by (app) (rate({app="foo"} |= "foo"[1h]))`),
 			},
 			expectedSplitStats: 3,  // 2 hour range interval split based on the base hour + the remainder
 			expectedShardStats: 20, // range query with a [1h] range vector resolves shards over 5 sharded subqueries * 4 shards each
@@ -1379,9 +1354,7 @@ func TestMetricsTripperware_SplitShardStats(t *testing.T) {
 				EndTs:     testTime,
 				Direction: logproto.FORWARD,
 				Path:      "/query_range",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (app) (rate({app="foo"} |= "foo"[1h]))`),
-				},
+				Plan:      testutil.MustPlan(`sum by (app) (rate({app="foo"} |= "foo"[1h]))`),
 			},
 			expectedSplitStats: 0, // 1 minute range interval not split
 			expectedShardStats: 4, // 4 row shards

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -84,9 +85,7 @@ func Test_splitQuery(t *testing.T) {
 					EndTs:     end,
 					Direction: logproto.BACKWARD,
 					Path:      "/query",
-					Plan: &plan.QueryPlan{
-						AST: syntax.MustParseExpr(`{app="foo"}`),
-					},
+					Plan:      testutil.MustPlan(`{app="foo"}`),
 				}
 			},
 		},
@@ -100,9 +99,7 @@ func Test_splitQuery(t *testing.T) {
 					EndTs:     end,
 					Direction: logproto.BACKWARD,
 					Path:      "/query",
-					Plan: &plan.QueryPlan{
-						AST: syntax.MustParseExpr(`{app="foo"}`),
-					},
+					Plan:      testutil.MustPlan(`{app="foo"}`),
 				}
 			},
 		},
@@ -1332,9 +1329,7 @@ func Test_splitMetricQuery(t *testing.T) {
 		},
 	} {
 		// Set query plans
-		tc.input.Plan = &plan.QueryPlan{
-			AST: syntax.MustParseExpr(tc.input.Query),
-		}
+		tc.input.Plan = testutil.MustPlan(tc.input.Query)
 
 		for _, e := range tc.expected {
 			e.(*LokiRequest).Plan = &plan.QueryPlan{

--- a/pkg/querier/queryrange/split_by_range_test.go
+++ b/pkg/querier/queryrange/split_by_range_test.go
@@ -13,9 +13,8 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 )
 
 func Test_RangeVectorSplitAlign(t *testing.T) {
@@ -40,9 +39,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum(bytes_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(180, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(bytes_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(bytes_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum(bytes_over_time({app="foo"}[1m]))`, 1, time.Unix(60, 0)),
@@ -58,9 +55,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum(bytes_over_time({app="foo"}[3h]))`,
 				TimeTs: twelve34,
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(bytes_over_time({app="foo"}[3h]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(bytes_over_time({app="foo"}[3h]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum(bytes_over_time({app="foo"}[34m]))`, 1, twelve34),
@@ -77,9 +72,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum by (bar) (bytes_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(180, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (bytes_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (bytes_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum by (bar)(bytes_over_time({app="foo"}[1m]))`, 10, time.Unix(60, 0)),
@@ -95,9 +88,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum by (bar) (bytes_over_time({app="foo"}[3h]))`,
 				TimeTs: twelve34,
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (bytes_over_time({app="foo"}[3h]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (bytes_over_time({app="foo"}[3h]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum by (bar)(bytes_over_time({app="foo"}[34m]))`, 10, twelve34), // 12:34:00
@@ -114,9 +105,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum(count_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(180, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(count_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(count_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum(count_over_time({app="foo"}[1m]))`, 1, time.Unix(60, 0)),
@@ -132,9 +121,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum(count_over_time({app="foo"}[3h]))`,
 				TimeTs: twelve34,
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(count_over_time({app="foo"}[3h]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(count_over_time({app="foo"}[3h]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum(count_over_time({app="foo"}[34m]))`, 1, twelve34),
@@ -151,9 +138,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum by (bar) (count_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(180, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (count_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (count_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum by (bar)(count_over_time({app="foo"}[1m]))`, 0, time.Unix(60, 0)),
@@ -169,9 +154,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum by (bar) (count_over_time({app="foo"}[3h]))`,
 				TimeTs: twelve34,
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (count_over_time({app="foo"}[3h]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (count_over_time({app="foo"}[3h]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum by (bar)(count_over_time({app="foo"}[34m]))`, 0, twelve34),
@@ -188,9 +171,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum(sum_over_time({app="foo"} | unwrap bar [3m]))`,
 				TimeTs: time.Unix(180, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(sum_over_time({app="foo"} | unwrap bar [3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(sum_over_time({app="foo"} | unwrap bar [3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum(sum_over_time({app="foo"} | unwrap bar[1m]))`, 1, time.Unix(60, 0)),
@@ -206,9 +187,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum(sum_over_time({app="foo"} | unwrap bar [3h]))`,
 				TimeTs: twelve34,
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(sum_over_time({app="foo"} | unwrap bar [3h]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(sum_over_time({app="foo"} | unwrap bar [3h]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum(sum_over_time({app="foo"} | unwrap bar[34m]))`, 1, twelve34),
@@ -225,9 +204,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3m]))`,
 				TimeTs: time.Unix(180, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum by (bar)(sum_over_time({app="foo"} | unwrap bar[1m]))`, 1, time.Unix(60, 0)),
@@ -243,9 +220,7 @@ func Test_RangeVectorSplitAlign(t *testing.T) {
 				Query:  `sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3h]))`,
 				TimeTs: twelve34,
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3h]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3h]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponseWithQueryTime(`sum by (bar)(sum_over_time({app="foo"} | unwrap bar[34m]))`, 1, twelve34),
@@ -315,9 +290,7 @@ func Test_RangeVectorSplit(t *testing.T) {
 				Query:  `sum(bytes_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(1, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(bytes_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(bytes_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponse(`sum(bytes_over_time({app="foo"}[1m]))`, 1),
@@ -331,9 +304,7 @@ func Test_RangeVectorSplit(t *testing.T) {
 				Query:  `sum by (bar) (bytes_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(1, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (bytes_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (bytes_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponse(`sum by (bar)(bytes_over_time({app="foo"}[1m]))`, 10),
@@ -347,9 +318,7 @@ func Test_RangeVectorSplit(t *testing.T) {
 				Query:  `sum(count_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(1, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(count_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(count_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponse(`sum(count_over_time({app="foo"}[1m]))`, 1),
@@ -363,9 +332,7 @@ func Test_RangeVectorSplit(t *testing.T) {
 				Query:  `sum by (bar) (count_over_time({app="foo"}[3m]))`,
 				TimeTs: time.Unix(1, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (count_over_time({app="foo"}[3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (count_over_time({app="foo"}[3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponse(`sum by (bar)(count_over_time({app="foo"}[1m]))`, 0),
@@ -379,9 +346,7 @@ func Test_RangeVectorSplit(t *testing.T) {
 				Query:  `sum(sum_over_time({app="foo"} | unwrap bar [3m]))`,
 				TimeTs: time.Unix(1, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum(sum_over_time({app="foo"} | unwrap bar [3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum(sum_over_time({app="foo"} | unwrap bar [3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponse(`sum(sum_over_time({app="foo"} | unwrap bar[1m]))`, 1),
@@ -395,9 +360,7 @@ func Test_RangeVectorSplit(t *testing.T) {
 				Query:  `sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3m]))`,
 				TimeTs: time.Unix(1, 0),
 				Path:   "/loki/api/v1/query",
-				Plan: &plan.QueryPlan{
-					AST: syntax.MustParseExpr(`sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3m]))`),
-				},
+				Plan:   testutil.MustPlan(`sum by (bar) (sum_over_time({app="foo"} | unwrap bar [3m]))`),
 			},
 			subQueries: []queryrangebase.RequestResponse{
 				subQueryRequestResponse(`sum by (bar)(sum_over_time({app="foo"} | unwrap bar[1m]))`, 1),
@@ -435,9 +398,7 @@ func subQueryRequestResponseWithQueryTime(expectedSubQuery string, sampleValue f
 			Query:  expectedSubQuery,
 			TimeTs: exec,
 			Path:   "/loki/api/v1/query",
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(expectedSubQuery),
-			},
+			Plan:   testutil.MustPlan(expectedSubQuery),
 		},
 		Response: &LokiPromResponse{
 			Response: &queryrangebase.PrometheusResponse{
@@ -468,9 +429,7 @@ func subQueryRequestResponse(expectedSubQuery string, sampleValue float64) query
 			Query:  expectedSubQuery,
 			TimeTs: time.Unix(1, 0),
 			Path:   "/loki/api/v1/query",
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(expectedSubQuery),
-			},
+			Plan:   testutil.MustPlan(expectedSubQuery),
 		},
 		Response: &LokiPromResponse{
 			Response: &queryrangebase.PrometheusResponse{

--- a/pkg/querier/tail/querier_test.go
+++ b/pkg/querier/tail/querier_test.go
@@ -38,9 +38,7 @@ func TestQuerier_Tail_QueryTimeoutConfigFlag(t *testing.T) {
 		DelayFor: 0,
 		Limit:    10,
 		Start:    time.Now(),
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{type="test"}`),
-		},
+		Plan:     testutil.MustPlan(`{type="test"}`),
 	}
 
 	// Setup mocks

--- a/pkg/querier/testutil/requests.go
+++ b/pkg/querier/testutil/requests.go
@@ -1,0 +1,14 @@
+package testutil
+
+import (
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/querier/plan"
+)
+
+// MustPlan creates a QueryPlan from a selector string.
+// Panics if the selector cannot be parsed.
+func MustPlan(selector string) *plan.QueryPlan {
+	return &plan.QueryPlan{
+		AST: syntax.MustParseExpr(selector),
+	}
+}

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -1777,6 +1778,7 @@ func Benchmark_store_OverlappingChunks(b *testing.B) {
 			Shards:    nil,
 			Start:     time.Unix(0, 1),
 			End:       time.Unix(0, time.Now().UnixNano()),
+			Plan:      testutil.MustPlan(`{foo="bar"}`),
 		}})
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -11,11 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/compression"
-	"github.com/grafana/loki/v3/pkg/storage/types"
-	"github.com/grafana/loki/v3/pkg/util"
-	"github.com/grafana/loki/v3/pkg/util/httpreq"
-
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/user"
@@ -26,6 +21,7 @@ import (
 	"github.com/grafana/loki/pkg/push"
 
 	"github.com/grafana/loki/v3/pkg/chunkenc"
+	"github.com/grafana/loki/v3/pkg/compression"
 	"github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/iter"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -35,11 +31,15 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/astmapper"
 	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
+	"github.com/grafana/loki/v3/pkg/storage/types"
+	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
@@ -371,9 +371,7 @@ func Test_store_SelectLogs(t *testing.T) {
 				logger:       log.NewNopLogger(),
 			}
 
-			tt.req.Plan = &plan.QueryPlan{
-				AST: syntax.MustParseExpr(tt.req.Selector),
-			}
+			tt.req.Plan = testutil.MustPlan(tt.req.Selector)
 
 			ctx = user.InjectOrgID(context.Background(), "test-user")
 			it, err := s.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: tt.req})
@@ -701,9 +699,7 @@ func Test_store_SelectSample(t *testing.T) {
 				chunkMetrics: NilMetrics,
 			}
 
-			tt.req.Plan = &plan.QueryPlan{
-				AST: syntax.MustParseExpr(tt.req.Selector),
-			}
+			tt.req.Plan = testutil.MustPlan(tt.req.Selector)
 
 			ctx = user.InjectOrgID(context.Background(), "test-user")
 			it, err := s.SelectSamples(ctx, logql.SelectSampleParams{SampleQueryRequest: tt.req})
@@ -1502,9 +1498,7 @@ func Test_OverlappingChunks(t *testing.T) {
 		Direction: logproto.BACKWARD,
 		Start:     time.Unix(0, 0),
 		End:       time.Unix(0, 10),
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(`{foo="bar"}`),
-		},
+		Plan:      testutil.MustPlan(`{foo="bar"}`),
 	}})
 	if err != nil {
 		t.Errorf("store.SelectLogs() error = %v", err)
@@ -1623,9 +1617,7 @@ func Test_GetSeries(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.req.Selector != "" {
-				tt.req.Plan = &plan.QueryPlan{
-					AST: syntax.MustParseExpr(tt.req.Selector),
-				}
+				tt.req.Plan = testutil.MustPlan(tt.req.Selector)
 			} else {
 				tt.req.Plan = &plan.QueryPlan{
 					AST: nil,
@@ -1912,9 +1904,7 @@ func TestQueryReferencingStructuredMetadata(t *testing.T) {
 			Direction: logproto.FORWARD,
 			Start:     chkFrom,
 			End:       chkThrough.Add(time.Minute),
-			Plan: &plan.QueryPlan{
-				AST: syntax.MustParseExpr(stream),
-			},
+			Plan:      testutil.MustPlan(stream),
 		}})
 		require.NoError(t, err)
 
@@ -1989,9 +1979,7 @@ func TestQueryReferencingStructuredMetadata(t *testing.T) {
 					Direction: logproto.FORWARD,
 					Start:     chkFrom,
 					End:       chkThrough.Add(time.Minute),
-					Plan: &plan.QueryPlan{
-						AST: syntax.MustParseExpr(tc.query),
-					},
+					Plan:      testutil.MustPlan(tc.query),
 				}})
 				require.NoError(t, err)
 				numEntries := int64(0)

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/astmapper"
-	"github.com/grafana/loki/v3/pkg/querier/plan"
+	"github.com/grafana/loki/v3/pkg/querier/testutil"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	chunkclient "github.com/grafana/loki/v3/pkg/storage/chunk/client"
@@ -138,9 +138,7 @@ func newQuery(query string, start, end time.Time, shards []astmapper.ShardAnnota
 		End:       end,
 		Direction: logproto.FORWARD,
 		Deletes:   deletes,
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(query),
-		},
+		Plan:      testutil.MustPlan(query),
 	}
 	for _, shard := range shards {
 		req.Shards = append(req.Shards, shard.String())
@@ -154,9 +152,7 @@ func newSampleQuery(query string, start, end time.Time, shards []astmapper.Shard
 		Start:    start,
 		End:      end,
 		Deletes:  deletes,
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(query),
-		},
+		Plan:     testutil.MustPlan(query),
 	}
 	for _, shard := range shards {
 		req.Shards = append(req.Shards, shard.String())


### PR DESCRIPTION
**What this PR does / why we need it**:

Add testutil.MustPlan() helper to create QueryPlan from selector strings and update all test files to use it instead of inline plan literals.

This is step 1 of the QueryRequest.Selector to QueryRequest.Plan migration: ensuring Plan is always populated on every producer.

Changes:
- Add pkg/querier/testutil/requests.go with MustPlan() helper
- Update 22 test files to use testutil.MustPlan() (115 instances)
- 32 instances remain where AST uses pre-parsed expressions

The fallback code in ingester and marshal layers remains for version-skew compatibility during rollout.