### PR TITLE
fix(logql): Wrap count min sketch errors with operator name

### DIFF
--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -282,7 +282,7 @@ func JoinCountMinSketchVector(_ bool, r StepResult, stepEvaluator StepEvaluator,
 	}
 
 	if GetRangeType(params) != InstantType {
-		return nil, fmt.Errorf("count min sketches are only supported on instant queries")
+		return nil, fmt.Errorf("approx_topk is only supported on instant queries")
 	}
 
 	return vec, nil
@@ -397,9 +397,9 @@ type CountMinSketchEvalStepEvaluator struct {
 }
 
 func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory SampleEvaluatorFactory, expr *CountMinSketchEvalExpr, params Params) (*CountMinSketchEvalStepEvaluator, error) {
-	// The count-min sketch is only supported for instant queries.
+	// approx_topk is only supported for instant queries.
 	if GetRangeType(params) != InstantType {
-		return nil, fmt.Errorf("count min sketches are only supported on instant queries")
+		return nil, fmt.Errorf("approx_topk is only supported on instant queries")
 	}
 	return &CountMinSketchEvalStepEvaluator{
 		ctx:           ctx,

--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -275,49 +275,25 @@ func (v *HeapCountMinSketchVector) Pop() any {
 }
 
 // JoinCountMinSketchVector joins the results from stepEvaluator into a CountMinSketchVector.
-func JoinCountMinSketchVector(_ bool, r StepResult, stepEvaluator StepEvaluator, params Params, op string) (promql_parser.Value, error) {
+func JoinCountMinSketchVector(_ bool, r StepResult, stepEvaluator StepEvaluator, params Params) (promql_parser.Value, error) {
 	vec := r.CountMinSketchVec()
 	if stepEvaluator.Error() != nil {
 		return nil, stepEvaluator.Error()
 	}
 
 	if GetRangeType(params) != InstantType {
-		return nil, errInstantQueryOnly(op)
+		return nil, errCountMinSketchInstantOnly("")
 	}
 
 	return vec, nil
 }
 
-// countMinSketchOperation returns the user-facing operator that produced a
-// count-min sketch, falling back to the inner aggregation name when unknown.
-func countMinSketchOperation(expr syntax.SampleExpr) string {
-	var op string
-	if expr == nil {
-		return ""
-	}
-	expr.Walk(func(e syntax.Expr) bool {
-		switch typed := e.(type) {
-		case *CountMinSketchEvalExpr:
-			if typed.operation != "" {
-				op = typed.operation
-				return false
-			}
-		case *syntax.VectorAggregationExpr:
-			if typed.Operation == syntax.OpTypeCountMinSketch || typed.Operation == syntax.OpTypeApproxTopK {
-				op = typed.Operation
-				return false
-			}
-		}
-		return true
-	})
-	return op
-}
-
-func errInstantQueryOnly(op string) error {
+func errCountMinSketchInstantOnly(op string) error {
+	const msg = "count min sketches are only supported on instant queries"
 	if op == "" {
-		return fmt.Errorf("this aggregation is only supported on instant queries")
+		return fmt.Errorf("%s", msg)
 	}
-	return fmt.Errorf("%s is only supported on instant queries", op)
+	return fmt.Errorf("%s error: %s", op, msg)
 }
 
 func newCountMinSketchVectorAggEvaluator(nextEvaluator StepEvaluator, expr *syntax.VectorAggregationExpr, maxLabels int) (*countMinSketchVectorAggEvaluator, error) {
@@ -430,7 +406,7 @@ type CountMinSketchEvalStepEvaluator struct {
 
 func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory SampleEvaluatorFactory, expr *CountMinSketchEvalExpr, params Params) (*CountMinSketchEvalStepEvaluator, error) {
 	if GetRangeType(params) != InstantType {
-		return nil, errInstantQueryOnly(expr.operation)
+		return nil, errCountMinSketchInstantOnly(expr.operation)
 	}
 	return &CountMinSketchEvalStepEvaluator{
 		ctx:           ctx,

--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -275,17 +275,49 @@ func (v *HeapCountMinSketchVector) Pop() any {
 }
 
 // JoinCountMinSketchVector joins the results from stepEvaluator into a CountMinSketchVector.
-func JoinCountMinSketchVector(_ bool, r StepResult, stepEvaluator StepEvaluator, params Params) (promql_parser.Value, error) {
+func JoinCountMinSketchVector(_ bool, r StepResult, stepEvaluator StepEvaluator, params Params, op string) (promql_parser.Value, error) {
 	vec := r.CountMinSketchVec()
 	if stepEvaluator.Error() != nil {
 		return nil, stepEvaluator.Error()
 	}
 
 	if GetRangeType(params) != InstantType {
-		return nil, fmt.Errorf("approx_topk is only supported on instant queries")
+		return nil, errInstantQueryOnly(op)
 	}
 
 	return vec, nil
+}
+
+// countMinSketchOperation returns the user-facing operator that produced a
+// count-min sketch, falling back to the inner aggregation name when unknown.
+func countMinSketchOperation(expr syntax.SampleExpr) string {
+	var op string
+	if expr == nil {
+		return ""
+	}
+	expr.Walk(func(e syntax.Expr) bool {
+		switch typed := e.(type) {
+		case *CountMinSketchEvalExpr:
+			if typed.operation != "" {
+				op = typed.operation
+				return false
+			}
+		case *syntax.VectorAggregationExpr:
+			if typed.Operation == syntax.OpTypeCountMinSketch || typed.Operation == syntax.OpTypeApproxTopK {
+				op = typed.Operation
+				return false
+			}
+		}
+		return true
+	})
+	return op
+}
+
+func errInstantQueryOnly(op string) error {
+	if op == "" {
+		return fmt.Errorf("this aggregation is only supported on instant queries")
+	}
+	return fmt.Errorf("%s is only supported on instant queries", op)
 }
 
 func newCountMinSketchVectorAggEvaluator(nextEvaluator StepEvaluator, expr *syntax.VectorAggregationExpr, maxLabels int) (*countMinSketchVectorAggEvaluator, error) {
@@ -397,9 +429,8 @@ type CountMinSketchEvalStepEvaluator struct {
 }
 
 func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory SampleEvaluatorFactory, expr *CountMinSketchEvalExpr, params Params) (*CountMinSketchEvalStepEvaluator, error) {
-	// approx_topk is only supported for instant queries.
 	if GetRangeType(params) != InstantType {
-		return nil, fmt.Errorf("approx_topk is only supported on instant queries")
+		return nil, errInstantQueryOnly(expr.operation)
 	}
 	return &CountMinSketchEvalStepEvaluator{
 		ctx:           ctx,

--- a/pkg/logql/count_min_sketch_test.go
+++ b/pkg/logql/count_min_sketch_test.go
@@ -1,11 +1,9 @@
 package logql
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -119,47 +117,8 @@ func BenchmarkHeapCountMinSketchVectorAdd(b *testing.B) {
 	}
 }
 
-func TestErrInstantQueryOnlyUsesOperator(t *testing.T) {
-	rangeParams := LiteralParams{
-		start: time.Unix(0, 0),
-		end:   time.Unix(60, 0),
-		step:  time.Second,
-	}
-
-	t.Run("eval names the source operator", func(t *testing.T) {
-		for _, op := range []string{syntax.OpTypeApproxTopK, "approx_foo"} {
-			_, err := NewCountMinSketchEvalStepEvaluator(context.Background(), nil, &CountMinSketchEvalExpr{operation: op}, rangeParams)
-			require.EqualError(t, err, op+" is only supported on instant queries")
-		}
-	})
-
-	t.Run("join names the source operator", func(t *testing.T) {
-		_, err := JoinCountMinSketchVector(true, CountMinSketchVector{}, noopStepEvaluator{}, rangeParams, syntax.OpTypeApproxTopK)
-		require.EqualError(t, err, "approx_topk is only supported on instant queries")
-	})
+func TestErrCountMinSketchInstantOnly(t *testing.T) {
+	require.EqualError(t, errCountMinSketchInstantOnly(""), "count min sketches are only supported on instant queries")
+	require.EqualError(t, errCountMinSketchInstantOnly(syntax.OpTypeApproxTopK), "approx_topk error: count min sketches are only supported on instant queries")
+	require.EqualError(t, errCountMinSketchInstantOnly("approx_foo"), "approx_foo error: count min sketches are only supported on instant queries")
 }
-
-func TestCountMinSketchOperation(t *testing.T) {
-	eval := &CountMinSketchEvalExpr{operation: syntax.OpTypeApproxTopK}
-	require.Equal(t, syntax.OpTypeApproxTopK, countMinSketchOperation(eval))
-
-	wrapped := &syntax.VectorAggregationExpr{
-		Operation: syntax.OpTypeTopK,
-		Grouping:  &syntax.Grouping{},
-		Left:      eval,
-	}
-	require.Equal(t, syntax.OpTypeApproxTopK, countMinSketchOperation(wrapped))
-
-	inner := &syntax.VectorAggregationExpr{
-		Operation: syntax.OpTypeCountMinSketch,
-		Grouping:  &syntax.Grouping{},
-	}
-	require.Equal(t, syntax.OpTypeCountMinSketch, countMinSketchOperation(inner))
-}
-
-type noopStepEvaluator struct{}
-
-func (noopStepEvaluator) Next() (bool, int64, StepResult) { return false, 0, nil }
-func (noopStepEvaluator) Close() error                    { return nil }
-func (noopStepEvaluator) Error() error                    { return nil }
-func (noopStepEvaluator) Explain(Node)                    {}

--- a/pkg/logql/count_min_sketch_test.go
+++ b/pkg/logql/count_min_sketch_test.go
@@ -1,16 +1,18 @@
 package logql
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
-
-	"github.com/grafana/loki/v3/pkg/logproto"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/sketch"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
 func TestHeapCountMinSketchVectorHeap(t *testing.T) {
@@ -116,3 +118,48 @@ func BenchmarkHeapCountMinSketchVectorAdd(b *testing.B) {
 		}
 	}
 }
+
+func TestErrInstantQueryOnlyUsesOperator(t *testing.T) {
+	rangeParams := LiteralParams{
+		start: time.Unix(0, 0),
+		end:   time.Unix(60, 0),
+		step:  time.Second,
+	}
+
+	t.Run("eval names the source operator", func(t *testing.T) {
+		for _, op := range []string{syntax.OpTypeApproxTopK, "approx_foo"} {
+			_, err := NewCountMinSketchEvalStepEvaluator(context.Background(), nil, &CountMinSketchEvalExpr{operation: op}, rangeParams)
+			require.EqualError(t, err, op+" is only supported on instant queries")
+		}
+	})
+
+	t.Run("join names the source operator", func(t *testing.T) {
+		_, err := JoinCountMinSketchVector(true, CountMinSketchVector{}, noopStepEvaluator{}, rangeParams, syntax.OpTypeApproxTopK)
+		require.EqualError(t, err, "approx_topk is only supported on instant queries")
+	})
+}
+
+func TestCountMinSketchOperation(t *testing.T) {
+	eval := &CountMinSketchEvalExpr{operation: syntax.OpTypeApproxTopK}
+	require.Equal(t, syntax.OpTypeApproxTopK, countMinSketchOperation(eval))
+
+	wrapped := &syntax.VectorAggregationExpr{
+		Operation: syntax.OpTypeTopK,
+		Grouping:  &syntax.Grouping{},
+		Left:      eval,
+	}
+	require.Equal(t, syntax.OpTypeApproxTopK, countMinSketchOperation(wrapped))
+
+	inner := &syntax.VectorAggregationExpr{
+		Operation: syntax.OpTypeCountMinSketch,
+		Grouping:  &syntax.Grouping{},
+	}
+	require.Equal(t, syntax.OpTypeCountMinSketch, countMinSketchOperation(inner))
+}
+
+type noopStepEvaluator struct{}
+
+func (noopStepEvaluator) Next() (bool, int64, StepResult) { return false, 0, nil }
+func (noopStepEvaluator) Close() error                    { return nil }
+func (noopStepEvaluator) Error() error                    { return nil }
+func (noopStepEvaluator) Explain(Node)                    {}

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -405,6 +405,8 @@ func (e *MergeLastOverTimeExpr) Walk(f syntax.WalkFn) {
 type CountMinSketchEvalExpr struct {
 	syntax.SampleExpr
 	downstreams []DownstreamSampleExpr
+	// operation is the user-facing operator that produced this sketch, e.g. approx_topk.
+	operation string
 }
 
 func (e CountMinSketchEvalExpr) String() string {
@@ -684,6 +686,10 @@ func (ev *DownstreamEvaluator) NewStepEvaluator(
 		}
 		return NewMergeLastOverTimeStepEvaluator(params, xs, e.offset, e.rangeInterval), nil
 	case *CountMinSketchEvalExpr:
+		if GetRangeType(params) != InstantType {
+			return nil, errInstantQueryOnly(e.operation)
+		}
+
 		queries := make([]DownstreamQuery, len(e.downstreams))
 
 		for i, d := range e.downstreams {

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -687,7 +687,7 @@ func (ev *DownstreamEvaluator) NewStepEvaluator(
 		return NewMergeLastOverTimeStepEvaluator(params, xs, e.offset, e.rangeInterval), nil
 	case *CountMinSketchEvalExpr:
 		if GetRangeType(params) != InstantType {
-			return nil, errInstantQueryOnly(e.operation)
+			return nil, errCountMinSketchInstantOnly(e.operation)
 		}
 
 		queries := make([]DownstreamQuery, len(e.downstreams))

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -409,9 +409,9 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 		case ProbabilisticQuantileVector:
 			return JoinQuantileSketchVector(next, vec, stepEvaluator, q.params)
 		case CountMinSketchVector:
-			return JoinCountMinSketchVector(next, vec, stepEvaluator, q.params)
+			return JoinCountMinSketchVector(next, vec, stepEvaluator, q.params, countMinSketchOperation(expr))
 		case HeapCountMinSketchVector:
-			return JoinCountMinSketchVector(next, vec.CountMinSketchVector, stepEvaluator, q.params)
+			return JoinCountMinSketchVector(next, vec.CountMinSketchVector, stepEvaluator, q.params, countMinSketchOperation(expr))
 		default:
 			return nil, fmt.Errorf("unsupported result type: %T", r)
 		}

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -409,9 +409,9 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 		case ProbabilisticQuantileVector:
 			return JoinQuantileSketchVector(next, vec, stepEvaluator, q.params)
 		case CountMinSketchVector:
-			return JoinCountMinSketchVector(next, vec, stepEvaluator, q.params, countMinSketchOperation(expr))
+			return JoinCountMinSketchVector(next, vec, stepEvaluator, q.params)
 		case HeapCountMinSketchVector:
-			return JoinCountMinSketchVector(next, vec.CountMinSketchVector, stepEvaluator, q.params, countMinSketchOperation(expr))
+			return JoinCountMinSketchVector(next, vec.CountMinSketchVector, stepEvaluator, q.params)
 		default:
 			return nil, fmt.Errorf("unsupported result type: %T", r)
 		}

--- a/pkg/logql/internal/logqltest/testdata/functions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/functions.logqltest
@@ -160,7 +160,7 @@ eval instant at 60s approx_topk(10, sum by (app, pod) (count_over_time({app=~"fo
   {app="foo", pod="a"} 6
 # approx_topk() is supported only for instant queries.
 eval range from 20s to 60s step 20s approx_topk(2, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
-  expect fail msg: approx_topk is only supported on instant queries
+  expect fail msg: approx_topk error: count min sketches are only supported on instant queries
 # approx_topk() forbids grouping (unlike topk).
 eval instant at 60s approx_topk(2, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))) by (app)
   expect fail msg: grouping not allowed

--- a/pkg/logql/internal/logqltest/testdata/functions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/functions.logqltest
@@ -160,7 +160,7 @@ eval instant at 60s approx_topk(10, sum by (app, pod) (count_over_time({app=~"fo
   {app="foo", pod="a"} 6
 # approx_topk() is supported only for instant queries.
 eval range from 20s to 60s step 20s approx_topk(2, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
-  expect fail msg: only supported on instant queries
+  expect fail msg: approx_topk is only supported on instant queries
 # approx_topk() forbids grouping (unlike topk).
 eval instant at 60s approx_topk(2, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))) by (app)
   expect fail msg: grouping not allowed

--- a/pkg/logql/optimize.go
+++ b/pkg/logql/optimize.go
@@ -39,6 +39,7 @@ func replaceApproxTopK(expr syntax.SampleExpr) {
 
 		vectorExpr.Operation = syntax.OpTypeTopK
 		vectorExpr.Left = &CountMinSketchEvalExpr{
+			operation: syntax.OpTypeApproxTopK,
 			SampleExpr: &syntax.VectorAggregationExpr{
 				Operation: syntax.OpTypeCountMinSketch,
 				Params:    0,

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -389,6 +389,7 @@ func (m ShardMapper) mapApproxTopk(expr *syntax.VectorAggregationExpr, forceNoSh
 	if shards == 0 || forceNoShard {
 		return &syntax.VectorAggregationExpr{
 			Left: &CountMinSketchEvalExpr{
+				operation: syntax.OpTypeApproxTopK,
 				downstreams: []DownstreamSampleExpr{{
 					SampleExpr: countMinSketchExpr,
 				}},
@@ -414,6 +415,7 @@ func (m ShardMapper) mapApproxTopk(expr *syntax.VectorAggregationExpr, forceNoSh
 	}
 
 	sharded := &CountMinSketchEvalExpr{
+		operation:   syntax.OpTypeApproxTopK,
 		downstreams: downstreams,
 	}
 

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -936,6 +936,7 @@ func TestMapping(t *testing.T) {
 				Params:    3,
 				Operation: syntax.OpTypeTopK,
 				Left: &CountMinSketchEvalExpr{
+					operation: syntax.OpTypeApproxTopK,
 					downstreams: []DownstreamSampleExpr{
 						{
 							shard: NewPowerOfTwoShard(index.ShardAnnotation{
@@ -986,6 +987,7 @@ func TestMapping(t *testing.T) {
 				Params:    3,
 				Operation: syntax.OpTypeTopK,
 				Left: &CountMinSketchEvalExpr{
+					operation: syntax.OpTypeApproxTopK,
 					downstreams: []DownstreamSampleExpr{
 						{
 							shard: nil,
@@ -1020,6 +1022,7 @@ func TestMapping(t *testing.T) {
 			in: `approx_topk(3, topk(5, rate({foo="bar"}[5m])))`,
 			expr: &syntax.VectorAggregationExpr{
 				Left: &CountMinSketchEvalExpr{
+					operation: syntax.OpTypeApproxTopK,
 					downstreams: []DownstreamSampleExpr{{
 						SampleExpr: &syntax.VectorAggregationExpr{
 							Operation: syntax.OpTypeCountMinSketch,


### PR DESCRIPTION
## Summary
- Range queries that use a count-min sketch operator now fail with `<operator> error: count min sketches are only supported on instant queries`.
- The sketch eval node records the user-facing operator that produced it (today `approx_topk`), so a future CMS-backed function can reuse the same path.

## Test plan
- [x] `go test -count=1 -timeout 5m -run 'TestLogQLScripts/functions.logqltest' ./pkg/logql/internal/logqltest/`
- [x] `go test -count=1 -timeout 3m -run 'TestErrCountMinSketchInstantOnly|TestHeapCountMinSketch|TestCountMinSketch|TestMapping|TestApproxTopk' ./pkg/logql/`
- [ ] In Grafana Explore, run a range `approx_topk(...)` query and confirm the error starts with `approx_topk error:`.

## Risks
None. Error text and operator metadata only; query behavior is unchanged.