### PR TITLE
chore(querier): Operate on AST directly in multi-tenant querier

### DIFF
--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -128,8 +128,8 @@ func validateExpr(expr Expr) error {
 	}
 }
 
-// validateMatchers checks whether a query would touch all the streams in the query range or uses at least one matcher to select specific streams.
-func validateMatchers(matchers []*labels.Matcher) error {
+// ValidateMatchers checks whether a query would touch all the streams in the query range or uses at least one matcher to select specific streams.
+func ValidateMatchers(matchers []*labels.Matcher) error {
 	_, matchers = util.SplitFiltersAndMatchers(matchers)
 	if len(matchers) == 0 {
 		return logqlmodel.NewParseError(errAtleastOneEqualityMatcherRequired, 0, 0)
@@ -248,7 +248,7 @@ func validateLogSelectorExpression(expr LogSelectorExpr) error {
 	case *VectorExpr:
 		return nil
 	default:
-		return validateMatchers(e.Matchers())
+		return ValidateMatchers(e.Matchers())
 	}
 }
 

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -59,6 +59,9 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 		return nil, err
 	}
 	matchedTenants, filteredMatchers := filterValuesByMatchers(defaultTenantLabel, tenantIDs, selector.Matchers()...)
+	if err := syntax.ValidateMatchers(filteredMatchers); err != nil {
+		return nil, err
+	}
 	updatedSelector := replaceMatchers(selector, filteredMatchers)
 
 	// Update Plan with the modified AST directly (no string round-trip)
@@ -106,8 +109,11 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 		return q.Querier.SelectSamples(ctx, params)
 	}
 
-	matchedTenants, updatedExpr, err := removeTenantSelector(params, tenantIDs)
+	matchedTenants, filteredMatchers, updatedExpr, err := removeTenantSelector(params, tenantIDs)
 	if err != nil {
+		return nil, err
+	}
+	if err := syntax.ValidateMatchers(filteredMatchers); err != nil {
 		return nil, err
 	}
 
@@ -385,18 +391,18 @@ func (q *MultiTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.D
 }
 
 // removeTenantSelector filters the given tenant IDs based on any tenant ID filter the in passed selector.
-func removeTenantSelector(params logql.SelectSampleParams, tenantIDs []string) (map[string]struct{}, syntax.Expr, error) {
+func removeTenantSelector(params logql.SelectSampleParams, tenantIDs []string) (map[string]struct{}, []*labels.Matcher, syntax.Expr, error) {
 	expr, err := params.Expr()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	selector, err := expr.Selector()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	matchedTenants, filteredMatchers := filterValuesByMatchers(defaultTenantLabel, tenantIDs, selector.Matchers()...)
 	updatedExpr := replaceMatchers(expr, filteredMatchers)
-	return matchedTenants, updatedExpr, nil
+	return matchedTenants, filteredMatchers, updatedExpr, nil
 }
 
 // replaceMatchers traverses the passed expression and replaces all matchers.

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -2,7 +2,6 @@ package querier
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -60,15 +59,14 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 		return nil, err
 	}
 	matchedTenants, filteredMatchers := filterValuesByMatchers(defaultTenantLabel, tenantIDs, selector.Matchers()...)
-	params.Selector = replaceMatchers(selector, filteredMatchers).String()
+	updatedSelector := replaceMatchers(selector, filteredMatchers)
 
-	parsed, err := syntax.ParseLogSelector(params.Selector, true)
-	if err != nil {
-		return nil, fmt.Errorf("log selector is invalid after matcher update: %w", err)
-	}
+	// Update Plan with the modified AST directly (no string round-trip)
 	params.Plan = &plan.QueryPlan{
-		AST: parsed,
+		AST: updatedSelector,
 	}
+	// Keep Selector in sync for backward compatibility during version-skew rollout
+	params.Selector = updatedSelector.String()
 
 	// in case of multiple tenants, we need to filter the store chunks by tenant if they are provided
 	storeOverridesByTenant := make(map[string][]*logproto.ChunkRef)
@@ -108,11 +106,17 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 		return q.Querier.SelectSamples(ctx, params)
 	}
 
