### PR TITLE
chore: Use Plan.AST to detect 'select all series' in SelectSeries

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1380,7 +1380,6 @@ func (i *Ingester) series(ctx context.Context, req *logproto.SeriesRequest) (*lo
 
 	if start, end, ok := buildStoreRequest(i.cfg, req.Start, req.End, time.Now()); ok {
 		var storeSeries []logproto.SeriesIdentifier
-		var parsed syntax.Expr
 
 		groups := []string{""}
 		if len(req.Groups) != 0 {
@@ -1388,6 +1387,7 @@ func (i *Ingester) series(ctx context.Context, req *logproto.SeriesRequest) (*lo
 		}
 
 		for _, group := range groups {
+			var parsed syntax.Expr
 			if group != "" {
 				parsed, err = syntax.ParseExpr(group)
 				if err != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -21,8 +21,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	lokilog "github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/astmapper"
+	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
@@ -500,12 +502,24 @@ func (s *LokiStore) SelectSeries(ctx context.Context, req logql.SelectLogParams)
 	if err != nil {
 		return nil, err
 	}
+	// decodeReq resolves matchers from Plan.AST only. Callers that have not been
+	// migrated yet set the deprecated Selector field instead, so parse it into a plan.
+	if (req.Plan == nil || req.Plan.AST == nil) && req.Selector != "" {
+		expr, err := syntax.ParseExpr(req.Selector)
+		if err != nil {
+			return nil, err
+		}
+		cpy := *req.QueryRequest
+		cpy.Plan = &plan.QueryPlan{AST: expr}
+		req = logql.SelectLogParams{QueryRequest: &cpy}
+	}
+
 	var from, through model.Time
 	var matchers []*labels.Matcher
 
 	// The Loki parser doesn't allow for an empty label matcher but for the Series API
 	// we allow this to select all series in the time range.
-	if req.Selector == "" {
+	if req.Plan == nil || req.Plan.AST == nil {
 		from, through = util.RoundToMilliseconds(req.Start, req.End)
 		nameLabelMatcher, err := labels.NewMatcher(labels.MatchEqual, model.MetricNameLabel, "logs")
 		if err != nil {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1053,6 +1053,31 @@ func Test_store_GetSeries(t *testing.T) {
 			},
 			1,
 		},
+		{
+			"plan without deprecated selector",
+			withoutSelector(newQuery("{foo=\"bar\"}", from, from.Add(6*time.Millisecond), nil, nil)),
+			[]logproto.SeriesIdentifier{
+				{Labels: mustParseLabels("{foo=\"bar\"}")},
+			},
+			1,
+		},
+		{
+			"deprecated selector without plan",
+			withoutPlan(newQuery("{foo=\"bar\"}", from, from.Add(6*time.Millisecond), nil, nil)),
+			[]logproto.SeriesIdentifier{
+				{Labels: mustParseLabels("{foo=\"bar\"}")},
+			},
+			1,
+		},
+		{
+			"neither selector nor plan selects all series",
+			withoutPlan(withoutSelector(newQuery("{foo=\"bar\"}", from, from.Add(6*time.Millisecond), nil, nil))),
+			[]logproto.SeriesIdentifier{
+				{Labels: mustParseLabels("{foo=\"bar\"}")},
+				{Labels: mustParseLabels("{foo=\"bazz\"}")},
+			},
+			1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -146,6 +146,18 @@ func newQuery(query string, start, end time.Time, shards []astmapper.ShardAnnota
 	return req
 }
 
+// withoutSelector clears the deprecated Selector field, leaving only the query plan.
+func withoutSelector(req *logproto.QueryRequest) *logproto.QueryRequest {
+	req.Selector = ""
+	return req
+}
+
+// withoutPlan clears the query plan, leaving only the deprecated Selector field.
+func withoutPlan(req *logproto.QueryRequest) *logproto.QueryRequest {
+	req.Plan = nil
+	return req
+}
+
 func newSampleQuery(query string, start, end time.Time, shards []astmapper.ShardAnnotation, deletes []*logproto.Delete) *logproto.SampleQueryRequest {
 	req := &logproto.SampleQueryRequest{
 		Selector: query,


### PR DESCRIPTION
**What this PR does / why we need it**:

The SelectSeries function used an empty Selector string as a sentinel to mean 'match all series'. This changes the check to also accept a nil Plan.AST as the signal, while keeping the Selector check for backward compatibility during the migration period.

Part of the QueryRequest.Selector to Plan migration.
