### PR TITLE
fix(ruler): Preserve Azure AD OAuth client secret when cloning remote-write config

### DIFF
--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -92,15 +92,23 @@ func (c *RemoteWriteConfig) Clone() (*RemoteWriteConfig, error) {
 	}
 
 	// BasicAuth.Password has a type of Secret (github.com/prometheus/common/config/config.go),
-	// so when its value is marshaled it is obfuscated as "<secret>".
-	// Here we copy the original password into the cloned config.
+	// so when its value is marshaled it is obfuscated as "<secret>". Here we copy the original
+	// password into the cloned config. AzureADConfig.OAuth.ClientSecret is still a plain string
+	// in the Prometheus version vendored here, but downstream forks type it as Secret (e.g. to
+	// fix CVE-2026-42151), so it needs the same treatment.
 	if n.Client != nil && n.Client.HTTPClientConfig.BasicAuth != nil {
 		n.Client.HTTPClientConfig.BasicAuth.Password = c.Client.HTTPClientConfig.BasicAuth.Password
+	}
+	if n.Client != nil && n.Client.AzureADConfig != nil && n.Client.AzureADConfig.OAuth != nil {
+		n.Client.AzureADConfig.OAuth.ClientSecret = c.Client.AzureADConfig.OAuth.ClientSecret
 	}
 
 	for id := range n.Clients {
 		if n.Clients[id].HTTPClientConfig.BasicAuth != nil {
 			n.Clients[id].HTTPClientConfig.BasicAuth.Password = c.Clients[id].HTTPClientConfig.BasicAuth.Password
+		}
+		if n.Clients[id].AzureADConfig != nil && n.Clients[id].AzureADConfig.OAuth != nil {
+			n.Clients[id].AzureADConfig.OAuth.ClientSecret = c.Clients[id].AzureADConfig.OAuth.ClientSecret
 		}
 	}
 

--- a/pkg/ruler/config_test.go
+++ b/pkg/ruler/config_test.go
@@ -2,9 +2,14 @@ package ruler
 
 import (
 	"flag"
+	"net/url"
 	"testing"
 
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/storage/remote/azuread"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoteWriteConfig(t *testing.T) {
@@ -16,4 +21,44 @@ func TestRemoteWriteConfig(t *testing.T) {
 	// assert new multi clients config is backward compatible if with single tenant.
 	// if not provided
 	assert.NotNil(t, r.Clients)
+}
+
+// TestRemoteWriteConfigClone_RestoresAzureADClientSecret guards against azuread.OAuthConfig.ClientSecret
+// being obfuscated by Clone's YAML round-trip once that field becomes Secret-typed, as it already is on
+// Loki main and in Grafana's CVE-2026-42151 backport.
+func TestRemoteWriteConfigClone_RestoresAzureADClientSecret(t *testing.T) {
+	remoteURL, err := url.Parse("http://azuread.example.com")
+	require.NoError(t, err)
+
+	azureADClient := config.RemoteWriteConfig{
+		URL: &config_util.URL{URL: remoteURL},
+		AzureADConfig: &azuread.AzureADConfig{
+			Cloud: azuread.AzurePublic,
+			OAuth: &azuread.OAuthConfig{
+				ClientID:     "11111111-1111-1111-1111-111111111111",
+				ClientSecret: "secret-azuread-client-secret",
+				TenantID:     "tenant-id",
+			},
+		},
+	}
+
+	orig := &RemoteWriteConfig{
+		Client: &azureADClient,
+		Clients: map[string]config.RemoteWriteConfig{
+			"azuread": azureADClient,
+		},
+	}
+
+	cloned, err := orig.Clone()
+	require.NoError(t, err)
+
+	require.NotNil(t, cloned.Client.AzureADConfig)
+	require.NotNil(t, cloned.Client.AzureADConfig.OAuth)
+	// The string conversion is a no-op today, but keeps this assertion working once
+	// ClientSecret's underlying type changes from string to a Secret-like named string type.
+	assert.Equal(t, "secret-azuread-client-secret", string(cloned.Client.AzureADConfig.OAuth.ClientSecret)) //nolint:unconvert
+
+	require.NotNil(t, cloned.Clients["azuread"].AzureADConfig)
+	require.NotNil(t, cloned.Clients["azuread"].AzureADConfig.OAuth)
+	assert.Equal(t, "secret-azuread-client-secret", string(cloned.Clients["azuread"].AzureADConfig.OAuth.ClientSecret)) //nolint:unconvert
 }


### PR DESCRIPTION
This PR preserves the Azure AD OAuth `client_secret` across `RemoteWriteConfig.Clone`'s YAML round-trip, in the same way `BasicAuth.Password` is already handled.

In an effort to patch GEL for CVE-2026-42151, we need to protect against a prometheus patch where `Clone`'s YAML round-trip would obfuscate the secret as `<secret>`.  We follow the pattern used by `BasicAuth.Password`.

Raised by @chaudum on [grafana/enterprise-logs#6239 (comment)](https://github.com/grafana/enterprise-logs/pull/6239#discussion_r3801510683).

Scoped to `release-3.5.x` only. A broader fix covering other `Secret`-typed fields on `RemoteWriteConfig` is being handled separately for `main`.

## Verification

- `go build ./pkg/ruler/...` and `go test ./pkg/ruler/...` pass.
- Added `TestRemoteWriteConfigClone_RestoresAzureADClientSecret`, which is a no-op regression guard in this repo today (since the field is a plain `string` here) but will start exercising the restore logic once the field becomes `Secret`-typed downstream.
