### PR TITLE
fix: Data race protection for filterer

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -110,7 +110,8 @@ type HeadManager struct {
 	shards                 int
 	activeHeads, prevHeads *tenantHeads
 
-	chunkFilter chunk.RequestChunkFilterer
+	chunkFilterMu sync.Mutex
+	chunkFilter   chunk.RequestChunkFilterer
 
 	Index
 
@@ -150,8 +151,8 @@ func NewHeadManager(name string, logger log.Logger, dir string, metrics *Metrics
 		}
 
 		idx := NewMultiIndex(IndexSlice(indices))
-		if m.chunkFilter != nil {
-			idx.SetChunkFilterer(m.chunkFilter)
+		if f := m.getChunkFilter(); f != nil {
+			idx.SetChunkFilterer(f)
 		}
 		return idx, nil
 	})
@@ -283,7 +284,16 @@ func (m *HeadManager) Stop() error {
 }
 
 func (m *HeadManager) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	m.chunkFilterMu.Lock()
 	m.chunkFilter = chunkFilter
+	m.chunkFilterMu.Unlock()
+}
+
+func (m *HeadManager) getChunkFilter() chunk.RequestChunkFilterer {
+	m.chunkFilterMu.Lock()
+	f := m.chunkFilter
+	m.chunkFilterMu.Unlock()
+	return f
 }
 
 func (m *HeadManager) Append(userID string, ls labels.Labels, fprint uint64, chks index.ChunkMetas) error {
@@ -692,13 +702,14 @@ func parseWALPath(p string) (id WALIdentifier, ok bool) {
 type tenantHeads struct {
 	mint, maxt atomic.Int64 // easy lookup for Bounds() impl
 
-	start       time.Time
-	shards      int
-	locks       []sync.RWMutex
-	tenants     []map[string]*Head
-	log         log.Logger
-	chunkFilter chunk.RequestChunkFilterer
-	metrics     *Metrics
+	start         time.Time
+	shards        int
+	locks         []sync.RWMutex
+	tenants       []map[string]*Head
+	log           log.Logger
+	chunkFilterMu sync.Mutex
+	chunkFilter   chunk.RequestChunkFilterer
+	metrics       *Metrics
 }
 
 func newTenantHeads(start time.Time, shards int, metrics *Metrics, logger log.Logger) *tenantHeads {
@@ -784,7 +795,16 @@ func (t *tenantHeads) shardForTenant(userID string) uint64 {
 func (t *tenantHeads) Close() error { return nil }
 
 func (t *tenantHeads) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	t.chunkFilterMu.Lock()
 	t.chunkFilter = chunkFilter
+	t.chunkFilterMu.Unlock()
+}
+
+func (t *tenantHeads) getChunkFilter() chunk.RequestChunkFilterer {
+	t.chunkFilterMu.Lock()
+	f := t.chunkFilter
+	t.chunkFilterMu.Unlock()
+	return f
 }
 
 func (t *tenantHeads) Bounds() (model.Time, model.Time) {
@@ -801,8 +821,8 @@ func (t *tenantHeads) tenantIndex(userID string, from, through model.Time) (idx 
 	}
 
 	idx = NewTSDBIndex(tenant.indexRange(int64(from), int64(through)))
-	if t.chunkFilter != nil {
-		idx.SetChunkFilterer(t.chunkFilter)
+	if f := t.getChunkFilter(); f != nil {
+		idx.SetChunkFilterer(f)
 	}
 	return idx, true
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"testing"
 	"time"
 
@@ -319,4 +320,48 @@ type fakeLimits struct {
 
 func (f *fakeLimits) VolumeMaxSeries(_ string) int {
 	return f.volumeMaxSeries
+}
+
+func TestIndexShipperQuerier_ConcurrentChunkFilterer(t *testing.T) {
+	tempDir := t.TempDir()
+	tableRange := config.TableRange{
+		Start: 0,
+		End:   math.MaxInt64,
+		PeriodConfig: &config.PeriodConfig{
+			IndexTables: config.IndexPeriodicTableConfig{
+				PeriodicTableConfig: config.PeriodicTableConfig{
+					Period: config.ObjectStorageIndexRequiredPeriod,
+				}},
+		},
+	}
+	indexStart := model.TimeFromUnixNano(time.Now().Truncate(config.ObjectStorageIndexRequiredPeriod).UnixNano())
+	tables := map[string][]*TSDBFile{
+		tableRange.PeriodConfig.IndexTables.TableFor(indexStart): {
+			BuildIndex(t, tempDir, []LoadableSeries{
+				{
+					Labels: mustParseLabels(`{foo="bar"}`),
+					Chunks: buildChunkMetas(int64(indexStart), int64(indexStart+99)),
+				},
+			}),
+		},
+	}
+	q := newIndexShipperQuerier(mockIndexShipperIndexIterator{tables: tables}, tableRange)
+	idx := NewMultiIndex(IndexSlice{q, q})
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+
+	// Populate PeriodConfig.schemaInt before concurrent queries.
+	_, err := q.GetChunkRefs(context.Background(), "fake", indexStart, indexStart+100, nil, nil, matcher)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			idx.SetChunkFilterer(&filterAll{})
+			_, err := idx.GetChunkRefs(context.Background(), "fake", indexStart, indexStart+100, nil, nil, matcher)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
@@ -23,9 +23,10 @@ type indexShipperIterator interface {
 
 // indexShipperQuerier is used for querying index from the shipper.
 type indexShipperQuerier struct {
-	shipper     indexShipperIterator
-	chunkFilter chunk.RequestChunkFilterer
-	tableRange  config.TableRange
+	shipper       indexShipperIterator
+	chunkFilterMu sync.Mutex
+	chunkFilter   chunk.RequestChunkFilterer
+	tableRange    config.TableRange
 }
 
 func newIndexShipperQuerier(shipper indexShipperIterator, tableRange config.TableRange) Index {
@@ -62,8 +63,8 @@ func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.T
 
 	idx := NewMultiIndex(itr)
 
-	if i.chunkFilter != nil {
-		idx.SetChunkFilterer(i.chunkFilter)
+	if f := i.getChunkFilter(); f != nil {
+		idx.SetChunkFilterer(f)
 	}
 	return idx, nil
 }
@@ -76,7 +77,16 @@ func (i *indexShipperQuerier) Bounds() (model.Time, model.Time) {
 }
 
 func (i *indexShipperQuerier) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	i.chunkFilterMu.Lock()
 	i.chunkFilter = chunkFilter
+	i.chunkFilterMu.Unlock()
+}
+
+func (i *indexShipperQuerier) getChunkFilter() chunk.RequestChunkFilterer {
+	i.chunkFilterMu.Lock()
+	f := i.chunkFilter
+	i.chunkFilterMu.Unlock()
+	return f
 }
 
 // Close implements Index.Close, but we offload this responsibility

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
@@ -382,7 +382,7 @@ func (i *MultiIndex) Volume(ctx context.Context, userID string, from, through mo
 	})
 }
 
-func (i MultiIndex) ForSeries(ctx context.Context, userID string, fpFilter index.FingerprintFilter, from model.Time, through model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta) (stop bool), matchers ...*labels.Matcher) error {
+func (i *MultiIndex) ForSeries(ctx context.Context, userID string, fpFilter index.FingerprintFilter, from model.Time, through model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta) (stop bool), matchers ...*labels.Matcher) error {
 	return i.forMatchingIndices(ctx, from, through, func(ctx context.Context, idx Index) error {
 		return idx.ForSeries(ctx, userID, fpFilter, from, through, fn, matchers...)
 	})

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
@@ -18,6 +18,7 @@ import (
 
 type MultiIndex struct {
 	iter        IndexIter
+	filtererMu  sync.Mutex
 	filterer    chunk.RequestChunkFilterer
 	maxParallel int
 }
@@ -99,7 +100,16 @@ func (i *MultiIndex) Bounds() (model.Time, model.Time) {
 }
 
 func (i *MultiIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	i.filtererMu.Lock()
 	i.filterer = chunkFilter
+	i.filtererMu.Unlock()
+}
+
+func (i *MultiIndex) getFilterer() chunk.RequestChunkFilterer {
+	i.filtererMu.Lock()
+	f := i.filterer
+	i.filtererMu.Unlock()
+	return f
 }
 
 func (i *MultiIndex) Close() error {
@@ -118,12 +128,12 @@ func (i *MultiIndex) forMatchingIndices(ctx context.Context, from, through model
 	return i.iter.For(ctx, i.maxParallel, func(ctx context.Context, idx Index) error {
 		if Overlap(idx, queryBounds) {
 
-			if i.filterer != nil {
+			if f := i.getFilterer(); f != nil {
 				// TODO(owen-d): Find a nicer way
 				// to handle filterer passing. Doing it
 				// in the read path rather than during instantiation
 				// feels bad :(
-				idx.SetChunkFilterer(i.filterer)
+				idx.SetChunkFilterer(f)
 			}
 
 			return f(ctx, idx)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index_test.go
@@ -2,6 +2,7 @@ package tsdb
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -162,4 +163,31 @@ func TestMultiIndex(t *testing.T) {
 
 		require.Equal(t, expected, xs)
 	})
+}
+
+// Concurrent queries stamp the same filterer onto shared child indexes.
+func TestMultiIndex_ConcurrentChunkFilterer(t *testing.T) {
+	dir := t.TempDir()
+	file := BuildIndex(t, dir, []LoadableSeries{
+		{
+			Labels: mustParseLabels(`{foo="bar"}`),
+			Chunks: []index.ChunkMeta{
+				{MinTime: 0, MaxTime: 10, Checksum: 1},
+			},
+		},
+	})
+	idx := NewMultiIndex(IndexSlice{file, file})
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			idx.SetChunkFilterer(&filterAll{})
+			_, err := idx.GetChunkRefs(context.Background(), "fake", 0, 10, nil, nil, matcher)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -121,8 +122,9 @@ func (f *TSDBFile) Reader() (io.ReadSeekCloser, error) {
 // and translates the IndexReader to an Index implementation
 // It loads the file into memory and doesn't keep a file descriptor open
 type TSDBIndex struct {
-	reader      IndexReader
-	chunkFilter chunk.RequestChunkFilterer
+	reader        IndexReader
+	chunkFilterMu sync.Mutex
+	chunkFilter   chunk.RequestChunkFilterer
 }
 
 // Return the index as well as the underlying raw file reader which isn't exposed as an index
@@ -154,7 +156,16 @@ func (i *TSDBIndex) Bounds() (model.Time, model.Time) {
 }
 
 func (i *TSDBIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	i.chunkFilterMu.Lock()
 	i.chunkFilter = chunkFilter
+	i.chunkFilterMu.Unlock()
+}
+
+func (i *TSDBIndex) getChunkFilter() chunk.RequestChunkFilterer {
+	i.chunkFilterMu.Lock()
+	f := i.chunkFilter
+	i.chunkFilterMu.Unlock()
+	return f
 }
 
 // fn must NOT capture it's arguments. They're reused across series iterations and returned to
@@ -164,8 +175,8 @@ func (i *TSDBIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
 // it is ignored (it's enforced elsewhere in index selection)
 func (i *TSDBIndex) ForSeries(ctx context.Context, _ string, fpFilter index.FingerprintFilter, from model.Time, through model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta) (stop bool), matchers ...*labels.Matcher) error {
 	var filterer chunk.Filterer
-	if i.chunkFilter != nil {
-		filterer = i.chunkFilter.ForRequest(ctx)
+	if f := i.getChunkFilter(); f != nil {
+		filterer = f.ForRequest(ctx)
 	}
 	return i.forSeriesAndLabels(ctx, fpFilter, filterer, from, through, fn, matchers...)
 }
@@ -265,8 +276,8 @@ func (i *TSDBIndex) GetChunkRefs(ctx context.Context, userID string, from, throu
 	}
 
 	var filterer chunk.Filterer
-	if i.chunkFilter != nil {
-		filterer = i.chunkFilter.ForRequest(ctx)
+	if f := i.getChunkFilter(); f != nil {
+		filterer = f.ForRequest(ctx)
 	}
 	var err error
 	if filterer != nil {
@@ -344,8 +355,8 @@ func (i *TSDBIndex) Stats(ctx context.Context, _ string, from, through model.Tim
 		var ls labels.Labels
 		var filterer chunk.Filterer
 		by := make(map[string]struct{})
-		if i.chunkFilter != nil {
-			filterer = i.chunkFilter.ForRequest(ctx)
+		if f := i.getChunkFilter(); f != nil {
+			filterer = f.ForRequest(ctx)
 			if filterer != nil {
 				for _, k := range filterer.RequiredLabelNames() {
 					by[k] = struct{}{}
@@ -420,8 +431,8 @@ func (i *TSDBIndex) Volume(
 	aggregateBySeries := seriesvolume.AggregateBySeries(aggregateBy) || aggregateBy == ""
 	var by map[string]struct{}
 	var filterer chunk.Filterer
-	if i.chunkFilter != nil {
-		filterer = i.chunkFilter.ForRequest(ctx)
+	if f := i.getChunkFilter(); f != nil {
+		filterer = f.ForRequest(ctx)
 	}
 	if !includeAll && (aggregateBySeries || len(targetLabels) > 0) {
 		by = make(map[string]struct{}, len(labelsToMatch))


### PR DESCRIPTION
**What this PR does / why we need it**:

`MultiIndex.forMatchingIndices` stamps the request chunk filterer onto shared child indexes from parallel workers on every query. Those children (`indexShipperQuerier`, `TSDBIndex`, `HeadManager` / `tenantHeads`) are long-lived and reused across queries, so concurrent queries race on the stored `chunkFilter` / `filterer` fields.

This showed up under race testing involving `SetChunkFilterer` on the same `indexShipperQuerier`. Fixing only that field is not enough; the same pattern exists on every shared Index that holds a filterer.

Protect those fields with a mutex (no API change). Also switch `MultiIndex.ForSeries` to a pointer receiver so it does not copy filtererMu (`go vet copylocks`).

**Which issue(s) this PR fixes**:
In support of: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

This is a stopgap. The real cleanup is to stop mutating shared indexes on the read path (request-scoped wrapper, or pass the filterer as an argument). Owen already flagged that in the `forMatchingIndices` TODO.

Mutexes are on:

`indexShipperQuerier.chunkFilter`
`TSDBIndex.chunkFilter`
`MultiIndex.filterer`
`HeadManager.chunkFilter`
`tenantHeads.chunkFilter`

```
% go test ./... -count=10 -race
ok  	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb	326.570s
ok  	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index	207.422s
ok  	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc	6.252s
?   	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool	[no test files]
ok  	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding	1.548s
?   	github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/testutil	[no test files]

```

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
