### PR TITLE
feat(querier): Allow reads to be restricted to preferred availability…

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -5571,6 +5571,26 @@ engine:
 # of the normal ingesters.
 # CLI flag: -querier.query-partition-ingesters
 [query_partition_ingesters: <boolean> | default = false]
+
+# Comma-separated list of availability zones to prefer when querying ingesters.
+# All zones in the list are given equal priority and are queried before any
+# other zone. Requires zone awareness to be enabled on the ingester ring. When
+# empty, zones are queried in random order. Setting this also limits the initial
+# requests to the number of zones the ingester ring requires for quorum, rather
+# than querying every zone.
+# CLI flag: -querier.prefer-availability-zones
+[prefer_availability_zones: <string> | default = ""]
+
+# Number of availability zones to query ingesters in. 0 (default) uses the
+# ingester ring quorum requirement, which queries a majority of zones. Set to 1
+# to query a single zone. Querying fewer zones than the ring quorum requires
+# every zone to hold a complete copy of the data, so it is ignored unless zone
+# awareness is enabled and the replication factor is greater than or equal to
+# the number of zones. Use querier.prefer-availability-zones to control which
+# zones are queried first. If the queried zones cannot serve the request, the
+# querier automatically falls back to the remaining zones.
+# CLI flag: -querier.ingester-query-zones
+[ingester_query_zones: <int> | default = 0]
 ```
 
 ### query_range

--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -2,7 +2,8 @@ package querier
 
 import (
 	"context"
-	"math/rand/v2"
+	"crypto/rand"
+	"math/big"
 	"net/http"
 	"slices"
 	"strings"
@@ -176,9 +177,7 @@ func ExtractPartitionContext(ctx context.Context) *PartitionContext {
 // evenly across the zones we fall back to.
 func preferredZoneSorter(preferredZones []string) ring.ZoneSorter {
 	return func(zones []string) []string {
-		rand.Shuffle(len(zones), func(i, j int) {
-			zones[i], zones[j] = zones[j], zones[i]
-		})
+		shuffleZones(zones)
 
 		if len(preferredZones) == 0 {
 			return zones
@@ -195,6 +194,21 @@ func preferredZoneSorter(preferredZones []string) ring.ZoneSorter {
 		}
 
 		return zones
+	}
+}
+
+// shuffleZones shuffles zones in place, using crypto/rand as the source of
+// randomness. If no randomness is available the current order is kept: the order
+// zones are queried in must never be a reason to fail a query.
+func shuffleZones(zones []string) {
+	for i := len(zones) - 1; i > 0; i-- {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return
+		}
+
+		j := int(n.Int64())
+		zones[i], zones[j] = zones[j], zones[i]
 	}
 }
 
@@ -235,10 +249,21 @@ func (q *IngesterQuerier) quorumConfigForZoneReads(replicationSet *ring.Replicat
 	}
 
 	if n := q.querierConfig.IngesterQueryZones; n > 0 {
-		zones := countZones(replicationSet.Instances)
+		// The completeness check below must use the number of zones registered in
+		// the ring, not the number left in the replication set. Zone-aware rings
+		// drop every instance of a zone that has any unhealthy instance, so a ring
+		// with more zones than replicas can present a replication set with few
+		// enough zones to look like it qualifies, when in fact no single zone holds
+		// a complete copy of the data.
+		ringZones := q.ring.ZonesCount()
+
+		// The quorum requirement is relative to the zones actually present in the
+		// replication set, since that is what dskit counts when deciding how many
+		// zones must succeed.
+		setZones := countZones(replicationSet.Instances)
 
 		switch {
-		case zones > q.ring.ReplicationFactor():
+		case ringZones > q.ring.ReplicationFactor():
 			// Querying fewer zones than the ring requires for quorum is only correct
 			// if every zone holds a complete copy of the data. Zone-aware replication
 			// places at most one replica per zone, so that only holds when there are
@@ -246,14 +271,14 @@ func (q *IngesterQuerier) quorumConfigForZoneReads(replicationSet *ring.Replicat
 			q.warnTooManyZones.Do(func() {
 				level.Warn(q.logger).Log(
 					"msg", "ignoring querier.ingester-query-zones because the ingester ring has more zones than the replication factor, so a single zone does not hold a complete copy of the data",
-					"zones", zones,
+					"zones", ringZones,
 					"replication_factor", q.ring.ReplicationFactor(),
 				)
 			})
-		case zones-n > replicationSet.MaxUnavailableZones:
+		case setZones-n > replicationSet.MaxUnavailableZones:
 			// Only ever loosen the ring's quorum requirement. Asking for more zones
 			// than the ring requires must not make queries more likely to fail.
-			replicationSet.MaxUnavailableZones = zones - n
+			replicationSet.MaxUnavailableZones = setZones - n
 		}
 	}
 
@@ -423,14 +448,18 @@ func (q *IngesterQuerier) TailDisconnectedIngesters(ctx context.Context, req *lo
 	// When reads are restricted to a subset of zones, only reconnect to ingesters in
 	// the zones we would query. Otherwise a long lived tail request would gradually
 	// connect to every ingester in the ring, defeating the zone restriction. Zones
-	// that already have a connected ingester are always allowed, so a zone we failed
-	// over to is not dropped again. If this leaves no allowed zone, every zone is
-	// considered, so tailing never stops reconnecting.
+	// that already have a connected ingester are also allowed, so a zone we failed
+	// over to is not dropped again.
+	//
+	// Only zones present in the replication set are considered: a preferred zone
+	// with no healthy ingester must not keep the tail from reconnecting to the zones
+	// that do have one. If that leaves no allowed zone, every zone is considered, so
+	// tailing never stops reconnecting.
 	var allowedZones []string
 	if q.zoneReadsEnabled() && replicationSet.ZoneAwarenessEnabled {
-		allowedZones = append(allowedZones, q.querierConfig.PreferAvailabilityZones...)
 		for _, ingester := range replicationSet.Instances {
-			if connected[ingester.Addr] && !slices.Contains(allowedZones, ingester.Zone) {
+			allowed := connected[ingester.Addr] || slices.Contains(q.querierConfig.PreferAvailabilityZones, ingester.Zone)
+			if allowed && !slices.Contains(allowedZones, ingester.Zone) {
 				allowedZones = append(allowedZones, ingester.Zone)
 			}
 		}

--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -2,6 +2,7 @@ package querier
 
 import (
 	"context"
+	"math/rand/v2"
 	"net/http"
 	"slices"
 	"strings"
@@ -53,6 +54,11 @@ type IngesterQuerier struct {
 	getShardCountForTenant func(string) int
 	pool                   *ring_client.Pool
 	logger                 log.Logger
+
+	// Zone preferences are evaluated on every query, so only warn once when they
+	// cannot be honoured.
+	warnZoneAwarenessDisabled sync.Once
+	warnTooManyZones          sync.Once
 }
 
 func NewIngesterQuerier(querierConfig Config, clientCfg client.Config, ring ring.ReadRing, partitionRing *ring.PartitionInstanceRing, getShardCountForTenant func(string) int, metricsNamespace string, logger log.Logger) (*IngesterQuerier, error) {
@@ -164,6 +170,99 @@ func ExtractPartitionContext(ctx context.Context) *PartitionContext {
 	return v
 }
 
+// preferredZoneSorter returns a ring.ZoneSorter that moves preferredZones to the
+// front of the list, and randomizes the order of the remaining zones. All
+// preferred zones are given equal priority. Randomizing the rest spreads load
+// evenly across the zones we fall back to.
+func preferredZoneSorter(preferredZones []string) ring.ZoneSorter {
+	return func(zones []string) []string {
+		rand.Shuffle(len(zones), func(i, j int) {
+			zones[i], zones[j] = zones[j], zones[i]
+		})
+
+		if len(preferredZones) == 0 {
+			return zones
+		}
+
+		// Move the preferred zones to the front. They have already been shuffled,
+		// so they keep equal priority relative to each other.
+		nextPos := 0
+		for idx, zone := range zones {
+			if slices.Contains(preferredZones, zone) {
+				zones[nextPos], zones[idx] = zones[idx], zones[nextPos]
+				nextPos++
+			}
+		}
+
+		return zones
+	}
+}
+
+// countZones returns the number of distinct zones the given instances belong to.
+func countZones(instances []ring.InstanceDesc) int {
+	zones := make([]string, 0, 3)
+	for _, instance := range instances {
+		if !slices.Contains(zones, instance.Zone) {
+			zones = append(zones, instance.Zone)
+		}
+	}
+	return len(zones)
+}
+
+// zoneReadsEnabled returns whether the querier is configured to prefer or restrict
+// the zones it reads from.
+func (q *IngesterQuerier) zoneReadsEnabled() bool {
+	return len(q.querierConfig.PreferAvailabilityZones) > 0 || q.querierConfig.IngesterQueryZones > 0
+}
+
+// quorumConfigForZoneReads returns the config to use when querying the ingester
+// ring, honouring querier.prefer-availability-zones and
+// querier.ingester-query-zones. replicationSet is modified in place when fewer
+// zones should be queried than the ring itself requires for quorum.
+func (q *IngesterQuerier) quorumConfigForZoneReads(replicationSet *ring.ReplicationSet) ring.DoUntilQuorumConfig {
+	if !q.zoneReadsEnabled() {
+		return defaultQuorumConfig
+	}
+
+	// Without zone awareness the ring gives no guarantee about how replicas are
+	// spread across zones, and instances may not report a zone at all, so there is
+	// nothing meaningful to prefer or restrict.
+	if !replicationSet.ZoneAwarenessEnabled {
+		q.warnZoneAwarenessDisabled.Do(func() {
+			level.Warn(q.logger).Log("msg", "ignoring querier availability zone preferences because zone awareness is disabled on the ingester ring")
+		})
+		return defaultQuorumConfig
+	}
+
+	if n := q.querierConfig.IngesterQueryZones; n > 0 {
+		zones := countZones(replicationSet.Instances)
+
+		switch {
+		case zones > q.ring.ReplicationFactor():
+			// Querying fewer zones than the ring requires for quorum is only correct
+			// if every zone holds a complete copy of the data. Zone-aware replication
+			// places at most one replica per zone, so that only holds when there are
+			// no more zones than replicas.
+			q.warnTooManyZones.Do(func() {
+				level.Warn(q.logger).Log(
+					"msg", "ignoring querier.ingester-query-zones because the ingester ring has more zones than the replication factor, so a single zone does not hold a complete copy of the data",
+					"zones", zones,
+					"replication_factor", q.ring.ReplicationFactor(),
+				)
+			})
+		case zones-n > replicationSet.MaxUnavailableZones:
+			// Only ever loosen the ring's quorum requirement. Asking for more zones
+			// than the ring requires must not make queries more likely to fail.
+			replicationSet.MaxUnavailableZones = zones - n
+		}
+	}
+
+	return ring.DoUntilQuorumConfig{
+		MinimizeRequests: true,
+		ZoneSorter:       preferredZoneSorter(q.querierConfig.PreferAvailabilityZones),
+	}
+}
+
 // forAllIngesters runs f, in parallel, for all ingesters
 func (q *IngesterQuerier) forAllIngesters(ctx context.Context, f func(context.Context, logproto.QuerierClient) (interface{}, error)) ([]responseFromIngesters, error) {
 	if q.querierConfig.QueryPartitionIngesters {
@@ -198,7 +297,11 @@ func (q *IngesterQuerier) forAllIngesters(ctx context.Context, f func(context.Co
 		return nil, err
 	}
 
-	return q.forGivenIngesters(ctx, replicationSet, defaultQuorumConfig, f)
+	// Must be called before replicationSet is passed by value below, as it may
+	// lower the number of zones required to answer the query.
+	quorumConfig := q.quorumConfigForZoneReads(&replicationSet)
+
+	return q.forGivenIngesters(ctx, replicationSet, quorumConfig, f)
 }
 
 // forGivenIngesterSets runs f, in parallel, for given ingester sets
@@ -317,6 +420,22 @@ func (q *IngesterQuerier) TailDisconnectedIngesters(ctx context.Context, req *lo
 		return nil, err
 	}
 
+	// When reads are restricted to a subset of zones, only reconnect to ingesters in
+	// the zones we would query. Otherwise a long lived tail request would gradually
+	// connect to every ingester in the ring, defeating the zone restriction. Zones
+	// that already have a connected ingester are always allowed, so a zone we failed
+	// over to is not dropped again. If this leaves no allowed zone, every zone is
+	// considered, so tailing never stops reconnecting.
+	var allowedZones []string
+	if q.zoneReadsEnabled() && replicationSet.ZoneAwarenessEnabled {
+		allowedZones = append(allowedZones, q.querierConfig.PreferAvailabilityZones...)
+		for _, ingester := range replicationSet.Instances {
+			if connected[ingester.Addr] && !slices.Contains(allowedZones, ingester.Zone) {
+				allowedZones = append(allowedZones, ingester.Zone)
+			}
+		}
+	}
+
 	// Look for disconnected ingesters or new one we should (re)connect to
 	reconnectIngesters := []ring.InstanceDesc{}
 
@@ -327,6 +446,10 @@ func (q *IngesterQuerier) TailDisconnectedIngesters(ctx context.Context, req *lo
 
 		// Skip ingesters which are leaving or joining the cluster
 		if ingester.State != ring.ACTIVE {
+			continue
+		}
+
+		if len(allowedZones) > 0 && !slices.Contains(allowedZones, ingester.Zone) {
 			continue
 		}
 

--- a/pkg/querier/ingester_querier_test.go
+++ b/pkg/querier/ingester_querier_test.go
@@ -846,11 +846,14 @@ func distinctZones(addrs []string, zoneByAddr map[string]string) []string {
 	return zones
 }
 
+// Note: the tests below deliberately do not call t.Parallel(). Constructing an
+// IngesterQuerier builds an ingester client pool, and clientpool.NewPool lazily
+// registers a package-level gauge without synchronisation, so two concurrent
+// constructions panic with a duplicate registration.
 func TestIngesterQuerier_zoneRestrictedReads(t *testing.T) {
-	t.Parallel()
-
 	for name, tc := range map[string]struct {
 		zones               []string
+		ringZonesCount      int
 		replicationFactor   int
 		maxUnavailableZones int
 		zoneAware           bool
@@ -907,6 +910,21 @@ func TestIngesterQuerier_zoneRestrictedReads(t *testing.T) {
 			expectZoneCount:     3,
 			expectZones:         []string{"A"},
 		},
+		"unhealthy zone hiding a wider topology falls back to ring quorum": {
+			// The ring has 4 zones but one of them is unhealthy, so
+			// GetReplicationSetForOperation drops it and returns only 3. The guard
+			// has to use the ring's zone count, otherwise this looks like a
+			// 3-zone/RF-3 ring where a single zone would be complete.
+			zones:               []string{"A", "B", "C"},
+			ringZonesCount:      4,
+			replicationFactor:   3,
+			maxUnavailableZones: 1,
+			zoneAware:           true,
+			preferredZones:      []string{"A"},
+			ingesterQueryZones:  1,
+			expectZoneCount:     2,
+			expectZones:         []string{"A"},
+		},
 		"zone awareness disabled queries every zone": {
 			zones:              []string{"A", "B", "C"},
 			replicationFactor:  3,
@@ -917,8 +935,6 @@ func TestIngesterQuerier_zoneRestrictedReads(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			ingesters, zoneByAddr := zonedIngesters(tc.zones...)
 
 			var ringMock *readRingMock
@@ -927,6 +943,7 @@ func TestIngesterQuerier_zoneRestrictedReads(t *testing.T) {
 			} else {
 				ringMock = newReadRingMock(ingesters, 0)
 			}
+			ringMock.zonesCount = tc.ringZonesCount
 
 			factory, queriedAddrs := newPerAddrClientFactory(func(_ string) *querierClientMock {
 				c := newQuerierClientMock()
@@ -968,8 +985,6 @@ func TestIngesterQuerier_zoneRestrictedReads(t *testing.T) {
 }
 
 func TestIngesterQuerier_zoneRestrictedReadsFallBackOnFailure(t *testing.T) {
-	t.Parallel()
-
 	ingesters, zoneByAddr := zonedIngesters("A", "B", "C")
 	ringMock := newZoneAwareReadRingMock(ingesters, 1, 3)
 
@@ -997,4 +1012,76 @@ func TestIngesterQuerier_zoneRestrictedReadsFallBackOnFailure(t *testing.T) {
 	queriedZones := distinctZones(queriedAddrs(), zoneByAddr)
 	require.Contains(t, queriedZones, "A", "the preferred zone should be tried first")
 	require.Len(t, queriedZones, 2, "exactly one zone should be used as fallback")
+}
+
+func TestIngesterQuerier_tailZoneRestrictedReconnects(t *testing.T) {
+	for name, tc := range map[string]struct {
+		// zones present in the ring, i.e. the zones that still have a healthy
+		// ingester.
+		zones          []string
+		preferredZones []string
+		connectedZones []string
+		expectZones    []string
+	}{
+		"reconnects only to the preferred zone": {
+			zones:          []string{"A", "B", "C"},
+			preferredZones: []string{"A"},
+			expectZones:    []string{"A"},
+		},
+		"keeps a zone that already has a connected ingester": {
+			zones:          []string{"A", "B", "C"},
+			preferredZones: []string{"A"},
+			connectedZones: []string{"B"},
+			expectZones:    []string{"A", "B"},
+		},
+		"reconnects to healthy zones when the preferred zone has no ingester left": {
+			// Zone A is preferred but entirely unhealthy, so the ring does not
+			// return it. Restricting reconnects to A would stall the tail.
+			zones:          []string{"B", "C"},
+			preferredZones: []string{"A"},
+			expectZones:    []string{"B", "C"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ingesters, zoneByAddr := zonedIngesters(tc.zones...)
+			ringMock := newZoneAwareReadRingMock(ingesters, 1, 3)
+
+			// Connect the first ingester of each listed zone, leaving the second one
+			// disconnected so the zone still has something to reconnect to.
+			var connected []string
+			connectedZone := map[string]bool{}
+			for _, instance := range ingesters {
+				if slices.Contains(tc.connectedZones, instance.Zone) && !connectedZone[instance.Zone] {
+					connectedZone[instance.Zone] = true
+					connected = append(connected, instance.Addr)
+				}
+			}
+
+			ingesterClient := newQuerierClientMock()
+			ingesterClient.On("Tail", mock.Anything, mock.Anything, mock.Anything).Return(&mockQuerierTailClient{}, nil)
+
+			cfg := mockQuerierConfig()
+			cfg.PreferAvailabilityZones = tc.preferredZones
+			cfg.IngesterQueryZones = 1
+
+			ingesterQuerier, err := newTestIngesterQuerierWithConfig(cfg, ringMock, newIngesterClientMockFactory(ingesterClient))
+			require.NoError(t, err)
+
+			clients, err := ingesterQuerier.TailDisconnectedIngesters(context.Background(), &logproto.TailRequest{}, connected)
+			require.NoError(t, err)
+
+			reconnected := make([]string, 0, len(clients))
+			for addr := range clients {
+				reconnected = append(reconnected, addr)
+			}
+
+			require.NotEmpty(t, reconnected, "a live tail must keep reconnecting")
+			require.ElementsMatch(t, tc.expectZones, distinctZones(reconnected, zoneByAddr))
+
+			// Already connected ingesters are never handed back.
+			for _, addr := range connected {
+				require.NotContains(t, reconnected, addr)
+			}
+		})
+	}
 }

--- a/pkg/querier/ingester_querier_test.go
+++ b/pkg/querier/ingester_querier_test.go
@@ -3,6 +3,9 @@ package querier
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -667,6 +670,19 @@ func newTestIngesterQuerier(readRingMock *readRingMock, ingesterClient *querierC
 	)
 }
 
+func newTestIngesterQuerierWithConfig(cfg Config, readRingMock *readRingMock, clientFactory client.PoolFactory) (*IngesterQuerier, error) {
+	return newIngesterQuerier(
+		cfg,
+		mockIngesterClientConfig(),
+		readRingMock,
+		nil,
+		func(string) int { return 0 },
+		clientFactory,
+		constants.Loki,
+		log.NewNopLogger(),
+	)
+}
+
 func newTestPartitionIngesterQuerier(clientFactory client.PoolFactory, instanceRing *readRingMock, partitionRing *ring.PartitionInstanceRing, tenantShards int) (*IngesterQuerier, error) {
 	return newIngesterQuerier(
 		mockQuerierConfig(),
@@ -711,4 +727,274 @@ func (c *mockQuerierTailClient) SendMsg(_ interface{}) error {
 
 func (c *mockQuerierTailClient) RecvMsg(_ interface{}) error {
 	return nil
+}
+
+func TestPreferredZoneSorter(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		preferred []string
+		zones     []string
+		// expectFirst is the set of zones expected to occupy the first
+		// len(expectFirst) positions, in any order.
+		expectFirst []string
+	}{
+		"no preferred zone keeps every zone": {
+			preferred:   nil,
+			zones:       []string{"A", "B", "C"},
+			expectFirst: nil,
+		},
+		"single preferred zone is sorted first": {
+			preferred:   []string{"A"},
+			zones:       []string{"A", "B", "C"},
+			expectFirst: []string{"A"},
+		},
+		"single preferred zone is sorted first regardless of input order": {
+			preferred:   []string{"C"},
+			zones:       []string{"A", "B", "C"},
+			expectFirst: []string{"C"},
+		},
+		"all preferred zones are sorted first": {
+			preferred:   []string{"A", "C"},
+			zones:       []string{"A", "B", "C"},
+			expectFirst: []string{"A", "C"},
+		},
+		"preferred zone missing from the ring is ignored": {
+			preferred:   []string{"D"},
+			zones:       []string{"A", "B", "C"},
+			expectFirst: nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Run repeatedly: the sorter shuffles, so a single run can pass by chance.
+			for i := 0; i < 50; i++ {
+				sorted := preferredZoneSorter(tc.preferred)(slices.Clone(tc.zones))
+
+				require.ElementsMatch(t, tc.zones, sorted, "every zone must be retained")
+				if len(tc.expectFirst) > 0 {
+					require.ElementsMatch(t, tc.expectFirst, sorted[:len(tc.expectFirst)])
+				}
+			}
+		})
+	}
+}
+
+// zonedIngesters returns two ingesters per zone, and a lookup from address to zone.
+func zonedIngesters(zones ...string) ([]ring.InstanceDesc, map[string]string) {
+	instances := make([]ring.InstanceDesc, 0, len(zones)*2)
+	zoneByAddr := make(map[string]string, len(zones)*2)
+
+	for i, zone := range zones {
+		for j := 0; j < 2; j++ {
+			addr := fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, j+1)
+			instances = append(instances, mockInstanceDescWithZone(addr, ring.ACTIVE, zone))
+			zoneByAddr[addr] = zone
+		}
+	}
+
+	return instances, zoneByAddr
+}
+
+// newPerAddrClientFactory returns a pool factory handing out one client per
+// address, along with a func returning the addresses a client was requested for.
+// The pool only creates a client for an ingester the querier actually queries, so
+// that set is exactly the set of queried ingesters.
+func newPerAddrClientFactory(setup func(addr string) *querierClientMock) (client.PoolFactory, func() []string) {
+	var (
+		mu      sync.Mutex
+		created = map[string]*querierClientMock{}
+	)
+
+	factory := client.PoolAddrFunc(func(addr string) (client.PoolClient, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if c, ok := created[addr]; ok {
+			return c, nil
+		}
+
+		c := setup(addr)
+		created[addr] = c
+		return c, nil
+	})
+
+	queriedAddrs := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+
+		addrs := make([]string, 0, len(created))
+		for addr := range created {
+			addrs = append(addrs, addr)
+		}
+		sort.Strings(addrs)
+		return addrs
+	}
+
+	return factory, queriedAddrs
+}
+
+func distinctZones(addrs []string, zoneByAddr map[string]string) []string {
+	zones := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if zone := zoneByAddr[addr]; !slices.Contains(zones, zone) {
+			zones = append(zones, zone)
+		}
+	}
+	sort.Strings(zones)
+	return zones
+}
+
+func TestIngesterQuerier_zoneRestrictedReads(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		zones               []string
+		replicationFactor   int
+		maxUnavailableZones int
+		zoneAware           bool
+		preferredZones      []string
+		ingesterQueryZones  int
+		expectZoneCount     int
+		expectZones         []string
+	}{
+		"unconfigured queries every zone": {
+			zones:               []string{"A", "B", "C"},
+			replicationFactor:   3,
+			maxUnavailableZones: 1,
+			zoneAware:           true,
+			expectZoneCount:     3,
+		},
+		"preferred zone only queries the zones needed for ring quorum": {
+			zones:               []string{"A", "B", "C"},
+			replicationFactor:   3,
+			maxUnavailableZones: 1,
+			zoneAware:           true,
+			preferredZones:      []string{"A"},
+			expectZoneCount:     2,
+			expectZones:         []string{"A"},
+		},
+		"one zone queries only the preferred zone": {
+			zones:               []string{"A", "B", "C"},
+			replicationFactor:   3,
+			maxUnavailableZones: 1,
+			zoneAware:           true,
+			preferredZones:      []string{"A"},
+			ingesterQueryZones:  1,
+			expectZoneCount:     1,
+			expectZones:         []string{"A"},
+		},
+		"two zones queries the preferred zone and one other": {
+			zones:               []string{"A", "B", "C"},
+			replicationFactor:   3,
+			maxUnavailableZones: 1,
+			zoneAware:           true,
+			preferredZones:      []string{"A"},
+			ingesterQueryZones:  2,
+			expectZoneCount:     2,
+			expectZones:         []string{"A"},
+		},
+		"more zones than replicas falls back to ring quorum": {
+			// With 4 zones and RF 3 a zone does not hold a complete copy of the
+			// data, so the restriction must be ignored.
+			zones:               []string{"A", "B", "C", "D"},
+			replicationFactor:   3,
+			maxUnavailableZones: 1,
+			zoneAware:           true,
+			preferredZones:      []string{"A"},
+			ingesterQueryZones:  1,
+			expectZoneCount:     3,
+			expectZones:         []string{"A"},
+		},
+		"zone awareness disabled queries every zone": {
+			zones:              []string{"A", "B", "C"},
+			replicationFactor:  3,
+			zoneAware:          false,
+			preferredZones:     []string{"A"},
+			ingesterQueryZones: 1,
+			expectZoneCount:    3,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ingesters, zoneByAddr := zonedIngesters(tc.zones...)
+
+			var ringMock *readRingMock
+			if tc.zoneAware {
+				ringMock = newZoneAwareReadRingMock(ingesters, tc.maxUnavailableZones, tc.replicationFactor)
+			} else {
+				ringMock = newReadRingMock(ingesters, 0)
+			}
+
+			factory, queriedAddrs := newPerAddrClientFactory(func(_ string) *querierClientMock {
+				c := newQuerierClientMock()
+				c.On("Label", mock.Anything, mock.Anything, mock.Anything).Return(new(logproto.LabelResponse), nil)
+				return c
+			})
+
+			cfg := mockQuerierConfig()
+			cfg.PreferAvailabilityZones = tc.preferredZones
+			cfg.IngesterQueryZones = tc.ingesterQueryZones
+
+			ingesterQuerier, err := newTestIngesterQuerierWithConfig(cfg, ringMock, factory)
+			require.NoError(t, err)
+
+			_, err = ingesterQuerier.Label(context.Background(), nil)
+			require.NoError(t, err)
+
+			// Zones beyond the ones needed are only started on failure, so wait for
+			// the expected count and then check no further zone gets queried.
+			require.Eventually(t, func() bool {
+				return len(distinctZones(queriedAddrs(), zoneByAddr)) >= tc.expectZoneCount
+			}, time.Second, time.Millisecond, "expected %d zones to be queried, got %v", tc.expectZoneCount, distinctZones(queriedAddrs(), zoneByAddr))
+
+			require.Never(t, func() bool {
+				return len(distinctZones(queriedAddrs(), zoneByAddr)) > tc.expectZoneCount
+			}, 100*time.Millisecond, 10*time.Millisecond, "no more than %d zones should be queried", tc.expectZoneCount)
+
+			queriedZones := distinctZones(queriedAddrs(), zoneByAddr)
+			require.Len(t, queriedZones, tc.expectZoneCount)
+			for _, zone := range tc.expectZones {
+				require.Contains(t, queriedZones, zone)
+			}
+
+			// Every ingester in a queried zone must be queried, as a zone only
+			// holds a complete copy of the data across all of its ingesters.
+			require.Len(t, queriedAddrs(), tc.expectZoneCount*2)
+		})
+	}
+}
+
+func TestIngesterQuerier_zoneRestrictedReadsFallBackOnFailure(t *testing.T) {
+	t.Parallel()
+
+	ingesters, zoneByAddr := zonedIngesters("A", "B", "C")
+	ringMock := newZoneAwareReadRingMock(ingesters, 1, 3)
+
+	// Every ingester in the preferred zone fails, so the querier has to fall back.
+	factory, queriedAddrs := newPerAddrClientFactory(func(addr string) *querierClientMock {
+		c := newQuerierClientMock()
+		if zoneByAddr[addr] == "A" {
+			c.On("Label", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("zone A is down"))
+		} else {
+			c.On("Label", mock.Anything, mock.Anything, mock.Anything).Return(new(logproto.LabelResponse), nil)
+		}
+		return c
+	})
+
+	cfg := mockQuerierConfig()
+	cfg.PreferAvailabilityZones = []string{"A"}
+	cfg.IngesterQueryZones = 1
+
+	ingesterQuerier, err := newTestIngesterQuerierWithConfig(cfg, ringMock, factory)
+	require.NoError(t, err)
+
+	_, err = ingesterQuerier.Label(context.Background(), nil)
+	require.NoError(t, err, "the query should succeed by falling back to another zone")
+
+	queriedZones := distinctZones(queriedAddrs(), zoneByAddr)
+	require.Contains(t, queriedZones, "A", "the preferred zone should be tried first")
+	require.Len(t, queriedZones, 2, "exactly one zone should be used as fallback")
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
@@ -62,6 +63,9 @@ type Config struct {
 	PerRequestLimitsEnabled   bool             `yaml:"per_request_limits_enabled"`
 	QueryPartitionIngesters   bool             `yaml:"query_partition_ingesters" category:"experimental"`
 
+	PreferAvailabilityZones flagext.StringSliceCSV `yaml:"prefer_availability_zones" category:"experimental"`
+	IngesterQueryZones      int                    `yaml:"ingester_query_zones" category:"experimental"`
+
 	IngesterQueryStoreMaxLookback time.Duration `yaml:"-"`
 	QueryPatternIngestersWithin   time.Duration `yaml:"-"`
 }
@@ -82,12 +86,17 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.MultiTenantQueriesEnabled, prefix+"multi-tenant-queries-enabled", false, "When true, allow queries to span multiple tenants.")
 	f.BoolVar(&cfg.PerRequestLimitsEnabled, prefix+"per-request-limits-enabled", false, "When true, querier limits sent via a header are enforced.")
 	f.BoolVar(&cfg.QueryPartitionIngesters, prefix+"query-partition-ingesters", false, "When true, querier directs ingester queries to the partition-ingesters instead of the normal ingesters.")
+	f.Var(&cfg.PreferAvailabilityZones, prefix+"prefer-availability-zones", "Comma-separated list of availability zones to prefer when querying ingesters. All zones in the list are given equal priority and are queried before any other zone. Requires zone awareness to be enabled on the ingester ring. When empty, zones are queried in random order. Setting this also limits the initial requests to the number of zones the ingester ring requires for quorum, rather than querying every zone.")
+	f.IntVar(&cfg.IngesterQueryZones, prefix+"ingester-query-zones", 0, "Number of availability zones to query ingesters in. 0 (default) uses the ingester ring quorum requirement, which queries a majority of zones. Set to 1 to query a single zone. Querying fewer zones than the ring quorum requires every zone to hold a complete copy of the data, so it is ignored unless zone awareness is enabled and the replication factor is greater than or equal to the number of zones. Use querier.prefer-availability-zones to control which zones are queried first. If the queried zones cannot serve the request, the querier automatically falls back to the remaining zones.")
 }
 
 // Validate validates the config.
 func (cfg *Config) Validate() error {
 	if cfg.QueryStoreOnly && cfg.QueryIngesterOnly {
 		return errors.New("querier.query_store_only and querier.query_ingester_only cannot both be true")
+	}
+	if cfg.IngesterQueryZones < 0 {
+		return errors.New("querier.ingester_query_zones must be greater than or equal to 0")
 	}
 	return nil
 }

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -376,6 +376,10 @@ func (s *storeMock) Stop() {
 type readRingMock struct {
 	replicationSet    ring.ReplicationSet
 	replicationFactor int
+	// zonesCount overrides the number of zones the ring reports. Leave at 0 to
+	// derive it from the instances in the replication set. Set it to mimic a ring
+	// whose replication set has had unhealthy zones filtered out.
+	zonesCount int
 }
 
 func newReadRingMock(ingesters []ring.InstanceDesc, maxErrors int) *readRingMock {
@@ -506,6 +510,12 @@ func (r *readRingMock) InstancesWithTokensInZoneCount(_ string) int {
 }
 
 func (r *readRingMock) ZonesCount() int {
+	if r.zonesCount > 0 {
+		return r.zonesCount
+	}
+	if n := countZones(r.replicationSet.Instances); n > 0 {
+		return n
+	}
 	return 1
 }
 

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -374,7 +374,8 @@ func (s *storeMock) Stop() {
 // readRingMock is a mocked version of a ReadRing, used in querier unit tests
 // to control the pool of ingesters available
 type readRingMock struct {
-	replicationSet ring.ReplicationSet
+	replicationSet    ring.ReplicationSet
+	replicationFactor int
 }
 
 func newReadRingMock(ingesters []ring.InstanceDesc, maxErrors int) *readRingMock {
@@ -383,6 +384,19 @@ func newReadRingMock(ingesters []ring.InstanceDesc, maxErrors int) *readRingMock
 			Instances: ingesters,
 			MaxErrors: maxErrors,
 		},
+	}
+}
+
+// newZoneAwareReadRingMock returns a readRingMock behaving like a zone-aware ring,
+// which reports MaxUnavailableZones instead of MaxErrors.
+func newZoneAwareReadRingMock(ingesters []ring.InstanceDesc, maxUnavailableZones, replicationFactor int) *readRingMock {
+	return &readRingMock{
+		replicationSet: ring.ReplicationSet{
+			Instances:            ingesters,
+			MaxUnavailableZones:  maxUnavailableZones,
+			ZoneAwarenessEnabled: true,
+		},
+		replicationFactor: replicationFactor,
 	}
 }
 
@@ -469,6 +483,9 @@ func (r *readRingMock) GetReplicationSetForOperation(_ ring.Operation) (ring.Rep
 }
 
 func (r *readRingMock) ReplicationFactor() int {
+	if r.replicationFactor > 0 {
+		return r.replicationFactor
+	}
 	return 1
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

On the read path the querier fans out to **every ingester in every zone**:
`forAllIngesters` builds its replication set with `GetReplicationSetForOperation(ring.Read)` (all healthy instances) and passes `defaultQuorumConfig`, which leaves `MinimizeRequests` unset, so `DoUntilQuorum` starts requests to all of them. With zone-aware replication and RF=3 that means every query crosses availability zone boundaries, which on
public cloud is billed egress.

This cannot be solved outside Loki: queriers discover ingesters through the ring and dial their registered addresses directly over gRPC, bypassing Kubernetes Services entirely, so `trafficDistribution: PreferClose`, topology-aware routing and `internalTrafficPolicy` have no effect on this hop. The zone preference has to come from the ring.

This PR adds two experimental querier options:

| Option | Effect |
| --- | --- |
| `-querier.prefer-availability-zones` | Comma-separated zones to query before any other zone. All listed zones get equal priority. |
| `-querier.ingester-query-zones` | Number of zones to query. `0` (default) keeps the ring's quorum requirement. |

On a 3-zone / RF=3 ring:

| Config | Zones queried |
| --- | --- |
| neither (default) | 3 — unchanged |
| `prefer-availability-zones=zone-a` | 2 — zone-a plus one other |
| `prefer-availability-zones=zone-a` + `ingester-query-zones=1` | 1 — zone-a only |

Implementation is small because dskit already has the hook. Setting the
preferred zones enables `MinimizeRequests` and supplies a
`DoUntilQuorumConfig.ZoneSorter` that moves the preferred zones to the front
(shuffling first, so multiple preferred zones stay equal priority, and the
fallback order stays spread). That alone queries the zones the ring requires
for quorum instead of all of them. Dropping to a single zone
additionally raises `MaxUnavailableZones` so `minSuccessfulZones` becomes 1.

Three guards keep this safe:

- No-op with a warning when zone awareness is disabled on the ingester ring —
  without it the ring makes no promise about replica spread and instances may
  report no zone at all.
- No-op with a warning when the ring has more zones than the replication
  factor. `findInstancesForKey` uses
  `targetHostsPerZone = max(1, replicationFactor/maxZones)`, so zone-aware
  replication places at most one replica per zone; a single zone therefore
  holds a complete copy only when there are no more zones than replicas.
- The override only ever *loosens* the ring's quorum requirement, so asking for
  more zones than the ring needs can never make queries fail more often.

Failures degrade gracefully rather than erroring. `GetReplicationSetForOperation`
already evicts an entire zone from the read set when any instance in it is
unhealthy, and `zoneAwareResultTracker` releases the next zone as soon as a
started zone reports an error, so an unhealthy local ingester means a fallback
to another zone, not a
failed query.

Related: #5319 and #19582 both ask for AZ-local
traffic, though both are framed around the write path. Mimir has the read-path
equivalent as `-querier.prefer-availability-zones`, wired only into its
ingest-storage path (grafana/mimir#2284, grafana/mimir#13045,
grafana/mimir#13756); this PR implements it for Loki's classic ingester ring.

**Which issue(s) this PR fixes**:
Relates to #19582 and #5319.

**Special notes for your reviewer**:

  1. **`index/stats` and `volume` values will change when querying one zone.**                                                                                                  
     `MergeStats` and `seriesvolume.Merge` sum per-ingester responses with no                                                                                                   
     deduplication, so the ingester portion of those endpoints currently                                                                                                        
     overcounts by roughly the replication factor. Reading a single zone makes                                                                                                  
     them reflect one copy, arguably a fix, but the query-frontend derives                                                                                                     
     sharding and splitting decisions from index stats, so query plans will                                                                                                     
     shift, and dashboards built on those endpoints will show a step change over                                                                                                
     the `query_ingesters_within` window. It only affects operators who opt in,                                                                                                 
     but tell me if you'd rather this were called out in the docs or handled                                                                                                    
     differently. 

  2. **Please sanity-check the completeness assumption.** The "one zone holds a                                                                                                 
     complete copy" claim rests on my reading of `findInstancesForKey` — at most                                                                                                
     one replica per zone, stopping at RF distinct instances — hence the                                                                                                        
     `zones > ReplicationFactor()` guard. If there is a topology where that                                                                                                     
     doesn't hold, the guard needs widening. 

3. **`TailDisconnectedIngesters` needed a change too.** It reconnects to any
   ring member not already connected, so a long-lived tail would gradually
   spread across every zone and quietly undo the restriction. Reconnects are
   now limited to the preferred zones plus any zone that already has a
   connected ingester, so a zone we failed over to isn't dropped again, and
   fall back to all zones if that set would be empty.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
