### PR TITLE
perf: Merge query responses as they come in, not at the end

### DIFF
--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -37,9 +37,34 @@ type packedResp struct {
 // a fan-out exits on a failure or a cancellation.
 func joinPartialFromResponses(ctx context.Context, responses []queryrangebase.Response) {
 	for _, r := range responses {
-		if s, ok := statisticsFromResponse(r); ok {
-			stats.JoinPartial(ctx, s)
-		}
+		joinPartialFromResponse(ctx, r)
+	}
+}
+
+// joinPartialFromResponse keeps the usage of an already-completed split when
+// a fan-out exits on a failure or a cancellation.
+func joinPartialFromResponse(ctx context.Context, resp queryrangebase.Response) {
+	if resp == nil {
+		return
+	}
+	if s, ok := statisticsFromResponse(resp); ok {
+		stats.JoinPartial(ctx, s)
+	}
+}
+
+// setResponseStats overwrites query statistics on response types that carry them.
+// Used after incremental MergeResponse, which treats the accumulator as a single
+// split and would undercount Summary.Splits.
+func setResponseStats(resp queryrangebase.Response, s stats.Result) {
+	switch r := resp.(type) {
+	case *LokiResponse:
+		r.Statistics = s
+	case *LokiPromResponse:
+		r.Statistics = s
+	case *LokiSeriesResponse:
+		r.Statistics = s
+	case *LokiLabelNamesResponse:
+		r.Statistics = s
 	}
 }
 
@@ -124,18 +149,18 @@ func (h *splitByInterval) Process(
 	threshold int64,
 	input []*lokiResult,
 	maxSeries int,
-) ([]queryrangebase.Response, error) {
-	var responses []queryrangebase.Response
+) (queryrangebase.Response, error) {
+	// Fold splits as they complete so peak memory is the running merged
+	// result plus in-flight workers, not N decoded split bodies.
+	var acc queryrangebase.Response
+	var mergedStats stats.Result
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(errors.New("split by interval process canceled"))
 
 	ch := h.Feed(ctx, input)
 
 	// queries with 0 limits should not be exited early
-	var unlimited bool
-	if threshold == 0 {
-		unlimited = true
-	}
+	unlimited := threshold == 0
 
 	// Parallelism will be at least 1
 	p := max(parallelism, 1)
@@ -156,34 +181,46 @@ func (h *splitByInterval) Process(
 			// Keep the usage of the intervals that completed before the
 			// cancellation, and report the cause so a real failure wins over a
 			// generic cancellation.
-			joinPartialFromResponses(ctx, responses)
+			joinPartialFromResponse(ctx, acc)
 			return nil, context.Cause(ctx)
 		case data := <-x.ch:
 			if data.err != nil {
 				// Keep the usage of the intervals that completed before the failure.
-				joinPartialFromResponses(ctx, responses)
+				joinPartialFromResponse(ctx, acc)
 				// Cancel the siblings with this failure as the cause, so it is not
 				// lost behind a generic cancellation.
 				cancel(data.err)
 				return nil, data.err
 			}
 
-			responses = append(responses, data.resp)
+			if s, ok := statisticsFromResponse(data.resp); ok {
+				mergedStats.MergeSplit(s)
+			}
+
+			if acc == nil {
+				acc = data.resp
+			} else {
+				merged, err := h.merger.MergeResponse(acc, data.resp)
+				if err != nil {
+					joinPartialFromResponse(ctx, acc)
+					cancel(err)
+					return nil, err
+				}
+				acc = merged
+			}
+			setResponseStats(acc, mergedStats)
 
 			// see if we can exit early if a limit has been reached
 			if casted, ok := data.resp.(*LokiResponse); !unlimited && ok {
 				threshold -= casted.Count()
-
 				if threshold <= 0 {
-					return responses, nil
+					return acc, nil
 				}
-
 			}
-
 		}
 	}
 
-	return responses, nil
+	return acc, nil
 }
 
 func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult, next queryrangebase.Handler) {
@@ -276,11 +313,7 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 	maxSeriesCapture := func(id string) int { return h.limits.MaxQuerySeries(ctx, id) }
 	maxSeries := validation.SmallestPositiveIntPerTenant(tenantIDs, maxSeriesCapture)
 	maxParallelism := MinWeightedParallelism(ctx, tenantIDs, h.configs, h.limits, model.Time(r.GetStart().UnixMilli()), model.Time(r.GetEnd().UnixMilli()))
-	resps, err := h.Process(ctx, maxParallelism, limit, input, maxSeries)
-	if err != nil {
-		return nil, err
-	}
-	return h.merger.MergeResponse(resps...)
+	return h.Process(ctx, maxParallelism, limit, input, maxSeries)
 }
 
 // maxRangeVectorAndOffsetDurationFromQueryString

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -83,6 +83,17 @@ func statisticsFromResponse(resp queryrangebase.Response) (stats.Result, bool) {
 	}
 }
 
