### PR TITLE
test(logql): Extend logqltest coverage for unwrapped range aggregations

### DIFF
--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -807,13 +807,14 @@ eval instant at 270s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m])
 eval range from 60s to 270s step 30s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m]) # overlapping
   {app="foo"} 0.3 0.3 0.3 0.3 0.3 0.15 _ _
   {app="bar"} 0.6 0.6 0.6 0.6 0.6 0.3 _ _
-# The offset shifts the window back.
-eval instant at 150s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[20s] offset 90s)
+# The offset shifts the window back: at 210s the un-offset window would already be empty
+# (windows past 180s are empty, per above), but shifted back 90s it still lands on data.
+eval instant at 210s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[20s] offset 90s)
   {app="foo"} 0.3
   {app="bar"} 0.6
-eval range from 60s to 150s step 30s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[20s] offset 90s)
-  {app="foo"} _ 0.15 0.3 0.3
-  {app="bar"} _ 0.3 0.6 0.6
+eval range from 60s to 210s step 30s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[20s] offset 90s)
+  {app="foo"} _ 0.15 0.3 0.3 0.3 0.3
+  {app="bar"} _ 0.3 0.6 0.6 0.6 0.6
 # rate() doesn't allow grouping, with or without unwrap.
 eval instant at 120s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m]) by (app)
   expect fail msg: grouping not allowed for rate aggregation

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -183,12 +183,20 @@ eval range from 60s to 70s step 10s last_over_time({app="a"} | logfmt | unwrap v
 # first_over_time() without()
 eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
   {app="a"} 2
+eval range from 20s to 50s step 10s first_over_time({app="a"} | logfmt | unwrap v [10s]) without (pod) # non-overlapping
+  {app="a"} 2 4 10 20
+eval range from 60s to 70s step 10s first_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod) # overlapping
+  {app="a"} 2 2
 eval range from 70s to 80s step 10s first_over_time({app="a"} | logfmt | unwrap v [1m] offset 10s) by (pod) # overlapping
   {pod="1"} 2 2
   {pod="2"} 10 10
 # last_over_time() without()
 eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
   {app="a"} 20
+eval range from 20s to 50s step 10s last_over_time({app="a"} | logfmt | unwrap v [10s]) without (pod) # non-overlapping
+  {app="a"} 2 4 10 20
+eval range from 60s to 70s step 10s last_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod) # overlapping
+  {app="a"} 20 20
 eval range from 70s to 80s step 10s last_over_time({app="a"} | logfmt | unwrap v [1m] offset 10s) by (pod)  # overlapping
   {pod="1"} 4 4
   {pod="2"} 20 20
@@ -285,6 +293,7 @@ load
   {app="a", pod="2"} "v=20" @ 50s
   {app="a", pod="1"} "noise" @ 25s
 
+# by()
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
   expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {pod="1"} 3
@@ -292,6 +301,7 @@ eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) 
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (app)
   expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {app="a"} 7
+# without()
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) without (pod)
   expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {app="a"} 7
@@ -303,6 +313,9 @@ eval range from 60s to 70s step 10s quantile_over_time(0.5, {app="a"} | logfmt |
   expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {pod="1"} 3 3
   {pod="2"} 15 15
+eval range from 60s to 70s step 10s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) without (pod)
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
+  {app="a"} 7 7
 eval instant at 60s quantile_over_time(0, {app="a"} | logfmt | unwrap v [1m]) by (pod)
   expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {pod="1"} 2
@@ -778,6 +791,35 @@ eval instant at 60s rate({app="err"} | unwrap v [1m])
 eval instant at 60s rate({app="err"} | unwrap v | __error__="" [1m])
   {app="err"} 0.1
 
+# rate() with unwrap: window shapes, offset, and grouping.
+clear
+load
+  {app="foo", bar="3"} "xbar"  @ 0s [repeat every 10s for 19]
+  {app="foo", bar="3"} "noise" @ 5s [repeat every 10s for 19]
+  {app="bar", bar="6"} "xbar"  @ 0s [repeat every 10s for 19]
+  {app="bar", bar="6"} "noise" @ 5s [repeat every 10s for 19]
+
+eval instant at 120s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m])
+  {app="foo"} 0.3
+  {app="bar"} 0.6
+eval instant at 270s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m])
+  expect empty
+eval range from 60s to 270s step 30s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m]) # overlapping
+  {app="foo"} 0.3 0.3 0.3 0.3 0.3 0.15 _ _
+  {app="bar"} 0.6 0.6 0.6 0.6 0.6 0.3 _ _
+# The offset shifts the window back.
+eval instant at 150s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[20s] offset 90s)
+  {app="foo"} 0.3
+  {app="bar"} 0.6
+eval range from 60s to 150s step 30s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[20s] offset 90s)
+  {app="foo"} _ 0.15 0.3 0.3
+  {app="bar"} _ 0.3 0.6 0.6
+# rate() doesn't allow grouping, with or without unwrap.
+eval instant at 120s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m]) by (app)
+  expect fail msg: grouping not allowed for rate aggregation
+eval instant at 120s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m]) without (app)
+  expect fail msg: grouping not allowed for rate aggregation
+
 # avg_over_time() edge cases:
 # - any NaN -> NaN
 # - +Inf absorbs a finite value
@@ -1126,27 +1168,53 @@ eval instant at 60s max_over_time({app="a"}[1m])
   expect fail msg: invalid aggregation max_over_time without unwrap
 
 # min_over_time() / max_over_time() with grouping.
