### PR TITLE
chore(dashboard): Add more metrics to `Loki / Writes Resources`

### DIFF
--- a/production/loki-mixin-compiled/dashboards/loki-reads-resources.json
+++ b/production/loki-mixin-compiled/dashboards/loki-reads-resources.json
@@ -64,9 +64,9 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-frontend\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-frontend\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "pods",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
@@ -89,6 +89,7 @@
                               "mode": "none"
                            }
                         },
+                        "noValue": "No OOMs observed in time period 🎉",
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
@@ -360,13 +361,13 @@
                   "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },
@@ -422,9 +423,9 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-scheduler\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-scheduler\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "pods",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
@@ -447,6 +448,7 @@
                               "mode": "none"
                            }
                         },
+                        "noValue": "No OOMs observed in time period 🎉",
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
@@ -718,13 +720,13 @@
                   "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-scheduler\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-scheduler\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },
@@ -780,9 +782,9 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "pods",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
@@ -805,6 +807,7 @@
                               "mode": "none"
                            }
                         },
+                        "noValue": "No OOMs observed in time period 🎉",
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
@@ -1076,13 +1079,13 @@
                   "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/querier\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/querier\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },
@@ -1279,9 +1282,9 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "pods",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
@@ -1304,6 +1307,7 @@
                               "mode": "none"
                            }
                         },
+                        "noValue": "No OOMs observed in time period 🎉",
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
@@ -1575,13 +1579,13 @@
                   "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/index-gateway\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/index-gateway\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },
@@ -1778,9 +1782,9 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "pods",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
@@ -1803,6 +1807,7 @@
                               "mode": "none"
                            }
                         },
+                        "noValue": "No OOMs observed in time period 🎉",
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
@@ -2074,13 +2079,13 @@
                   "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/bloom-gateway\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/bloom-gateway\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },
@@ -2277,9 +2282,9 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "pods",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
@@ -2302,6 +2307,7 @@
                               "mode": "none"
                            }
                         },
+                        "noValue": "No OOMs observed in time period 🎉",
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
@@ -2573,13 +2579,13 @@
                   "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/(.*ingester|partition-ingester).*\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/(.*ingester|partition-ingester).*\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },
@@ -2635,9 +2641,9 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "pods",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
@@ -2660,6 +2666,7 @@
                               "mode": "none"
                            }
                         },
+                        "noValue": "No OOMs observed in time period 🎉",
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
@@ -2931,13 +2938,13 @@
                   "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/ruler\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/ruler\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },

--- a/production/loki-mixin-compiled/dashboards/loki-writes-resources.json
+++ b/production/loki-mixin-compiled/dashboards/loki-writes-resources.json
@@ -48,6 +48,101 @@
                         },
                         "unit": "short"
                      },
+                     "overrides": [ ]
+                  },
+                  "id": 1,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"distributor\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
+                        "format": "time_series",
+                        "legendFormat": "{{job}}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "noValue": "No OOMs observed in time period 🎉",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 2,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"distributor\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=\"distributor\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -89,7 +184,7 @@
                         }
                      ]
                   },
-                  "id": 1,
+                  "id": 3,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -190,7 +285,7 @@
                         }
                      ]
                   },
-                  "id": 2,
+                  "id": 4,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -201,7 +296,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"distributor\"})",
@@ -252,7 +347,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 3,
+                  "id": 5,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -263,16 +358,16 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/distributor\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
                   "tooltip": {
                      "sort": 2
                   },
@@ -314,7 +409,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 4,
+                  "id": 6,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -325,19 +420,64 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (loki_ingester_memory_streams{cluster=~\"$cluster\", job=~\"($namespace)/(.*ingester.*)\"})",
+                        "expr": "label_replace(count by (job) (up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"}), \"job\", \"$1\", \"job\", \".*/(.*)\")",
                         "format": "time_series",
-                        "legendFormat": "{{pod}}",
+                        "legendFormat": "{{job}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "In-memory streams",
-                  "tooltip": {
-                     "sort": 2
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "noValue": "No OOMs observed in time period 🎉",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
                   },