+// topKMerge truncates to Limit on every MergeResponse call. Pairwise folding
+// can drop names that would rank in the final result after later splits.
+func topKMerge(resp queryrangebase.Response) bool {
+	switch resp.(type) {
+	case *VolumeResponse, *DetectedFieldsResponse:
+		return true
+	default:
+		return false
+	}
+}
+
 type SplitByMetrics struct {
 	splits prometheus.Histogram
 }
@@ -153,6 +164,7 @@ func (h *splitByInterval) Process(
 	// Fold splits as they complete so peak memory is the running merged
 	// result plus in-flight workers, not N decoded split bodies.
 	var acc queryrangebase.Response
+	var topK []queryrangebase.Response
 	var mergedStats stats.Result
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(errors.New("split by interval process canceled"))
@@ -182,11 +194,13 @@ func (h *splitByInterval) Process(
 			// cancellation, and report the cause so a real failure wins over a
 			// generic cancellation.
 			joinPartialFromResponse(ctx, acc)
+			joinPartialFromResponses(ctx, topK)
 			return nil, context.Cause(ctx)
 		case data := <-x.ch:
 			if data.err != nil {
 				// Keep the usage of the intervals that completed before the failure.
 				joinPartialFromResponse(ctx, acc)
+				joinPartialFromResponses(ctx, topK)
 				// Cancel the siblings with this failure as the cause, so it is not
 				// lost behind a generic cancellation.
 				cancel(data.err)
@@ -195,6 +209,11 @@ func (h *splitByInterval) Process(
 
 			if s, ok := statisticsFromResponse(data.resp); ok {
 				mergedStats.MergeSplit(s)
+			}
+
+			if topKMerge(data.resp) {
+				topK = append(topK, data.resp)
+				continue
 			}
 
 			if acc == nil {
@@ -218,6 +237,15 @@ func (h *splitByInterval) Process(
 				}
 			}
 		}
+	}
+
+	if len(topK) > 0 {
+		merged, err := h.merger.MergeResponse(topK...)
+		if err != nil {
+			joinPartialFromResponses(ctx, topK)
+			return nil, err
+		}
+		return merged, nil
 	}
 
 	return acc, nil

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -1861,6 +1861,59 @@ func Test_ExitEarly(t *testing.T) {
 	require.Equal(t, expected, res)
 }
 
+func Test_splitByInterval_Do_manySplitsPreservesSplitStats(t *testing.T) {
+	// Pairwise MergeResponse treats the accumulator as one split, so Process
+	// restamps stats from the raw sub-responses. This would report Splits=2
+	// without that restamp.
+	const n = 8
+	ctx := user.InjectOrgID(context.Background(), "1")
+	next := queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+		return &LokiResponse{
+			Status:    loghttp.QueryStatusSuccess,
+			Direction: r.(*LokiRequest).Direction,
+			Limit:     r.(*LokiRequest).Limit,
+			Version:   uint32(loghttp.VersionV1),
+			Data: LokiData{
+				ResultType: loghttp.ResultTypeStream,
+				Result: []logproto.Stream{
+					{
+						Labels: `{foo="bar"}`,
+						Entries: []logproto.Entry{
+							{Timestamp: time.Unix(0, r.(*LokiRequest).StartTs.UnixNano()), Line: "line"},
+						},
+					},
+				},
+			},
+		}, nil
+	})
+
+	defSplitter := newDefaultSplitter(fakeLimits{}, nil)
+	l := WithSplitByLimits(fakeLimits{maxQueryParallelism: 1}, time.Hour)
+	split := SplitByIntervalMiddleware(
+		testSchemas,
+		l,
+		DefaultCodec,
+		defSplitter,
+		nilMetrics,
+	).Wrap(next)
+
+	req := &LokiRequest{
+		StartTs:   time.Unix(0, 0),
+		EndTs:     time.Unix(0, (time.Duration(n) * time.Hour).Nanoseconds()),
+		Query:     "",
+		Limit:     1000,
+		Step:      1,
+		Direction: logproto.FORWARD,
+		Path:      "/api/prom/query_range",
+	}
+
+	res, err := split.Do(ctx, req)
+	require.NoError(t, err)
+	got := res.(*LokiResponse)
+	require.Equal(t, int64(n), got.Statistics.Summary.Splits)
+	require.Len(t, got.Data.Result[0].Entries, n)
+}
+
 func Test_DoesntDeadlock(t *testing.T) {
 	n := 10
 

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1726,6 +1727,59 @@ func Test_seriesvolume_splitByInterval_Do(t *testing.T) {
 		})
 	})
 