-	matchedTenants, updatedSelector, err := removeTenantSelector(params, tenantIDs)
+	matchedTenants, updatedExpr, err := removeTenantSelector(params, tenantIDs)
 	if err != nil {
 		return nil, err
 	}
-	params.Selector = updatedSelector.String()
+
+	// Update Plan with the modified AST directly (no string round-trip)
+	params.Plan = &plan.QueryPlan{
+		AST: updatedExpr,
+	}
+	// Keep Selector in sync for backward compatibility during version-skew rollout
+	params.Selector = updatedExpr.String()
 
 	// in case of multiple tenants, we need to filter the store chunks by tenant if they are provided
 	storeOverridesByTenant := make(map[string][]*logproto.ChunkRef)

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -390,8 +390,12 @@ func (q *MultiTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.D
 	}, nil
 }
 
-// removeTenantSelector filters the given tenant IDs based on any tenant ID filter the in passed selector.
-func removeTenantSelector(params logql.SelectSampleParams, tenantIDs []string) (map[string]struct{}, []*labels.Matcher, syntax.Expr, error) {
+// removeTenantSelector filters the given tenant IDs based on any tenant ID filter in the passed selector.
+// It returns:
+//   - matchedTenants: tenant IDs that matched the selector's tenant filter
+//   - filteredMatchers: matchers with __tenant_id__ removed, for validation before use
+//   - updatedExpr: the expression with filteredMatchers already applied
+func removeTenantSelector(params logql.SelectSampleParams, tenantIDs []string) (matchedTenants map[string]struct{}, filteredMatchers []*labels.Matcher, updatedExpr syntax.Expr, err error) {
 	expr, err := params.Expr()
 	if err != nil {
 		return nil, nil, nil, err
@@ -400,8 +404,8 @@ func removeTenantSelector(params logql.SelectSampleParams, tenantIDs []string) (
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	matchedTenants, filteredMatchers := filterValuesByMatchers(defaultTenantLabel, tenantIDs, selector.Matchers()...)
-	updatedExpr := replaceMatchers(expr, filteredMatchers)
+	matchedTenants, filteredMatchers = filterValuesByMatchers(defaultTenantLabel, tenantIDs, selector.Matchers()...)
+	updatedExpr = replaceMatchers(expr, filteredMatchers)
 	return matchedTenants, filteredMatchers, updatedExpr, nil
 }
 

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -192,7 +192,7 @@ func TestMultiTenantQuerier_TenantFilter(t *testing.T) {
 				Selector: tc.selector,
 				Plan:     testutil.MustPlan(tc.selector),
 			}}
-			_, updatedSelector, err := removeTenantSelector(params, []string{})
+			_, _, updatedSelector, err := removeTenantSelector(params, []string{})
 			require.NoError(t, err)
 			require.Equal(t, removeWhiteSpace(tc.expected), removeWhiteSpace(updatedSelector.String()))
 		})
@@ -699,6 +699,66 @@ func TestMultiTenantQuerier_DetectedLabels(t *testing.T) {
 				// Allow for some error in cardinality estimation due to HyperLogLog approximation
 				require.InDelta(t, tc.expected[i].Cardinality, resp.DetectedLabels[i].Cardinality, float64(tc.expected[i].Cardinality)*0.02)
 			}
