### PR TITLE
fix(loki): clear resultCache on BaseLabelsBuilder Reset

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -201,6 +201,7 @@ func (b *BaseLabelsBuilder) Reset() {
 	b.errDetails = ""
 	b.baseMap = nil
 	b.parserKeyHints.Reset()
+	clear(b.resultCache)
 }
 
 // ParserLabelHints returns a limited list of expected labels to extract for metric queries.

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -191,7 +191,11 @@ func (b *BaseLabelsBuilder) ForLabels(lbs labels.Labels, hash uint64) *LabelsBui
 	return res
 }
 
-// Reset clears all current state for the builder.
+// Reset clears all current state for the builder. It does not clear
+// resultCache: Reset runs once per line, and resultCache entries are keyed
+// by label set hash so they are safely reused across lines within the same
+// pipeline. Use ResetCache to also evict resultCache, which should only
+// happen on a pipeline-level reset (e.g. once per push in a tailer).
 func (b *BaseLabelsBuilder) Reset() {
 	b.del = b.del[:0]
 	for k := range b.add {
@@ -201,6 +205,16 @@ func (b *BaseLabelsBuilder) Reset() {
 	b.errDetails = ""
 	b.baseMap = nil
 	b.parserKeyHints.Reset()
+}
+
+// ResetCache clears resultCache in addition to everything Reset clears.
+// Long lived pipelines (e.g. tailers) reuse the same builder across pushes
+// via Pipeline.Reset, so stale cached LabelsResult entries must be evicted
+// there to prevent unbounded growth. Do not call this per line: streamPipeline
+// and noopStreamPipeline rely on resultCache surviving across lines within
+// the same push for cheap LabelsResult reuse.
+func (b *BaseLabelsBuilder) ResetCache() {
+	b.Reset()
 	clear(b.resultCache)
 }
 

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -73,6 +73,7 @@ func (n *noopPipeline) ForStream(labels labels.Labels) StreamPipeline {
 
 func (n *noopPipeline) Reset() {
 	clear(n.cache)
+	n.baseBuilder.ResetCache()
 }
 
 // IsNoopPipeline tells if a pipeline is a Noop.
@@ -189,7 +190,7 @@ func (p *pipeline) ForStream(labels labels.Labels) StreamPipeline {
 }
 
 func (p *pipeline) Reset() {
-	p.baseBuilder.Reset()
+	p.baseBuilder.ResetCache()
 	clear(p.streamPipelines)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`BaseLabelsBuilder.Reset` at `pkg/logql/log/labels.go:195` clears `del`, `add`, `err`, `baseMap` and the parser hints but leaves `resultCache` populated. Long lived tailing pipelines reuse the builder via `Reset`, so stale cached `LabelsResult` entries accumulate and leak memory.

This adds a `BaseLabelsBuilder.ResetCache` method that clears `resultCache`, and calls it from `Pipeline.Reset` and `noopPipeline.Reset` (once per push in tailers). The per-line `Reset` used by `streamPipeline.Process` and `noopStreamPipeline.Process` does not clear the cache, so cross-line `LabelsResult` reuse within a push is preserved while the cache still cannot grow unbounded across pushes.

**Which issue(s) this PR fixes**:
No linked issue.

**Special notes for your reviewer**:

`go test ./pkg/logql/log` passes RED and GREEN, `go vet` clean.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
