### PR TITLE
feat: Add per tenant max push size override

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3440,10 +3440,6 @@ ring:
 # CLI flag: -distributor.push-worker-count
 [push_worker_count: <int> | default = 256]
 
-# The maximum size of a Push request.
-# CLI flag: -distributor.max-push-size-bytes
-[max_push_size_bytes: <int> | default = 2147483647]
-
 # The maximum number of inflight bytes at a time. 0 means disabled.
 # CLI flag: -distributor.max-inflight-bytes
 [max_inflight_bytes: <int> | default = 0]
@@ -4524,6 +4520,10 @@ The `limits_config` block configures global and per-tenant limits in Loki. The v
 # Identifier that is added at the end of a truncated log line.
 # CLI flag: -distributor.max-line-size-truncate-identifier
 [max_line_size_truncate_identifier: <string> | default = ""]
+
+# The maximum size of a Push request.
+# CLI flag: -distributor.max-push-size
+[max_push_size: <int> | default = 2GB]
 
 # Alter the log line timestamp during ingestion when the timestamp is the same
 # as the previous entry for the same stream. When enabled, if a log line in a

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -92,7 +92,6 @@ type Config struct {
 	PushWorkerCount int        `yaml:"push_worker_count"`
 
 	// Request parser
-	MaxPushSizeBytes int `yaml:"max_push_size_bytes"`
 	MaxInflightBytes int `yaml:"max_inflight_bytes"`
 
 	// For testing.
@@ -133,7 +132,6 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.RateStore.RegisterFlagsWithPrefix("distributor.rate-store", fs)
 	cfg.WriteFailuresLogging.RegisterFlagsWithPrefix("distributor.write-failures-logging", fs)
 	cfg.OTLPAttributeLogging.RegisterFlagsWithPrefix("distributor.otlp-attribute-logging", fs)
-	fs.IntVar(&cfg.MaxPushSizeBytes, "distributor.max-push-size-bytes", math.MaxInt32, "The maximum size of a Push request.")
 	fs.IntVar(&cfg.MaxInflightBytes, "distributor.max-inflight-bytes", 0, "The maximum number of inflight bytes at a time. 0 means disabled.")
 	fs.IntVar(&cfg.PushWorkerCount, "distributor.push-worker-count", 256, "Number of workers to push batches to ingesters.")
 	fs.BoolVar(&cfg.KafkaEnabled, "distributor.kafka-writes-enabled", false, "Enable writes to Kafka during Push requests.")
@@ -151,9 +149,6 @@ func (cfg *Config) Validate() error {
 	}
 	if err := cfg.CircuitBreaker.Validate(); err != nil {
 		return err
-	}
-	if cfg.MaxPushSizeBytes < 0 {
-		return errors.New("max push size cannot be less than zero")
 	}
 	if cfg.MaxInflightBytes < 0 {
 		return errors.New("max inflight bytes cannot be less than zero")

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -69,7 +69,8 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	streamResolver := newRequestScopedStreamResolver(tenantID, d.validator.Limits, logger)
 
 	presumedAgentIP := extractPresumedAgentIP(r)
-	req, pushStats, err := push.ParseRequest(logger, tenantID, d.cfg.MaxPushSizeBytes, int64(d.cfg.MaxPushSizeBytes), r, d.validator.Limits, d.tenantConfigs,
+	maxPushSize := d.validator.Limits.MaxPushSize(tenantID)
+	req, pushStats, err := push.ParseRequest(logger, tenantID, maxPushSize, int64(maxPushSize), r, d.validator.Limits, d.tenantConfigs,
 		pushRequestParser, d.usageTracker, streamResolver, presumedAgentIP, format)
 	if err != nil {
 		switch {

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -82,8 +82,8 @@ func TestPushHandlerMaxPushSize(t *testing.T) {
 	limits := &validation.Limits{}
 	flagext.DefaultValues(limits)
 	limits.RejectOldSamples = false
+	_ = limits.MaxPushSize.Set("1000")
 	distributors, _ := prepare(t, 1, 3, limits, nil)
-	distributors[0].cfg.MaxPushSizeBytes = 1000
 
 	newPushRequest := func() *logproto.PushRequest {
 		return &logproto.PushRequest{

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -49,6 +49,7 @@ type Limits interface {
 	IngestionPartitionsTenantShardSize(userID string) int
 
 	SimulatedPushLatency(userID string) time.Duration
+	MaxPushSize(userID string) int
 
 	validation.IngestionPolicyOverrideLimits
 }

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -104,6 +104,7 @@ type TenantsRetention interface {
 type Limits interface {
 	OTLPConfig(userID string) OTLPConfig
 	DiscoverServiceName(userID string) []string
+	MaxPushSize(userID string) int
 }
 
 type EmptyLimits struct{}

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -916,6 +917,10 @@ func (f *fakeLimits) DiscoverServiceName(_ string) []string {
 		"job",
 		"k8s_job_name",
 	}
+}
+
+func (f *fakeLimits) MaxPushSize(_ string) int {
+	return math.MaxInt32
 }
 
 type mockStreamResolver struct {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -104,6 +104,7 @@ type Limits struct {
 	MaxLineSize                   flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
 	MaxLineSizeTruncate           bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
 	MaxLineSizeTruncateIdentifier string           `yaml:"max_line_size_truncate_identifier" json:"max_line_size_truncate_identifier"`
+	MaxPushSize                   flagext.ByteSize `yaml:"max_push_size" json:"max_push_size"`
 	IncrementDuplicateTimestamp   bool             `yaml:"increment_duplicate_timestamp" json:"increment_duplicate_timestamp"`
 	SimulatedPushLatency          time.Duration    `yaml:"simulated_push_latency" json:"simulated_push_latency" doc:"description=Simulated latency to add to push requests. Used for testing. Set to 0s to disable."`
 
@@ -332,6 +333,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.MaxLineSize, "distributor.max-line-size", "Maximum line size on ingestion path. Example: 256kb. Any log line exceeding this limit will be discarded unless `distributor.max-line-size-truncate` is set, in which case it is truncated rather than discarded completely. There is no limit when set to 0.")
 	f.BoolVar(&l.MaxLineSizeTruncate, "distributor.max-line-size-truncate", false, "Whether to truncate lines that exceed max_line_size.")
 	f.StringVar(&l.MaxLineSizeTruncateIdentifier, "distributor.max-line-size-truncate-identifier", "", "Identifier that is added at the end of a truncated log line.")
+
+	_ = l.MaxPushSize.Set("2GB")
+	f.Var(&l.MaxPushSize, "distributor.max-push-size", "The maximum size of a Push request.")
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names.")
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name.")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 15, "Maximum number of label names per series.")
@@ -923,6 +927,11 @@ func (o *Overrides) MaxLineSizeTruncate(userID string) bool {
 // MaxLineSizeTruncateIdentifier returns whether lines longer than max should be truncated.
 func (o *Overrides) MaxLineSizeTruncateIdentifier(userID string) string {
 	return o.getOverridesForUser(userID).MaxLineSizeTruncateIdentifier
+}
+
+// MaxPushSize returns the maximum size of a push request.
+func (o *Overrides) MaxPushSize(userID string) int {
+	return o.getOverridesForUser(userID).MaxPushSize.Val()
 }
 
 // MaxEntriesLimitPerQuery returns the limit to number of entries the querier should return per query.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a per-tenant override for `max-push-size`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