+		})
+	}
+}
+
+// TestSelectLogs_TenantIDOnlySelector verifies that SelectLogs validates the
+// rewritten selector after __tenant_id__ matchers are stripped. A query left
+// with no equality or regexp matcher should be rejected to prevent scanning
+// every stream for the matched tenant.
+func TestSelectLogs_TenantIDOnlySelector(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		orgID    string
+		selector string
+	}{
+		{
+			desc:     "tenant ID only selector becomes empty after stripping",
+			orgID:    "1|2",
+			selector: `{__tenant_id__="1"}`,
+		},
+		{
+			desc:     "tenant ID with negation matcher leaves no equality matcher",
+			orgID:    "1|2",
+			selector: `{__tenant_id__="1", foo!="bar"}`,
+		},
+		{
+			desc:     "tenant ID with regex-all matcher leaves no equality matcher",
+			orgID:    "1|2",
+			selector: `{__tenant_id__="1", foo=~".*"}`,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Validate that the original selector would pass ParseLogSelector
+			// validation (has at least one equality/regexp matcher).
+			_, err := syntax.ParseLogSelector(tc.selector, true)
+			require.NoError(t, err, "original selector should be valid")
+
+			querier := newQuerierMock()
+			querier.On("SelectLogs", mock.Anything, mock.Anything).Return(func() iter.EntryIterator { return mockStreamIterator(1, 2) }, nil)
+
+			multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+			ctx := user.InjectOrgID(context.Background(), tc.orgID)
+
+			params := logql.SelectLogParams{QueryRequest: &logproto.QueryRequest{
+				Selector:  tc.selector,
+				Direction: logproto.BACKWARD,
+				Limit:     0,
+				Shards:    nil,
+				Start:     time.Unix(0, 1),
+				End:       time.Unix(0, time.Now().UnixNano()),
+				Plan:      testutil.MustPlan(tc.selector),
+			}}
+
+			// SelectLogs should fail because the rewritten selector has no
+			// equality or regexp matcher after stripping __tenant_id__.
+			_, err = multiTenantQuerier.SelectLogs(ctx, params)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "at least one regexp or equality matcher")
+
+			// Verify the underlying querier was NOT called.
+			querier.AssertNotCalled(t, "SelectLogs", mock.Anything, mock.Anything)
 		})
 	}
 }

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -763,6 +763,56 @@ func TestSelectLogs_TenantIDOnlySelector(t *testing.T) {
 	}
 }
 
+// TestSelectSamples_TenantIDOnlySelector verifies that SelectSamples validates
+// the rewritten selector after __tenant_id__ matchers are stripped. A query
+// left with no equality or regexp matcher should be rejected to prevent
+// scanning every stream for the matched tenant.
+func TestSelectSamples_TenantIDOnlySelector(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		orgID    string
+		selector string
+	}{
+		{
+			desc:     "tenant ID only selector becomes empty after stripping",
+			orgID:    "1|2",
+			selector: `count_over_time({__tenant_id__="1"}[1m])`,
+		},
+		{
+			desc:     "tenant ID with negation matcher leaves no equality matcher",
+			orgID:    "1|2",
+			selector: `count_over_time({__tenant_id__="1", foo!="bar"}[1m])`,
+		},
+		{
+			desc:     "tenant ID with regex-all matcher leaves no equality matcher",
+			orgID:    "1|2",
+			selector: `count_over_time({__tenant_id__="1", foo=~".*"}[1m])`,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			querier := newQuerierMock()
+			querier.On("SelectSamples", mock.Anything, mock.Anything).Return(func() iter.SampleIterator { return newSampleIterator() }, nil)
+
+			multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+			ctx := user.InjectOrgID(context.Background(), tc.orgID)
+
+			params := logql.SelectSampleParams{SampleQueryRequest: &logproto.SampleQueryRequest{
+				Selector: tc.selector,
+				Plan:     testutil.MustPlan(tc.selector),
+			}}
+
+			// SelectSamples should fail because the rewritten selector has no
+			// equality or regexp matcher after stripping __tenant_id__.
+			_, err := multiTenantQuerier.SelectSamples(ctx, params)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "at least one regexp or equality matcher")
+
+			// Verify the underlying querier was NOT called.
+			querier.AssertNotCalled(t, "SelectSamples", mock.Anything, mock.Anything)
+		})
+	}
+}
+
 func TestMultiTenantQuerierPatterns(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Rework MultiTenantQuerier to operate on the AST directly instead of converting to string and re-parsing.

This is step 2 of the QueryRequest.Selector to QueryRequest.Plan migration (loki-private#2709).

Changes:
- SelectLogs: Assign modified AST directly to Plan, eliminating the string round-trip (AST → string → parse → AST)
- SelectSamples: Fix bug where Plan was not being updated after tenant selector removal; now updates Plan with modified AST
- Remove unused fmt import

Both methods still update Selector for backward compatibility during version-skew rollout.
