### PR TITLE
perf: Hold on to less memory by trimming results down to request limit

### DIFF
--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -132,7 +132,6 @@ func (h *splitByInterval) Process(
 	ch := h.Feed(ctx, input)
 
 	// queries with 0 limits should not be exited early
-	limit := threshold
 	unlimited := threshold == 0
 
 	// Parallelism will be at least 1
@@ -179,9 +178,9 @@ func (h *splitByInterval) Process(
 
 					// Each split still carries the original line limit, so holding
 					// every sub-response until a final merge is O(splits × limit).
-					// When the combined count exceeds the request limit, compact
-					// immediately so oversized splits can be GC'd.
-					if n, allLogs := lokiResponseCount(responses); allLogs && n > limit {
+					// Compact immediately so oversized splits can be GC'd and so a
+					// single already-merged result keeps stats.Splits accurate.
+					if allLokiResponses(responses) {
 						responses = []queryrangebase.Response{mergeLokiResponse(responses...)}
 					}
 
@@ -290,25 +289,22 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 	if err != nil {
 		return nil, err
 	}
-	// A single response is already complete. Re-merging it would call
-	// MergeSplit once more and reset stats.Splits to 1, which is wrong when
-	// Process already compacted several interval responses into one.
+	// A single response is already complete. Process compact-merges log
+	// early-exits (including a first interval that already filled the limit),
+	// so re-merging would call MergeSplit once more and reset stats.Splits to 1.
 	if len(resps) == 1 {
 		return resps[0], nil
 	}
 	return h.merger.MergeResponse(resps...)
 }
 
-func lokiResponseCount(responses []queryrangebase.Response) (int64, bool) {
-	var n int64
+func allLokiResponses(responses []queryrangebase.Response) bool {
 	for _, r := range responses {
-		lr, ok := r.(*LokiResponse)
-		if !ok {
-			return 0, false
+		if _, ok := r.(*LokiResponse); !ok {
+			return false
 		}
-		n += lr.Count()
 	}
-	return n, true
+	return true
 }
 
 // maxRangeVectorAndOffsetDurationFromQueryString

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -132,10 +132,8 @@ func (h *splitByInterval) Process(
 	ch := h.Feed(ctx, input)
 
 	// queries with 0 limits should not be exited early
-	var unlimited bool
-	if threshold == 0 {
-		unlimited = true
-	}
+	limit := threshold
+	unlimited := threshold == 0
 
 	// Parallelism will be at least 1
 	p := max(parallelism, 1)
@@ -175,6 +173,18 @@ func (h *splitByInterval) Process(
 				threshold -= casted.Count()
 
 				if threshold <= 0 {
+					// Stop in-flight splits before compacting; merge can take
+					// long enough that the next interval would otherwise start.
+					cancel(errors.New("split by interval process canceled"))
+
+					// Each split still carries the original line limit, so holding
+					// every sub-response until a final merge is O(splits × limit).
+					// When the combined count exceeds the request limit, compact
+					// immediately so oversized splits can be GC'd.
+					if n, allLogs := lokiResponseCount(responses); allLogs && n > limit {
+						responses = []queryrangebase.Response{mergeLokiResponse(responses...)}
+					}
+
 					return responses, nil
 				}
 
@@ -280,7 +290,25 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 	if err != nil {
 		return nil, err
 	}
+	// A single response is already complete. Re-merging it would call
+	// MergeSplit once more and reset stats.Splits to 1, which is wrong when
+	// Process already compacted several interval responses into one.
+	if len(resps) == 1 {
+		return resps[0], nil
+	}
 	return h.merger.MergeResponse(resps...)
+}
+
+func lokiResponseCount(responses []queryrangebase.Response) (int64, bool) {
+	var n int64
+	for _, r := range responses {
+		lr, ok := r.(*LokiResponse)
+		if !ok {
+			return 0, false
+		}
+		n += lr.Count()
+	}
+	return n, true
 }
 
 // maxRangeVectorAndOffsetDurationFromQueryString

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
@@ -2052,6 +2052,71 @@ func Test_splitByInterval_Process_compactsOverLimit(t *testing.T) {
 			require.Equal(t, stats.Result{Summary: stats.Summary{Splits: 2}}, compacted.Statistics)
 			require.Equal(t, expectedEntries(direction), compacted.Data.Result[0].Entries)
 			require.Equal(t, int32(2), calls.Load())
+		})
+	}
+}
+
+func Test_splitByInterval_firstIntervalFillsLimit(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "1")
+	const perSplit = 3
+	const limit uint32 = 3
+	const intervals = 3
+
+	next := func(calls *atomic.Int32) queryrangebase.Handler {
+		return queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+			req := r.(*LokiRequest)
+			time.Sleep(time.Millisecond)
+			calls.Add(1)
+			return &LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: req.Direction,
+				Limit:     req.Limit,
+				Version:   uint32(loghttp.VersionV1),
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result: []logproto.Stream{
+						{
+							Labels:  `{foo="bar", level="debug"}`,
+							Entries: splitIntervalLogLines(req.StartTs, perSplit, req.Direction),
+						},
+					},
+				},
+			}, nil
+		})
+	}
+
+	for _, direction := range []logproto.Direction{logproto.FORWARD, logproto.BACKWARD} {
+		t.Run(direction.String(), func(t *testing.T) {
+			var calls atomic.Int32
+			split := SplitByIntervalMiddleware(
+				testSchemas,
+				WithSplitByLimits(fakeLimits{maxQueryParallelism: 1}, time.Hour),
+				DefaultCodec,
+				newDefaultSplitter(fakeLimits{}, nil),
+				nilMetrics,
+			).Wrap(next(&calls))
+
+			res, err := split.Do(ctx, &LokiRequest{
+				StartTs:   time.Unix(0, 0),
+				EndTs:     time.Unix(0, (time.Duration(intervals) * time.Hour).Nanoseconds()),
+				Query:     "",
+				Limit:     limit,
+				Step:      1,
+				Direction: direction,
+				Path:      "/api/prom/query_range",
+			})
+			require.NoError(t, err)
+
+			got := res.(*LokiResponse)
+			require.Equal(t, int64(limit), got.Count())
+			require.Equal(t, stats.Result{Summary: stats.Summary{Splits: 1}}, got.Statistics)
+			require.Equal(t, int32(1), calls.Load())
+
+			firstStart := time.Unix(0, 0)
+			if direction == logproto.BACKWARD {
+				firstStart = time.Unix(0, (2 * time.Hour).Nanoseconds())
+			}
+			require.Equal(t, splitIntervalLogLines(firstStart, perSplit, direction), got.Data.Result[0].Entries)
 		})
 	}
 }

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1926,6 +1927,133 @@ func Test_DoesntDeadlock(t *testing.T) {
 	// give runtime a bit of slack when catching up -- this isn't an exact science :(
 	// Allow for 1% increase in goroutines
 	require.LessOrEqual(t, endingGoroutines, startingGoroutines*101/100)
+}
+
+func splitIntervalLogLines(start time.Time, n int, direction logproto.Direction) []logproto.Entry {
+	entries := make([]logproto.Entry, n)
+	for i := 0; i < n; i++ {
+		offset := i
+		if direction == logproto.BACKWARD {
+			offset = n - 1 - i
+		}
+		ts := start.Add(time.Duration(offset) * time.Second)
+		entries[i] = logproto.Entry{
+			Timestamp: ts,
+			Line:      strconv.FormatInt(ts.UnixNano(), 10),
+		}
+	}
+	return entries
+}
+
+func Test_splitByInterval_Process_compactsOverLimit(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "1")
+	const perSplit = 3
+	const limit uint32 = 4
+	const intervals = 3
+
+	next := func(calls *atomic.Int32) queryrangebase.Handler {
+		return queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+			req := r.(*LokiRequest)
+			time.Sleep(time.Millisecond) // match Test_ExitEarly: keep unused splits from starting
+			calls.Add(1)
+			return &LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: req.Direction,
+				Limit:     req.Limit,
+				Version:   uint32(loghttp.VersionV1),
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result: []logproto.Stream{
+						{
+							Labels:  `{foo="bar", level="debug"}`,
+							Entries: splitIntervalLogLines(req.StartTs, perSplit, req.Direction),
+						},
+					},
+				},
+			}, nil
+		})
+	}
+
+	expectedEntries := func(direction logproto.Direction) []logproto.Entry {
+		if direction == logproto.FORWARD {
+			return append(
+				splitIntervalLogLines(time.Unix(0, 0), perSplit, direction),
+				splitIntervalLogLines(time.Unix(0, time.Hour.Nanoseconds()), 1, direction)...,
+			)
+		}
+		newest := time.Unix(0, (2 * time.Hour).Nanoseconds())
+		return append(
+			splitIntervalLogLines(newest, perSplit, direction),
+			splitIntervalLogLines(time.Unix(0, time.Hour.Nanoseconds()), perSplit, direction)[0],
+		)
+	}
+
+	for _, direction := range []logproto.Direction{logproto.FORWARD, logproto.BACKWARD} {
+		t.Run(direction.String()+"/Do", func(t *testing.T) {
+			var calls atomic.Int32
+			split := SplitByIntervalMiddleware(
+				testSchemas,
+				WithSplitByLimits(fakeLimits{maxQueryParallelism: 1}, time.Hour),
+				DefaultCodec,
+				newDefaultSplitter(fakeLimits{}, nil),
+				nilMetrics,
+			).Wrap(next(&calls))
+
+			res, err := split.Do(ctx, &LokiRequest{
+				StartTs:   time.Unix(0, 0),
+				EndTs:     time.Unix(0, (time.Duration(intervals) * time.Hour).Nanoseconds()),
+				Query:     "",
+				Limit:     limit,
+				Step:      1,
+				Direction: direction,
+				Path:      "/api/prom/query_range",
+			})
+			require.NoError(t, err)
+
+			got := res.(*LokiResponse)
+			require.Equal(t, int64(limit), got.Count())
+			require.Equal(t, stats.Result{Summary: stats.Summary{Splits: 2}}, got.Statistics)
+			require.Equal(t, expectedEntries(direction), got.Data.Result[0].Entries)
+			require.Equal(t, int32(2), calls.Load())
+		})
+
+		t.Run(direction.String()+"/Process", func(t *testing.T) {
+			var calls atomic.Int32
+			h := &splitByInterval{next: next(&calls)}
+
+			input := make([]*lokiResult, 0, intervals)
+			for i := 0; i < intervals; i++ {
+				start := time.Unix(0, (time.Duration(i) * time.Hour).Nanoseconds())
+				input = append(input, &lokiResult{
+					req: &LokiRequest{
+						StartTs:   start,
+						EndTs:     start.Add(time.Hour),
+						Query:     "",
+						Limit:     limit,
+						Step:      1,
+						Direction: direction,
+						Path:      "/api/prom/query_range",
+					},
+					ch: make(chan *packedResp),
+				})
+			}
+			if direction == logproto.BACKWARD {
+				for i, j := 0, len(input)-1; i < j; i, j = i+1, j-1 {
+					input[i], input[j] = input[j], input[i]
+				}
+			}
+
+			resps, err := h.Process(ctx, 1, int64(limit), input, 0)
+			require.NoError(t, err)
+			require.Len(t, resps, 1)
+			compacted, ok := resps[0].(*LokiResponse)
+			require.True(t, ok)
+			require.Equal(t, int64(limit), compacted.Count())
+			require.Equal(t, stats.Result{Summary: stats.Summary{Splits: 2}}, compacted.Statistics)
+			require.Equal(t, expectedEntries(direction), compacted.Data.Result[0].Entries)
+			require.Equal(t, int32(2), calls.Load())
+		})
+	}
 }
 
 func assertSplits(t *testing.T, want, splits []queryrangebase.Request) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Query-frontend split-by-interval was keeping every log sub-response until a final merge. Each split still carries the original line limit, so peak memory was O(splits × limit) and large limited queries could OOM the frontend.
`Process` now compact-merges as soon as accumulated lines exceed the request limit, using the existing `mergeLokiResponse` / `mergeOrderedNonOverlappingStreams` path, and replaces the pending slice with that single trimmed result. In-flight splits are cancelled before the merge so extra intervals do not start while compacting.
`Do()` returns a single already-compacted response as-is. Re-merging it would call `MergeSplit` again and reset `stats.Splits` to 1.
Metric, series, and volume queries are unchanged (`limit == 0` still skips early exit). When the total lands exactly on the limit, behavior matches before: no compact, `Do()` merges as usual.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