+                  "id": 7,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=~\"ingester|partition-ingester\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
                   "type": "timeseries"
                },
                {
@@ -403,7 +543,7 @@
                         }
                      ]
                   },
-                  "id": 5,
+                  "id": 8,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -414,7 +554,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"}[$__rate_interval]))",
@@ -504,7 +644,7 @@
                         }
                      ]
                   },
-                  "id": 6,
+                  "id": 9,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -515,7 +655,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"})",
@@ -566,7 +706,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 7,
+                  "id": 10,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -577,16 +717,66 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 6,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/(.*ingester.*)\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", job=~\"($namespace)/(.*ingester.*)\"})",
                         "format": "time_series",
                         "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Memory (go heap inuse)",
+                  "title": "Memory (go heap alloc)",
+                  "tooltip": {
+                     "sort": 2
+                  },
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 11,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by(pod) (loki_ingester_memory_streams{cluster=~\"$cluster\", job=~\"($namespace)/(.*ingester.*)\"})",
+                        "format": "time_series",
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "In-memory streams",
                   "tooltip": {
                      "sort": 2
                   },
@@ -616,7 +806,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 8,
+                  "id": 12,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -627,10 +817,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 3,
                   "targets": [
                      {
-                        "expr": "sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -663,7 +853,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 9,
+                  "id": 13,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -674,10 +864,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 3,
                   "targets": [
                      {
-                        "expr": "sum by(instance, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -710,7 +900,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 10,
+                  "id": 14,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -721,7 +911,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 1,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*(.*ingester.*).*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*(.*ingester.*).*\"})",

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -82,19 +82,5 @@
     // Enable panels that depend on autoscaler metrics
     // (loki_autoscaler_min_replicas / loki_autoscaler_max_replicas).
     autoscaling_metrics: false,
-    // Per-component autoscaling status.
-    // Only consulted when autoscaling_metrics is true.
-    // If true, min and max replicas for the component are shown.
-    // If false, a panel that says "not autoscaled" is shown instead.
-    autoscaled: {
-      gateway: false,  // only when internal_components=true
-      query_frontend: false,
-      query_scheduler: false,
-      querier: false,
-      index_gateway: false,
-      bloom_gateway: false,
-      ingester: false,
-      ruler: false,
-    },
   },
 }

--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -227,6 +227,22 @@ local utils = import 'mixin-utils/utils.libsonnet';
       tooltip: { sort: 2 },  // Sort descending.
     },
 
+  // Live heap objects, i.e. memory actually in use by the application.
+  // Prefer this over goHeapInUsePanel: heap_inuse_bytes counts whole spans the
+  // allocator has reserved, so it also includes allocator overhead and
+  // fragmentation within partially used spans. heap_alloc_bytes is "memory we
+  // actually use"; heap_inuse_bytes is "memory the Go runtime holds for current
+  // and future allocations".
+  goHeapAllocPanel(title, jobName)::
+    $.newQueryPanel(title, 'bytes') +
+    $.queryPanel(
+      'sum by(%s) (go_memstats_heap_alloc_bytes{%s})' % [$._config.per_instance_label, $.jobMatcher(jobName)],
+      '{{%s}}' % $._config.per_instance_label
+    ) +
+    {
+      tooltip: { sort: 2 },  // Sort descending.
+    },
+
   filterNodeDisk(matcher)::
     |||
       ignoring(%s) group_right() (label_replace(count by(%s, %s, device) (container_fs_writes_bytes_total{%s, %s, device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
@@ -348,4 +364,168 @@ local utils = import 'mixin-utils/utils.libsonnet';
   p99LatencyByPod(metric, selectorStr)::
     $.newQueryPanel('Per Pod Latency (p99)', 'ms') +
     latencyPanelWithExtraGrouping(metric, selectorStr, '1e3', 'pod'),
+
+  //
+  // Shared building blocks for the "Resources" dashboards.
+  //
+
+  // Regex matching the "type" label on the loki_autoscaler_* metrics, per
+  // component. Follows the naming convention emitted by the loki-autoscaler
+  // exporter.
+  autoscalerType:: {
+    gateway: 'cortex_gateway(_internal)?',
+    distributor: 'distributor',
+    query_frontend: 'query-frontend',
+    query_scheduler: 'query-scheduler',
+    querier: 'querier',
+    index_gateway: 'index-gateway',
+    bloom_gateway: 'bloom-gateway',
+    ingester: '(partition-)?ingester',
+    ruler: 'ruler',
+  },
+
+  // withNoValue replaces the "No data" a panel renders when its query
+  // returns nothing with a custom message.
+  withNoValue(text):: {
+    fieldConfig+: {
+      defaults+: {
+        noValue: text,
+      },
+    },
+  },
+
+  oomKilledPanel(matcher)::
+    $.newQueryPanel('OOMs') +
+    $.queryPanel(
+      |||
+        sum(
+          increase(kube_pod_container_status_restarts_total{%(ns)s, %(m)s}[$__rate_interval]) > 0
+          and on(pod)
+          kube_pod_container_status_last_terminated_reason{%(m)s, reason="OOMKilled"} == 1
+        )
+      ||| % { ns: $.namespaceMatcher(), m: matcher },
+      'OOMs'
+    ) +
+    $.withNoValue('No OOMs observed in time period 🎉'),
+
+  // Grouped by job rather than summed, so that zone-replicated components
+  // report one series per zone. The partition ingesters, for example, run each
+  // zone as its own StatefulSet but export a single per-zone min/max replicas
+  // series, so a summed pod count compares N zones of pods against one zone's
+  // limit. Grouping keeps both panels in the same units, and surfaces any
+  // imbalance between zones.
+  // The job label carries a "<namespace>/" prefix that is redundant here (the
+  // namespace is already a dashboard variable), so strip it for the legend.
+  // Series whose job has no prefix are left untouched by label_replace.
+  runningPodsPanel(matcher)::
+    $.newQueryPanel('Running Pods') +
+    $.queryPanel(
+      'label_replace(count by (%(job)s) (up{%(ns)s, %(m)s}), "%(job)s", "$1", "%(job)s", ".*/(.*)")' % {
+        job: $._config.per_job_label,
+        ns: $.namespaceMatcher(),
+        m: matcher,
+      },
+      '{{%s}}' % $._config.per_job_label
+    ),
+
+  minReplicasPanel(component)::
+    $.panel('Min Replicas') +
+    $.newStatPanel(
+      'sum(loki_autoscaler_min_replicas{%s, type=~"%s"})' % [$.namespaceMatcher(), $.autoscalerType[component]],
+      unit='short',
+      decimals=0,
+      novalue='Not auto-scaled',
+    ),
+
+  maxReplicasPanel(component)::
+    $.panel('Max Replicas') +
+    $.newStatPanel(
+      'sum(loki_autoscaler_max_replicas{%s, type=~"%s"})' % [$.namespaceMatcher(), $.autoscalerType[component]],
+      unit='short',
+      decimals=0,
+      novalue='Not auto-scaled',
+    ),
+
+  // autoscalingPanels returns the leading Min/Max Replicas panels + spans for
+  // a component's row, or nothing at all when autoscaling_metrics is disabled.
+  //
+  // The panels are rendered whether or not the component is actually
+  // auto-scaled: when the autoscaler exports no metrics for it they display
+  // "Not auto-scaled" instead of a number, so there is no build-time list of
+  // auto-scaled components to keep in sync.
+  autoscalingPanels(component)::
+    if !$._config.autoscaling_metrics then
+      { panels: [], spans: [] }
+    else
+      {
+        panels: [$.minReplicasPanel(component), $.maxReplicasPanel(component)],
+        spans: [2, 2],
+      },
+
+  diskWritesPanel(matcher)::
+    $.newQueryPanel('Disk Writes', 'Bps') +
+    $.queryPanel(
+      'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(matcher)],
+      '{{%s}} - {{device}}' % $._config.per_instance_label
+    ) +
+    $.withStacking,
+
+  diskReadsPanel(matcher)::
+    $.newQueryPanel('Disk Reads', 'Bps') +
+    $.queryPanel(
+      'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(matcher)],
+      '{{%s}} - {{device}}' % $._config.per_instance_label
+    ) +
+    $.withStacking,
+
+  // componentRow builds a per-component row. Panels are packed onto 12-unit
+  // visual lines and wrap onto subsequent lines when the running total
+  // exceeds 12, letting a single (collapsible) row hold several visual lines.
+  // Layouts:
+  //   autoscaling_metrics off (OSS default):
+  //     Line 1: [RunningPods=4, OOMs=4, CPU=4]
+  //     Line 2: [Memory ws=6, Memory heap=6]
+  //   autoscaling_metrics on:
+  //     Line 1: [MinReplicas=2, MaxReplicas=2, RunningPods=4, CPU=4]
+  //     Line 2: [OOMs=4, Memory ws=4, Memory heap=4]
+  // trailingPanels/trailingSpans are appended after the core panels (e.g.
+  // Disk Writes/Reads/Space, Rules), and are expected to add up to 12.
+  componentRow(
+    title,
+    cpuPanel,
+    memoryPanel,
+    goHeapPanel,
+    runningPodsMatcher,
+    oomMatcher,
+    autoscalingComponent,
+    trailingPanels=[],
+    trailingSpans=[],
+  )::
+    local as = $.autoscalingPanels(autoscalingComponent);
+    local hasAS = std.length(as.panels) > 0;
+    local oomPanel = $.oomKilledPanel(oomMatcher);
+    local podsPanel = $.runningPodsPanel(runningPodsMatcher);
+    local corePanels =
+      if hasAS then
+        // Autoscaling-on layout: replicas/status on line 1 with RunningPods
+        // and CPU; OOMs + memory on line 2.
+        as.panels + [podsPanel, cpuPanel, oomPanel, memoryPanel, goHeapPanel]
+      else
+        // Autoscaling-off layout: RunningPods/OOMs/CPU on line 1; memory on
+        // line 2.
+        [podsPanel, oomPanel, cpuPanel, memoryPanel, goHeapPanel];
+    local coreSpans = if hasAS then as.spans + [4, 4, 4, 4, 4] else [4, 4, 4, 6, 6];
+    local spans = coreSpans + trailingSpans;
+    local row = std.foldl(
+      function(r, p) r.addPanel(p),
+      corePanels + trailingPanels,
+      $.row(title),
+    );
+    // Override the spans auto-assigned by addPanel() with our explicit list.
+    row {
+      panels: [
+        row.panels[i] { span: spans[i] }
+        for i in std.range(0, std.length(spans) - 1)
+      ],
+    },
 }

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -13,153 +13,6 @@
   then '(.*ingester.*|loki-single-binary)'
   else '(.*ingester|partition-ingester).*',
 
-  // Regex for the "type" label on the autoscaler metric, per component.
-  // Follows the naming convention emitted by the loki-autoscaler exporter.
-  local autoscaler_type = {
-    gateway: 'cortex_gateway(_internal)?',
-    query_frontend: 'query-frontend',
-    query_scheduler: 'query-scheduler',
-    querier: 'querier',
-    index_gateway: 'index-gateway',
-    bloom_gateway: 'bloom-gateway',
-    ingester: '(partition-)?ingester',
-    ruler: 'ruler',
-  },
-
-  local oomKilledPanel(matcher) =
-    $.newQueryPanel('OOMs') +
-    $.queryPanel(
-      |||
-        sum(
-          increase(kube_pod_container_status_restarts_total{%(ns)s, %(m)s}[$__rate_interval]) > 0
-          and on(pod)
-          kube_pod_container_status_last_terminated_reason{%(m)s, reason="OOMKilled"} == 1
-        )
-      ||| % { ns: $.namespaceMatcher(), m: matcher },
-      'OOMs'
-    ),
-
-  local runningPodsPanel(matcher) =
-    $.newQueryPanel('Running Pods') +
-    $.queryPanel(
-      'count(up{%s, %s})' % [$.namespaceMatcher(), matcher],
-      'pods'
-    ),
-
-  local minReplicasPanel(component) =
-    $.panel('Min Replicas') +
-    $.newStatPanel(
-      'sum(loki_autoscaler_min_replicas{%s, type=~"%s"})' % [$.namespaceMatcher(), autoscaler_type[component]],
-      unit='short',
-      decimals=0,
-    ),
-
-  local maxReplicasPanel(component) =
-    $.panel('Max Replicas') +
-    $.newStatPanel(
-      'sum(loki_autoscaler_max_replicas{%s, type=~"%s"})' % [$.namespaceMatcher(), autoscaler_type[component]],
-      unit='short',
-      decimals=0,
-    ),
-
-  local notAutoScaledPanel = {
-    type: 'text',
-    title: 'Autoscaling',
-    options: {
-      mode: 'markdown',
-      content: '### Not auto-scaled',
-    },
-  },
-
-  // Returns the leading panels + spans for a component's row:
-  // - Min/Max Replicas stats when autoscaling_metrics is enabled and the
-  //   component is flagged auto-scaled.
-  // - A "Not auto-scaled" text panel when autoscaling_metrics is enabled
-  //   but the component is flagged not auto-scaled.
-  // - Nothing when autoscaling_metrics is disabled.
-  local autoscalingPanels(component) =
-    if !$._config.autoscaling_metrics then { panels: [], spans: [] }
-    else if $._config.autoscaled[component] then {
-      panels: [minReplicasPanel(component), maxReplicasPanel(component)],
-      spans: [2, 2],
-    }
-    else { panels: [notAutoScaledPanel], spans: [4] },
-
-  local diskWritesPanel(matcher) =
-    $.newQueryPanel('Disk Writes', 'Bps') +
-    $.queryPanel(
-      'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(matcher)],
-      '{{%s}} - {{device}}' % $._config.per_instance_label
-    ) +
-    $.withStacking,
-
-  local diskReadsPanel(matcher) =
-    $.newQueryPanel('Disk Reads', 'Bps') +
-    $.queryPanel(
-      'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(matcher)],
-      '{{%s}} - {{device}}' % $._config.per_instance_label
-    ) +
-    $.withStacking,
-
-  // Override auto-distributed spans with an explicit list. Total span for
-  // each row is 12; sums > 12 wrap to a new visual line, letting a single
-  // (collapsible) row hold multiple visual lines of panels.
-  local withSpans(spans) = {
-    panels: [
-      super.panels[i] { span: spans[i] }
-      for i in std.range(0, std.length(spans) - 1)
-    ],
-  },
-
-  // addPanels chains .addPanel(p) for each panel in the list, returning
-  // the resulting row.
-  local addPanels(row, panels) =
-    std.foldl(function(r, p) r.addPanel(p), panels, row),
-
-  // componentRow builds a per-component row. Panels are packed onto
-  // 12-unit visual lines and wrap onto subsequent lines when the running
-  // total exceeds 12. Layouts:
-  //   autoscaling_metrics off (OSS default):
-  //     Line 1: [RunningPods=4, OOMs=4, CPU=4]
-  //     Line 2: [Memory ws=6, Memory heap=6]
-  //   autoscaling on, component auto-scaled:
-  //     Line 1: [MinReplicas=2, MaxReplicas=2, RunningPods=4, CPU=4]
-  //     Line 2: [OOMs=4, Memory ws=4, Memory heap=4]
-  //   autoscaling on, component not auto-scaled:
-  //     Line 1: [Not-auto-scaled=4, RunningPods=4, CPU=4]
-  //     Line 2: [OOMs=4, Memory ws=4, Memory heap=4]
-  // trailingPanels/trailingSpans are appended after the core panels
-  // (e.g. Disk Writes/Reads/Space, Rules).
-  local componentRow(title, cpuPanel, memoryPanel, goHeapPanel, runningPodsMatcher, oomMatcher, autoscalingComponent, trailingPanels=[], trailingSpans=[]) =
-    local as = autoscalingPanels(autoscalingComponent);
-    local hasAS = std.length(as.panels) > 0;
-    local corePanels =
-      if hasAS then
-        // Autoscaling-on layout: replicas/status on line 1 with RunningPods+CPU;
-        // OOMs + memory on line 2.
-        as.panels + [
-          runningPodsPanel(runningPodsMatcher),
-          cpuPanel,
-          oomKilledPanel(oomMatcher),
-          memoryPanel,
-          goHeapPanel,
-        ]
-      else
-        // Autoscaling-off layout: RunningPods/OOMs/CPU on line 1; memory on line 2.
-        [
-          runningPodsPanel(runningPodsMatcher),
-          oomKilledPanel(oomMatcher),
-          cpuPanel,
-          memoryPanel,
-          goHeapPanel,
-        ];
-    local coreSpans =
-      if hasAS then
-        as.spans + [4, 4, 4, 4, 4]
-      else
-        [4, 4, 4, 6, 6];
-    addPanels($.row(title), corePanels + trailingPanels) + withSpans(coreSpans + trailingSpans),
-
   grafanaDashboards+:: {
     'loki-reads-resources.json':
       ($.dashboard('Loki / Reads Resources', uid='reads-resources'))
@@ -170,11 +23,11 @@
       // --- Gateway ---
       .addRowIf(
         $._config.internal_components,
-        componentRow(
+        $.componentRow(
           'Gateway',
           $.containerCPUUsagePanel('CPU', 'cortex-gw(-internal)?'),
           $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw(-internal)?'),
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw(-internal)?'),
+          $.goHeapAllocPanel('Memory (go heap alloc)', 'cortex-gw(-internal)?'),
           'container=~"cortex-gw(-internal)?"',
           'container=~"cortex-gw(-internal)?"',
           'gateway'
@@ -182,95 +35,95 @@
       )
 
       // --- Query Frontend ---
-      .addRow(componentRow(
+      .addRow($.componentRow(
         'Query Frontend',
         $.containerCPUUsagePanel('CPU', 'query-frontend'),
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-frontend'),
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-frontend'),
+        $.goHeapAllocPanel('Memory (go heap alloc)', 'query-frontend'),
         'container="query-frontend"',
         'container="query-frontend"',
         'query_frontend'
       ))
 
       // --- Query Scheduler ---
-      .addRow(componentRow(
+      .addRow($.componentRow(
         'Query Scheduler',
         $.containerCPUUsagePanel('CPU', 'query-scheduler'),
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-scheduler'),
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-scheduler'),
+        $.goHeapAllocPanel('Memory (go heap alloc)', 'query-scheduler'),
         'container="query-scheduler"',
         'container="query-scheduler"',
         'query_scheduler'
       ))
 
       // --- Querier ---
-      .addRow(componentRow(
+      .addRow($.componentRow(
         'Querier',
         $.containerCPUUsagePanel('CPU', 'querier'),
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'querier'),
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'querier'),
+        $.goHeapAllocPanel('Memory (go heap alloc)', 'querier'),
         'container="querier"',
         'container="querier"',
         'querier',
         trailingPanels=[
-          diskWritesPanel('container="querier"'),
-          diskReadsPanel('container="querier"'),
+          $.diskWritesPanel('container="querier"'),
+          $.diskReadsPanel('container="querier"'),
           $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', 'querier'),
         ],
         trailingSpans=[4, 4, 4],
       ))
 
       // --- Index Gateway ---
-      .addRow(componentRow(
+      .addRow($.componentRow(
         'Index Gateway',
         $.CPUUsagePanel('CPU', index_gateway_pod_matcher),
         $.memoryWorkingSetPanel('Memory (workingset)', index_gateway_pod_matcher),
-        $.goHeapInUsePanel('Memory (go heap inuse)', index_gateway_job_matcher),
+        $.goHeapAllocPanel('Memory (go heap alloc)', index_gateway_job_matcher),
         index_gateway_pod_matcher,
         index_gateway_pod_matcher,
         'index_gateway',
         trailingPanels=[
-          diskWritesPanel(index_gateway_pod_matcher),
-          diskReadsPanel(index_gateway_pod_matcher),
+          $.diskWritesPanel(index_gateway_pod_matcher),
+          $.diskReadsPanel(index_gateway_pod_matcher),
           $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', index_gateway_job_matcher),
         ],
         trailingSpans=[4, 4, 4],
       ))
 
       // --- Bloom Gateway ---
-      .addRow(componentRow(
+      .addRow($.componentRow(
         'Bloom Gateway',
         $.containerCPUUsagePanel('CPU', 'bloom-gateway'),
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'bloom-gateway'),
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'bloom-gateway'),
+        $.goHeapAllocPanel('Memory (go heap alloc)', 'bloom-gateway'),
         'container="bloom-gateway"',
         'container="bloom-gateway"',
         'bloom_gateway',
         trailingPanels=[
-          diskWritesPanel('container="bloom-gateway"'),
-          diskReadsPanel('container="bloom-gateway"'),
+          $.diskWritesPanel('container="bloom-gateway"'),
+          $.diskReadsPanel('container="bloom-gateway"'),
           $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', 'bloom-gateway'),
         ],
         trailingSpans=[4, 4, 4],
       ))
 
       // --- Ingester ---
-      .addRow(componentRow(
+      .addRow($.componentRow(
         'Ingester',
         $.CPUUsagePanel('CPU', ingester_pod_matcher),
         $.memoryWorkingSetPanel('Memory (workingset)', ingester_pod_matcher),
-        $.goHeapInUsePanel('Memory (go heap inuse)', ingester_job_matcher),
+        $.goHeapAllocPanel('Memory (go heap alloc)', ingester_job_matcher),
         ingester_pod_matcher,
         ingester_pod_matcher,
         'ingester'
       ))
 
       // --- Ruler ---
-      .addRow(componentRow(
+      .addRow($.componentRow(
         'Ruler',
         $.containerCPUUsagePanel('CPU', 'ruler'),
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'ruler'),
+        $.goHeapAllocPanel('Memory (go heap alloc)', 'ruler'),
         'container="ruler"',
         'container="ruler"',
         'ruler',

--- a/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
@@ -12,34 +12,42 @@
       .addCluster()
       .addNamespace()
       .addTag()
+
+      // --- Gateway ---
       .addRowIf(
         $._config.internal_components,
-        $.row('Gateway')
-        .addPanel(
+        $.componentRow(
+          'Gateway',
           $.containerCPUUsagePanel('CPU', 'cortex-gw(-internal)?'),
-        )
-        .addPanel(
           $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw(-internal)?'),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw(-internal)?'),
-        )
-      )
-      .addRow(
-        $.row('Distributor')
-        .addPanel(
-          $.containerCPUUsagePanel('CPU', 'distributor'),
-        )
-        .addPanel(
-          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'distributor'),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'distributor'),
+          $.goHeapAllocPanel('Memory (go heap alloc)', 'cortex-gw(-internal)?'),
+          'container=~"cortex-gw(-internal)?"',
+          'container=~"cortex-gw(-internal)?"',
+          'gateway'
         )
       )
-      .addRow(
-        $.row('Ingester')
-        .addPanel(
+
+      // --- Distributor ---
+      .addRow($.componentRow(
+        'Distributor',
+        $.containerCPUUsagePanel('CPU', 'distributor'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'distributor'),
+        $.goHeapAllocPanel('Memory (go heap alloc)', 'distributor'),
+        'container="distributor"',
+        'container="distributor"',
+        'distributor'
+      ))
+
+      // --- Ingester ---
+      .addRow($.componentRow(
+        'Ingester',
+        $.CPUUsagePanel('CPU', ingester_pod_matcher),
+        $.memoryWorkingSetPanel('Memory (workingset)', ingester_pod_matcher),
+        $.goHeapAllocPanel('Memory (go heap alloc)', ingester_job_matcher),
+        ingester_pod_matcher,
+        ingester_pod_matcher,
+        'ingester',
+        trailingPanels=[
           $.newQueryPanel('In-memory streams') +
           $.queryPanel(
             'sum by(%s) (loki_ingester_memory_streams{%s})' % [$._config.per_instance_label, $.jobMatcher(ingester_job_matcher)],
@@ -48,35 +56,11 @@
           {
             tooltip: { sort: 2 },  // Sort descending.
           },
-        )
-        .addPanel(
-          $.CPUUsagePanel('CPU', ingester_pod_matcher),
-        )
-        .addPanel(
-          $.memoryWorkingSetPanel('Memory (workingset)', ingester_pod_matcher),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', ingester_job_matcher),
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Writes', 'Bps') +
-          $.queryPanel(
-            'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDisk(ingester_pod_matcher)],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Reads', 'Bps') +
-          $.queryPanel(
-            'sum by(%s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDisk(ingester_pod_matcher)],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
+          $.diskWritesPanel(ingester_pod_matcher),
+          $.diskReadsPanel(ingester_pod_matcher),
           $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', ingester_job_matcher),
-        )
-      ),
+        ],
+        trailingSpans=[3, 3, 3, 3],
+      )),
   },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Brings `Loki / Writes Resources` in line with the changes made to `Loki / Reads Resources` in #23250.

The Ingester row previously packed 7 panels onto a single 12-unit line, leaving each one squeezed into ~1.7 units and unreadable. Every component row now gets **Running Pods**, **OOMs** and **Min/Max Replicas** panels, laid out on explicit 12-unit visual lines:

```
Line 1: MinReplicas=2  MaxReplicas=2  RunningPods=4  CPU=4
Line 2: OOMs=4  Memory (workingset)=4  Memory (go heap alloc)=4
Line 3: In-memory streams=3  Disk Writes=3  Disk Reads=3  Disk Space=3   (Ingester only)
```

The row-building helpers move out of `loki-reads-resources.libsonnet` into `dashboard-utils.libsonnet` so both dashboards share one implementation instead of diverging copies.

Two "no data" messages are customised in that shared code, so they apply to both dashboards:

- The OOMs panels show **"No OOMs observed in time period 🎉"**.
- Min/Max Replicas show **"Not auto-scaled"** when the autoscaler exports no metrics for the component.

**Removing `_config.autoscaled`**

That second message replaces the `_config.autoscaled` list added in #23250, along with the "Not auto-scaled" text panel it selected. Whether a component is auto-scaled is now answered at query time by the presence of `loki_autoscaler_{min,max}_replicas`, so there is no build-time list to keep in sync with reality. The config option is dropped.

Split pods apart by type so we can see when there are two types of ingester or two types of gateway. 

Also change go heap inuse to go heap alloc, which is a better measure of memory used. 

**Which issue(s) this PR fixes**: N/A. 

**Special notes for your reviewer**: Tested locally against pre-production environment. 

Loki / Writes Resources: 
<img width="1283" height="1057" alt="image" src="https://github.com/user-attachments/assets/bb2a09f0-be86-4831-a444-7fcbe4752a7b" />
<img width="1283" height="849" alt="image" src="https://github.com/user-attachments/assets/c14b8996-4587-48b0-9cc3-7f7c7e65a1c5" />
Loki / Reads Resources:
<img width="1283" height="1058" alt="image" src="https://github.com/user-attachments/assets/dbd9ef8c-9f04-4b02-81d9-78db1c5989ab" />


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
