### PR TITLE
feat(logql): Evaluate CountDistinctSketchExpr as mergeable HLL sketches

### DIFF
--- a/pkg/logql/approx_count_distinct.go
+++ b/pkg/logql/approx_count_distinct.go
@@ -1,36 +1,179 @@
 package logql
 
 import (
+	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
+	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
+
+const (
+	CountDistinctVectorType = "CountDistinctVector"
+	CountDistinctMatrixType = "CountDistinctMatrix"
+)
+
+// CountDistinctVector is a list of HyperLogLog sketches keyed by metric labels.
+type CountDistinctVector []CountDistinctSample
+
+// CountDistinctMatrix is one CountDistinctVector per evaluation step.
+type CountDistinctMatrix []CountDistinctVector
+
+// CountDistinctSample is one HyperLogLog sketch keyed by metric labels.
+type CountDistinctSample struct {
+	T      int64
+	F      *hyperloglog.Sketch
+	Metric labels.Labels
+}
+
+var countDistinctKeyPool = sync.Pool{
+	New: func() interface{} { return make(map[string]int) },
+}
+
+// Merge unions sketches that share exact grouping labels.
+func (v CountDistinctVector) Merge(right CountDistinctVector) (CountDistinctVector, error) {
+	groups := countDistinctKeyPool.Get().(map[string]int)
+	defer func() {
+		clear(groups)
+		countDistinctKeyPool.Put(groups)
+	}()
+	for i, sample := range v {
+		groups[sample.Metric.String()] = i
+	}
+
+	for _, sample := range right {
+		key := sample.Metric.String()
+		i, ok := groups[key]
+		if !ok {
+			groups[key] = len(v)
+			v = append(v, sample)
+			continue
+		}
+		if err := v[i].F.Merge(sample.F); err != nil {
+			return v, err
+		}
+	}
+	return v, nil
+}
+
+func (CountDistinctVector) SampleVector() promql.Vector {
+	return promql.Vector{}
+}
+
+func (CountDistinctVector) QuantileSketchVec() ProbabilisticQuantileVector {
+	return ProbabilisticQuantileVector{}
+}
+
+func (CountDistinctVector) CountMinSketchVec() CountMinSketchVector {
+	return CountMinSketchVector{}
+}
+
+func (v CountDistinctVector) CountDistinctVec() CountDistinctVector {
+	return v
+}
+
+func (CountDistinctVector) String() string {
+	return "CountDistinctVector()"
+}
+
+func (CountDistinctVector) Type() promql_parser.ValueType { return CountDistinctVectorType }
+
+func (CountDistinctMatrix) String() string {
+	return "CountDistinctMatrix()"
+}
+
+func (CountDistinctMatrix) Type() promql_parser.ValueType { return CountDistinctMatrixType }
+
+// Merge unions each step's sketches. Lengths must match so the same evaluation
+// time is never combined with another.
+func (m CountDistinctMatrix) Merge(right CountDistinctMatrix) (CountDistinctMatrix, error) {
+	if len(m) != len(right) {
+		return nil, fmt.Errorf("failed to merge count distinct matrix: lengths differ %d!=%d", len(m), len(right))
+	}
+	var err error
+	for i, vec := range m {
+		m[i], err = vec.Merge(right[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge count distinct matrix: %w", err)
+		}
+	}
+	return m, nil
+}
+
+// Estimate converts sketches into a numeric sample vector.
+func (v CountDistinctVector) Estimate() SampleVector {
+	out := make(promql.Vector, 0, len(v))
+	for _, sample := range v {
+		out = append(out, promql.Sample{
+			T:      sample.T,
+			F:      float64(sample.F.Estimate()),
+			Metric: sample.Metric,
+		})
+	}
+	return SampleVector(out)
+}
+
+// JoinCountDistinctVector joins step sketches into a CountDistinctMatrix.
+func JoinCountDistinctVector(next bool, r StepResult, stepEvaluator StepEvaluator, params Params) (promql_parser.Value, error) {
+	vec := r.CountDistinctVec()
+	if stepEvaluator.Error() != nil {
+		return nil, stepEvaluator.Error()
+	}
+
+	if GetRangeType(params) == InstantType {
+		return CountDistinctMatrix{vec}, nil
+	}
+
+	stepCount := int(math.Ceil(float64(params.End().Sub(params.Start()).Nanoseconds()) / float64(params.Step().Nanoseconds())))
+	if stepCount <= 0 {
+		stepCount = 1
+	}
+
+	result := make(CountDistinctMatrix, 0, stepCount)
+	for next {
+		result = append(result, vec)
+		next, _, r = stepEvaluator.Next()
+		vec = r.CountDistinctVec()
+		if stepEvaluator.Error() != nil {
+			return nil, stepEvaluator.Error()
+		}
+	}
+
+	return result, stepEvaluator.Error()
+}
 
 func newCountDistinctStepEvaluator(
 	it iter.PeekingSampleIterator,
 	params Params,
 	interval, offset time.Duration,
+	emitSketch bool,
 ) StepEvaluator {
-	return &RangeVectorEvaluator{
-		iter: newCountDistinctIterator(
-			it,
-			interval.Nanoseconds(),
-			params.Step().Nanoseconds(),
-			params.Start().UnixNano(),
-			params.End().UnixNano(),
-			offset.Nanoseconds(),
-		),
+	iter := newCountDistinctIterator(
+		it,
+		interval.Nanoseconds(),
+		params.Step().Nanoseconds(),
+		params.Start().UnixNano(),
+		params.End().UnixNano(),
+		offset.Nanoseconds(),
+		emitSketch,
+	)
+	if emitSketch {
+		return &countDistinctSketchEvaluator{iter: iter}
 	}
+	return &RangeVectorEvaluator{iter: iter}
 }
 
 func newCountDistinctIterator(
 	it iter.PeekingSampleIterator,
 	selRange, step, start, end, offset int64,
+	emitSketch bool,
 ) RangeVectorIterator {
 	// forces at least one step.
 	if step == 0 {
@@ -52,23 +195,36 @@ func newCountDistinctIterator(
 			current:  start - step, // first loop iteration will set it to start
 			offset:   offset,
 		},
+		emitSketch: emitSketch,
 	}
 }
 
 type countDistinctBatchRangeVectorIterator struct {
 	*batchRangeVectorIterator
+	emitSketch bool
 }
 
 func (r *countDistinctBatchRangeVectorIterator) At() (int64, StepResult) {
+	// convert ts from nano to milli seconds as the iterator work with nanoseconds
+	ts := r.current/1e+6 + r.offset/1e+6
+	if r.emitSketch {
+		at := make(CountDistinctVector, 0, len(r.window))
+		for _, series := range r.window {
+			at = append(at, CountDistinctSample{
+				F:      countDistinctSketch(series.Floats),
+				T:      ts,
+				Metric: series.Metric,
+			})
+		}
+		return ts, at
+	}
 	if r.at == nil {
 		r.at = make([]promql.Sample, 0, len(r.window))
 	}
 	r.at = r.at[:0]
-	// convert ts from nano to milli seconds as the iterator work with nanoseconds
-	ts := r.current/1e+6 + r.offset/1e+6
 	for _, series := range r.window {
 		r.at = append(r.at, promql.Sample{
-			F:      countDistinctEstimate(series.Floats),
+			F:      float64(countDistinctSketch(series.Floats).Estimate()),
 			T:      ts,
 			Metric: series.Metric,
 		})
@@ -76,10 +232,46 @@ func (r *countDistinctBatchRangeVectorIterator) At() (int64, StepResult) {
 	return ts, SampleVector(r.at)
 }
 
-func countDistinctEstimate(samples []promql.FPoint) float64 {
+func countDistinctSketch(samples []promql.FPoint) *hyperloglog.Sketch {
 	hll := hyperloglog.New14()
 	for _, sample := range samples {
 		hll.InsertHash(math.Float64bits(sample.F))
 	}
-	return float64(hll.Estimate())
+	return hll
+}
+
+// countDistinctSketchEvaluator is RangeVectorEvaluator for HLL sketches.
+// SampleVector is empty on that StepResult, so pipeline errors are checked here.
+type countDistinctSketchEvaluator struct {
+	iter RangeVectorIterator
+	err  error
+}
+
+func (e *countDistinctSketchEvaluator) Next() (bool, int64, StepResult) {
+	next := e.iter.Next()
+	if !next {
+		return false, 0, CountDistinctVector{}
+	}
+	ts, r := e.iter.At()
+	vec := r.CountDistinctVec()
+	for _, s := range vec {
+		if s.Metric.Has(logqlmodel.ErrorLabel) && s.Metric.Get(logqlmodel.PreserveErrorLabel) != trueString {
+			e.err = logqlmodel.NewPipelineErr(s.Metric)
+			return false, 0, CountDistinctVector{}
+		}
+	}
+	return true, ts, vec
+}
+
+func (e *countDistinctSketchEvaluator) Close() error { return e.iter.Close() }
+
+func (e *countDistinctSketchEvaluator) Error() error {
+	if e.err != nil {
+		return e.err
+	}
+	return e.iter.Error()
+}
+
+func (e *countDistinctSketchEvaluator) Explain(parent Node) {
+	parent.Child("CountDistinct")
 }

--- a/pkg/logql/approx_count_distinct_test.go
+++ b/pkg/logql/approx_count_distinct_test.go
@@ -5,13 +5,78 @@ import (
 	"testing"
 	"time"
 
+	"github.com/axiomhq/hyperloglog"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
+
+func TestCountDistinctVectorMerge(t *testing.T) {
+	left := CountDistinctVector{
+		{
+			T:      1,
+			F:      hyperloglog.New14(),
+			Metric: labels.FromStrings("version", "1"),
+		},
+	}
+	left[0].F.Insert([]byte("a"))
+	left[0].F.Insert([]byte("b"))
+
+	right := CountDistinctVector{
+		{
+			T:      1,
+			F:      hyperloglog.New14(),
+			Metric: labels.FromStrings("version", "1"),
+		},
+		{
+			T:      1,
+			F:      hyperloglog.New14(),
+			Metric: labels.FromStrings("version", "2"),
+		},
+	}
+	right[0].F.Insert([]byte("b"))
+	right[0].F.Insert([]byte("c"))
+	right[1].F.Insert([]byte("x"))
+
+	merged, err := left.Merge(right)
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+
+	byVersion := map[string]uint64{}
+	for _, sample := range merged {
+		byVersion[sample.Metric.Get("version")] = sample.F.Estimate()
+	}
+	require.Equal(t, uint64(3), byVersion["1"])
+	require.Equal(t, uint64(1), byVersion["2"])
+}
+
+func TestCountDistinctMatrixMerge(t *testing.T) {
+	left := CountDistinctMatrix{
+		{{T: 1, F: hyperloglog.New14(), Metric: labels.FromStrings("version", "1")}},
+		{{T: 2, F: hyperloglog.New14(), Metric: labels.FromStrings("version", "1")}},
+	}
+	left[0][0].F.Insert([]byte("a"))
+	left[1][0].F.Insert([]byte("b"))
+
+	right := CountDistinctMatrix{
+		{{T: 1, F: hyperloglog.New14(), Metric: labels.FromStrings("version", "1")}},
+		{{T: 2, F: hyperloglog.New14(), Metric: labels.FromStrings("version", "1")}},
+	}
+	right[0][0].F.Insert([]byte("c"))
+	right[1][0].F.Insert([]byte("b"))
+
+	merged, err := left.Merge(right)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), merged[0][0].F.Estimate())
+	require.Equal(t, uint64(1), merged[1][0].F.Estimate())
+
+	_, err = left.Merge(CountDistinctMatrix{left[0]})
+	require.Error(t, err)
+}
 
 func TestApproxCountDistinctEval(t *testing.T) {
 	start := time.Unix(100, 0)
@@ -209,4 +274,89 @@ func TestApproxCountDistinctBoundaries(t *testing.T) {
 	vec := res.Data.(promql.Vector)
 	require.Len(t, vec, 1)
 	require.InDelta(t, 2, vec[0].F, 0.01)
+}
+
+func TestCountDistinctSketchExprReturnsSketches(t *testing.T) {
+	now := time.Unix(100, 0)
+	streams := []logproto.Stream{
+		{
+			Labels: `{job="devices", version="1"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: now.Add(-10 * time.Second), Line: `mac="aa:bb"`},
+			},
+		},
+	}
+
+	q := NewMockQuerier(1, streams)
+	params, err := NewLiteralParams(
+		`approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
+		now, now, 0, 0, logproto.FORWARD, 1000, nil, nil,
+	)
+	require.NoError(t, err)
+
+	parsed, ok := params.GetExpression().(*syntax.LabelAggregationExpr)
+	require.True(t, ok)
+	sketch := syntax.NewCountDistinctSketchFromLabelAggregation(parsed)
+
+	ev := NewDefaultEvaluator(q, 5*time.Minute, 10_000)
+	sketchParams := ParamsWithExpressionOverride{
+		Params:             params,
+		ExpressionOverride: sketch,
+	}
+	step, err := ev.NewStepEvaluator(user.InjectOrgID(context.Background(), "fake"), ev, sketch, sketchParams)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = step.Close() })
+	okNext, _, result := step.Next()
+	require.True(t, okNext)
+	sketches := result.CountDistinctVec()
+	require.Len(t, sketches, 1)
+	require.Equal(t, uint64(1), sketches[0].F.Estimate())
+}
+
+func TestCountDistinctSketchExprRangeSteps(t *testing.T) {
+	start := time.Unix(100, 0)
+	end := start.Add(60 * time.Second)
+	step := 30 * time.Second
+	streams := []logproto.Stream{
+		{
+			Labels: `{job="devices", version="1"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: start.Add(-50 * time.Second), Line: `mac="early"`},
+				{Timestamp: start.Add(-10 * time.Second), Line: `mac="mid"`},
+				{Timestamp: start.Add(40 * time.Second), Line: `mac="late"`},
+			},
+		},
+	}
+
+	q := NewMockQuerier(1, streams)
+	params, err := NewLiteralParams(
+		`approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
+		start, end, step, 0, logproto.FORWARD, 1000, nil, nil,
+	)
+	require.NoError(t, err)
+
+	parsed, ok := params.GetExpression().(*syntax.LabelAggregationExpr)
+	require.True(t, ok)
+	sketch := syntax.NewCountDistinctSketchFromLabelAggregation(parsed)
+
+	ev := NewDefaultEvaluator(q, 5*time.Minute, 10_000)
+	sketchParams := ParamsWithExpressionOverride{
+		Params:             params,
+		ExpressionOverride: sketch,
+	}
+	stepEv, err := ev.NewStepEvaluator(user.InjectOrgID(context.Background(), "fake"), ev, sketch, sketchParams)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stepEv.Close() })
+
+	var estimates []uint64
+	for {
+		okNext, _, result := stepEv.Next()
+		if !okNext {
+			break
+		}
+		sketches := result.CountDistinctVec()
+		require.Len(t, sketches, 1)
+		estimates = append(estimates, sketches[0].F.Estimate())
+	}
+	require.Equal(t, []uint64{2, 1, 1}, estimates)
 }

--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -48,6 +48,10 @@ func (v CountMinSketchVector) CountMinSketchVec() CountMinSketchVector {
 	return v
 }
 
+func (CountMinSketchVector) CountDistinctVec() CountDistinctVector {
+	return CountDistinctVector{}
+}
+
 func (v *CountMinSketchVector) Merge(right *CountMinSketchVector) (*CountMinSketchVector, error) {
 	// The underlying CMS implementation already merges the HLL sketches that are part of that structure.
 	err := v.F.Merge(right.F)

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -412,6 +412,8 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 			return JoinCountMinSketchVector(next, vec, stepEvaluator, q.params)
 		case HeapCountMinSketchVector:
 			return JoinCountMinSketchVector(next, vec.CountMinSketchVector, stepEvaluator, q.params)
+		case CountDistinctVector:
+			return JoinCountDistinctVector(next, vec, stepEvaluator, q.params)
 		default:
 			return nil, fmt.Errorf("unsupported result type: %T", r)
 		}

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -339,6 +339,10 @@ func (s *storeSampleResult) CountMinSketchVec() CountMinSketchVector {
 	return CountMinSketchVector{}
 }
 
+func (s *storeSampleResult) CountDistinctVec() CountDistinctVector {
+	return CountDistinctVector{}
+}
+
 type statsQuerier struct{}
 
 func (statsQuerier) SelectLogs(ctx context.Context, _ SelectLogParams) (iter.EntryIterator, error) {

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -376,22 +376,9 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 		}
 		return newRangeAggEvaluator(iter.NewPeekingSampleIterator(it), e, q, e.Left.Offset)
 	case *syntax.LabelAggregationExpr:
-		it, err := ev.querier.SelectSamples(ctx, SelectSampleParams{
-			&logproto.SampleQueryRequest{
-				Start:    q.Start().Add(-e.Left.Interval).Add(-e.Left.Offset),
-				End:      q.End().Add(-e.Left.Offset).Add(time.Nanosecond),
-				Selector: e.String(),
-				Shards:   q.Shards(),
-				Plan: &plan.QueryPlan{
-					AST: expr,
-				},
-				StoreChunks: q.GetStoreChunks(),
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-		return newCountDistinctStepEvaluator(iter.NewPeekingSampleIterator(it), q, e.Left.Interval, e.Left.Offset), nil
+		return ev.newCountDistinctEvaluator(ctx, expr, e.String(), e.Left, q, false)
+	case *syntax.CountDistinctSketchExpr:
+		return ev.newCountDistinctEvaluator(ctx, expr, e.String(), e.Left, q, true)
 	case *syntax.BinOpExpr:
 		return newBinOpStepEvaluator(ctx, nextEvFactory, e, q)
 	case *syntax.LabelReplaceExpr:
@@ -405,6 +392,32 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 	default:
 		return nil, EvaluatorUnsupportedType(e, ev)
 	}
+}
+
+func (ev *DefaultEvaluator) newCountDistinctEvaluator(
+	ctx context.Context,
+	expr syntax.SampleExpr,
+	selector string,
+	left *syntax.LogRangeExpr,
+	q Params,
+	emitSketch bool,
+) (StepEvaluator, error) {
+	it, err := ev.querier.SelectSamples(ctx, SelectSampleParams{
+		&logproto.SampleQueryRequest{
+			Start:    q.Start().Add(-left.Interval).Add(-left.Offset),
+			End:      q.End().Add(-left.Offset).Add(time.Nanosecond),
+			Selector: selector,
+			Shards:   q.Shards(),
+			Plan: &plan.QueryPlan{
+				AST: expr,
+			},
+			StoreChunks: q.GetStoreChunks(),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newCountDistinctStepEvaluator(iter.NewPeekingSampleIterator(it), q, left.Interval, left.Offset, emitSketch), nil
 }
 
 func newVectorAggEvaluator(

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -68,6 +68,10 @@ func (ProbabilisticQuantileVector) CountMinSketchVec() CountMinSketchVector {
 	return CountMinSketchVector{}
 }
 
+func (ProbabilisticQuantileVector) CountDistinctVec() CountDistinctVector {
+	return CountDistinctVector{}
+}
+
 func (q ProbabilisticQuantileVector) ToProto() *logproto.QuantileSketchVector {
 	samples := make([]*logproto.QuantileSketchSample, len(q))
 	for i, sample := range q {

--- a/pkg/logql/step_evaluator.go
+++ b/pkg/logql/step_evaluator.go
@@ -8,6 +8,7 @@ type StepResult interface {
 	SampleVector() promql.Vector
 	QuantileSketchVec() ProbabilisticQuantileVector
 	CountMinSketchVec() CountMinSketchVector
+	CountDistinctVec() CountDistinctVector
 }
 
 type SampleVector promql.Vector
@@ -24,6 +25,10 @@ func (p SampleVector) QuantileSketchVec() ProbabilisticQuantileVector {
 
 func (SampleVector) CountMinSketchVec() CountMinSketchVector {
 	return CountMinSketchVector{}
+}
+
+func (SampleVector) CountDistinctVec() CountDistinctVector {
+	return CountDistinctVector{}
 }
 
 // StepEvaluator evaluate a single step of a query.


### PR DESCRIPTION
## Summary

Third slice of experimental LogQL `approx_count_distinct` (grafana/loki-private#2769).

#24114 evaluates `LabelAggregationExpr` locally and returns HyperLogLog **estimates**. Shard children need the raw sketches, not those derived numbers.

This PR evaluates that internal expression as mergeable HLL sketches (precision 14). Sliding-window `At()` returns a `CountDistinctVector` of sketches keyed by `labels.String()`. Range steps join into a `CountDistinctMatrix`. Instant queries are a one-element matrix.

Public `/query` and `/query_range` are still unsharded and return estimates.

## How it wires to #24114

#24114 already has the sliding-window iterator and `Estimate()`. This PR adds `emitSketch` so the same iterator can emit HLLs on the upcoming sharded path, plus `countDistinctSketchEvaluator` (pipeline-error checks on sketch metrics), `JoinCountDistinctSketchSampleVector`, and `CountDistinctMatrix.Merge`.

## Roadmap

1. Syntax, AST, extractor — #24112
2. Local HLL estimates (instant + range) — #24114
3. **This PR** — evaluate `CountDistinctSketchExpr` as mergeable sketches
4. Shard mapper + protobuf transport of sketches — #24120
5. Feature gate + result-cache bypass
6. Docs

## What to check

- Public operator still returns estimates (instant + range, grouped + ungrouped).
- Direct `CountDistinctSketchExpr` eval returns mergeable HLLs, including range steps. Not publicly exposed yet.
- Matrix merge keys on exact `labels.String()`; step-length mismatch errors.

## Risks

Public `/query` and `/query_range` for `approx_count_distinct` still behave as in #24114.

`LabelAggregationExpr` still calls the evaluator with `emitSketch=false`. That path still returns a PromQL `SampleVector` of HyperLogLog estimates, and the engine still joins it with `JoinSampleVector`. Instant and range, grouped and ungrouped, are unchanged.

This PR only adds a second, internal path: `CountDistinctSketchExpr` (`emitSketch=true`) returns HLLs and `JoinCountDistinctVector`. Users cannot parse that operator; the mapper builds it. The public operator does not go through that join.

## Test plan

- [x] `go test ./pkg/logql/`