+#
+# In this scenario, each pod's values rise and fall, so min/max sit strictly inside the sequence,
+# distinct from both first_over_time() and last_over_time() on the same window.
 clear
 load
-  {app="a", pod="1"} "v=2"  @ 20s
-  {app="a", pod="1"} "v=4"  @ 30s
-  {app="a", pod="2"} "v=10" @ 40s
-  {app="a", pod="2"} "v=20" @ 50s
+  {app="a", pod="1"} "v=4"  @ 10s
+  {app="a", pod="1"} "v=9"  @ 20s
+  {app="a", pod="1"} "v=1"  @ 30s
+  {app="a", pod="1"} "v=6"  @ 40s
   {app="a", pod="1"} "noise" @ 25s
+  {app="a", pod="2"} "v=12" @ 10s
+  {app="a", pod="2"} "v=3"  @ 20s
+  {app="a", pod="2"} "v=15" @ 30s
+  {app="a", pod="2"} "v=8"  @ 40s
 
-eval instant at 60s min_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
-  {pod="1"} 2
-  {pod="2"} 10
-eval instant at 60s max_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
-  {pod="1"} 4
-  {pod="2"} 20
-eval instant at 60s min_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
-  {app="a"} 2
-eval instant at 60s max_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
-  {app="a"} 20
-eval range from 60s to 70s step 10s min_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
-  {pod="1"} 2 2
-  {pod="2"} 10 10
+# by()
+eval instant at 40s min_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 1
+  {pod="2"} 3
+eval range from 30s to 40s step 10s min_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod) # overlapping
+  {pod="1"} 1 1
+  {pod="2"} 3 3
+eval range from 20s to 40s step 20s min_over_time({app="a"} | logfmt | unwrap v [10s]) by (pod) # non-overlapping
+  {pod="1"} 9 6
+  {pod="2"} 3 8
+eval instant at 40s max_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 9
+  {pod="2"} 15
+eval range from 30s to 40s step 10s max_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod) # overlapping
+  {pod="1"} 9 9
+  {pod="2"} 15 15
+eval range from 20s to 40s step 20s max_over_time({app="a"} | logfmt | unwrap v [10s]) by (pod) # non-overlapping
+  {pod="1"} 9 6
+  {pod="2"} 3 8
+# without()
+eval instant at 40s min_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 1
+eval range from 30s to 40s step 10s min_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod) # overlapping
+  {app="a"} 1 1
+eval range from 20s to 40s step 20s min_over_time({app="a"} | logfmt | unwrap v [10s]) without (pod) # non-overlapping
+  {app="a"} 3 6
+eval instant at 40s max_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 15
+eval range from 30s to 40s step 10s max_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod) # overlapping
+  {app="a"} 15 15
+eval range from 20s to 40s step 20s max_over_time({app="a"} | logfmt | unwrap v [10s]) without (pod) # non-overlapping
+  {app="a"} 9 8
 
 # min_over_time() / max_over_time() over a structured metadata field.
 clear
@@ -1297,21 +1365,48 @@ load
   {app="a", pod="2"} "v=20" @ 50s
   {app="a", pod="1"} "noise" @ 25s
 
+# by()
 eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 1
   {pod="2"} 5
 eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 1
   {pod="2"} 25
-eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) by (app)
-  {app="a"} 49
-eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) by (app)
   {app="a"} 7
-eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) by (app)
   {app="a"} 49
 eval range from 60s to 70s step 10s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 1 1
   {pod="2"} 5 5
+eval range from 60s to 70s step 10s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 1 1
+  {pod="2"} 25 25
+# without()
+eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 7
+eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 49
+eval range from 60s to 70s step 10s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 7 7
+eval range from 60s to 70s step 10s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 49 49
+
+# stdvar_over_time() / stddev_over_time() with repeated non-exact floats stay exactly 0.
+#
+# Welford's algorithm can accumulate floating-point rounding error on repeated non-integer
+# values; a regression here would surface as a tiny negative variance turning into NaN through
+# stddev_over_time()'s sqrt.
+clear
+load
+  {app="a"} "v=1.5990505637277868" @ 20s
+  {app="a"} "v=1.5990505637277868" @ 30s
+  {app="a"} "v=1.5990505637277868" @ 40s
+
+eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 0
+eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 0
 
 # stddev_over_time() / stdvar_over_time() over a structured metadata field.
 clear


### PR DESCRIPTION
**What this PR does / why we need it**:

Fills gaps in `range_aggregations.logqltest` coverage for unwrapped range vector
aggregations:
- `rate()` with `| unwrap` had only one overlapping-window case; adds the
  non-overlapping/output-gap and offset shapes, plus its own
  grouping-not-allowed check (previously only asserted on the log-line form).
- `min_over_time()`/`max_over_time()` grouping was only tested on instant
  queries with monotonic per-group data, which can't distinguish `min`/`max`
  from `first`/`last`. Replaces the fixture with non-monotonic values and adds
  range coverage (`by`/`without`, overlapping/non-overlapping).
- `first_over_time()`/`last_over_time()` and `quantile_over_time()` were
  missing a `without()` case over a range query.
- `stddev_over_time()`/`stdvar_over_time()` grouping had only one range case;
  fills in the missing `by`/`without` combinations, plus a regression case
  (mirroring Prometheus's) asserting repeated non-exact float samples still
  yield an exact `0` variance.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Test-only change to `pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest`.
Every new/changed expected value was hand-derived and verified by running
`go test ./pkg/logql/internal/logqltest/ -run 'TestLogQLScripts/range_aggregations.logqltest'`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)