+	t.Run("volumes rank after all splits, not pairwise", func(t *testing.T) {
+		// Pairwise MergeResponse applies Limit after each fold and can drop a
+		// name that later splits would have ranked in the top N.
+		next := queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+			from := r.(*logproto.VolumeRequest).From.Time().UTC()
+			var volumes []logproto.Volume
+			switch {
+			case from.Before(time.Unix(3600, 0).UTC()):
+				volumes = []logproto.Volume{
+					{Name: `{app="a"}`, Volume: 100},
+					{Name: `{app="b"}`, Volume: 90},
+				}
+			case from.Before(time.Unix(7200, 0).UTC()):
+				volumes = []logproto.Volume{
+					{Name: `{app="c"}`, Volume: 80},
+					{Name: `{app="d"}`, Volume: 70},
+				}
+			default:
+				volumes = []logproto.Volume{
+					{Name: `{app="b"}`, Volume: 80},
+					{Name: `{app="d"}`, Volume: 80},
+				}
+			}
+			return &VolumeResponse{
+				Response: &logproto.VolumeResponse{
+					Volumes: volumes,
+					Limit:   2,
+				},
+			}, nil
+		})
+
+		l := WithSplitByLimits(fakeLimits{maxQueryParallelism: 1}, time.Hour)
+		split := setup(next, l)
+		req := &logproto.VolumeRequest{
+			From:     model.TimeFromUnix(0),
+			Through:  model.TimeFromUnix(int64((3 * time.Hour) / time.Second)),
+			Matchers: "{}",
+			Limit:    2,
+		}
+
+		res, err := split.Do(ctx, req)
+		require.NoError(t, err)
+
+		got := res.(*VolumeResponse).Response
+		require.Equal(t, &logproto.VolumeResponse{
+			Volumes: []logproto.Volume{
+				{Name: `{app="b"}`, Volume: 170},
+				{Name: `{app="d"}`, Volume: 150},
+			},
+			Limit: 2,
+		}, got)
+	})
+
 	// This will never happen because we hardcode 24h spit by for this code path
 	// in the middleware. However, that split by is not validated here, so we either
 	// need to support this case or error.
@@ -1999,5 +2053,120 @@ func assertSplits(t *testing.T, want, splits []queryrangebase.Request) {
 			equal := assert.Equal(t, exp, act)
 			t.Logf("\t#%d [matches: %v]: expected %q/%q got %q/%q\n", j, equal, exp.GetStart(), exp.GetEnd(), act.GetStart(), act.GetEnd())
 		}
+	}
+}
+
+func foldResponses(resps []queryrangebase.Response) (queryrangebase.Response, error) {
+	var acc queryrangebase.Response
+	for _, r := range resps {
+		if acc == nil {
+			acc = r
+			continue
+		}
+		merged, err := DefaultCodec.MergeResponse(acc, r)
+		if err != nil {
+			return nil, err
+		}
+		acc = merged
+	}
+	return acc, nil
+}
+
+func makeLogSplitResponses(splits, streams, entriesPerStream int) []queryrangebase.Response {
+	line := strings.Repeat("x", 256)
+	resps := make([]queryrangebase.Response, splits)
+	for i := 0; i < splits; i++ {
+		result := make([]logproto.Stream, streams)
+		for s := 0; s < streams; s++ {
+			ents := make([]logproto.Entry, entriesPerStream)
+			for e := 0; e < entriesPerStream; e++ {
+				ents[e] = logproto.Entry{
+					Timestamp: time.Unix(int64(i*entriesPerStream+e), 0),
+					Line:      line,
+				}
+			}
+			result[s] = logproto.Stream{
+				Labels:  fmt.Sprintf(`{app="foo", stream="%d"}`, s),
+				Entries: ents,
+			}
+		}
+		resps[i] = &LokiResponse{
+			Status:    loghttp.QueryStatusSuccess,
+			Direction: logproto.FORWARD,
+			Limit:     uint32(splits * streams * entriesPerStream),
+			Version:   uint32(loghttp.VersionV1),
+			Data: LokiData{
+				ResultType: loghttp.ResultTypeStream,
+				Result:     result,
+			},
+		}
+	}
+	return resps
+}
+
+func makeMetricSplitResponses(splits, series, samples int) []queryrangebase.Response {
+	resps := make([]queryrangebase.Response, splits)
+	for i := 0; i < splits; i++ {
+		result := make([]queryrangebase.SampleStream, series)
+		for s := 0; s < series; s++ {
+			vals := make([]logproto.LegacySample, samples)
+			for p := 0; p < samples; p++ {
+				vals[p] = logproto.LegacySample{
+					TimestampMs: int64(i*samples+p) * 1000,
+					Value:       float64(p),
+				}
+			}
+			result[s] = queryrangebase.SampleStream{
+				Labels:  []logproto.LabelAdapter{{Name: "series", Value: strconv.Itoa(s)}},
+				Samples: vals,
+			}
+		}
+		resps[i] = &LokiPromResponse{
+			Response: &queryrangebase.PrometheusResponse{
+				Status: "success",
+				Data: queryrangebase.PrometheusData{
+					ResultType: model.ValMatrix.String(),
+					Result:     result,
+				},
+			},
+		}
+	}
+	return resps
+}
+
+func Benchmark_mergeSplits(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		resps []queryrangebase.Response
+	}{
+		{"logs/splits=64/streams=8/entries=50", makeLogSplitResponses(64, 8, 50)},
+		{"logs/splits=256/streams=8/entries=50", makeLogSplitResponses(256, 8, 50)},
+		{"metrics/splits=64/series=20/samples=30", makeMetricSplitResponses(64, 20, 30)},
+		{"metrics/splits=256/series=20/samples=30", makeMetricSplitResponses(256, 20, 30)},
+	} {
+		b.Run(tc.name+"/all_at_once", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				got, err := DefaultCodec.MergeResponse(tc.resps...)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if got == nil {
+					b.Fatal("nil result")
+				}
+			}
+		})
+		b.Run(tc.name+"/incremental", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				got, err := foldResponses(tc.resps)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if got == nil {
+					b.Fatal("nil result")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Query-frontend currently buffers every time-split response, then calls `MergeResponse` once. For large queries with a 15m split interval, that can be thousands of decoded bodies in RAM at the same time, which can OOMs query-frontend.
Fold each completed split into a running result and drop the raw split so peak memory is the merged result plus in-flight workers, not `N` split bodies.
`MergeResponse` treats the accumulator as one split, so pairwise merge would report `Splits=2` regardless of interval count. Accumulate stats with `MergeSplit` on each raw sub-response and write them back onto the merged result.

This does not cap a single huge sub-response, and it does not shrink `max_query_parallelism` / shard buffering.

## Volume ranking
Pairwise `MergeResponse` is not safe for `/index/volume` (or detected fields). `seriesvolume.Merge` sums then truncates to `Limit`, so an intermediate fold can drop a name that later splits would have put in the top N.
Volume and detected-fields splits are buffered and merged once. Those payloads are already bounded by `Limit` (default 100 names), so this does not bring back the query-frontend OOM. Log and metric splits still fold incrementally.
## Merge benchmarks
Apple M5 Pro, `go test ./pkg/querier/queryrange/ -bench Benchmark_mergeSplits -benchmem`. Median of 3 runs. `B/op` is **total bytes allocated during merge**, not peak RSS.
| workload | strategy | ns/op | B/op | allocs/op |
|---|---|---:|---:|---:|
| logs, 64 splits × 8 streams × 50 lines | all-at-once | 0.16ms | 2.2 MiB | 87 |
| | incremental | 4.4ms | 72 MiB | 2,898 |
| logs, 256 splits × 8 streams × 50 lines | all-at-once | 0.69ms | 8.8 MiB | 103 |
| | incremental | 61ms | 1.1 GiB | 11,731 |
| metrics, 64 splits × 20 series × 30 samples | all-at-once | 0.27ms | 2.3 MiB | 2,775 |
| | incremental | 2.2ms | 29 MiB | 9,031 |
| metrics, 256 splits × 20 series × 30 samples | all-at-once | 1.0ms | 9.8 MiB | 10,538 |
| | incremental | 17ms | 347 MiB | 35,052 |
Incremental fold recopies the accumulator on every split (`O(n²)` copy), so CPU and total allocation go up. Peak residency is a different number: completed split bodies can be GC'd instead of sitting in a slice until the final merge. That is the OOM case (thousands of decoded split bodies). This microbenchmark keeps every input live, so it does not measure that peak.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
