### PR TITLE
fix: Data race in cached client

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/storage/cached_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/cached_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -130,8 +129,7 @@ func (c *cachedObjectClient) listTableNames(ctx context.Context) ([]client.Stora
 	c.tablesMtx.RLock()
 	defer c.tablesMtx.RUnlock()
 
-	// Copy so callers can use the slice after we unlock; buildTableNamesCache replaces the backing array.
-	return slices.Clone(c.tableNames), nil
+	return c.tableNames, nil
 }
 
 func (c *cachedObjectClient) listTable(ctx context.Context, tableName string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
@@ -148,8 +146,7 @@ func (c *cachedObjectClient) listTable(ctx context.Context, tableName string) ([
 	tbl.mtx.RLock()
 	defer tbl.mtx.RUnlock()
 
-	// Copy so callers can use the slices after we unlock; buildCache mutates the cached slices in place.
-	return slices.Clone(tbl.commonObjects), slices.Clone(tbl.userIDs), nil
+	return tbl.commonObjects, tbl.userIDs, nil
 }
 
 func (c *cachedObjectClient) listUserIndexInTable(ctx context.Context, tableName, userID string) ([]client.StorageObject, error) {
@@ -167,7 +164,7 @@ func (c *cachedObjectClient) listUserIndexInTable(ctx context.Context, tableName
 	defer tbl.mtx.RUnlock()
 
 	if objects, ok := tbl.userObjects[userID]; ok {
-		return slices.Clone(objects), nil
+		return objects, nil
 	}
 
 	return []client.StorageObject{}, nil
@@ -296,12 +293,11 @@ func (t *table) buildCache(ctx context.Context, objectClient client.ObjectClient
 		return err
 	}
 
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
-
-	t.commonObjects = t.commonObjects[:0]
-	t.userObjects = map[string][]client.StorageObject{}
-	t.userIDs = t.userIDs[:0]
+	// Build a new snapshot so callers holding previously returned slices
+	// are not racing with in-place appends on the cached backing arrays.
+	commonObjects := []client.StorageObject{}
+	userObjects := map[string][]client.StorageObject{}
+	userIDs := []client.StorageCommonPrefix{}
 
 	for _, object := range objects {
 		// The s3 client can also return the directory itself in the ListObjects.
@@ -315,16 +311,22 @@ func (t *table) buildCache(ctx context.Context, objectClient client.ObjectClient
 		}
 
 		if len(ss) == 2 {
-			t.commonObjects = append(t.commonObjects, object)
+			commonObjects = append(commonObjects, object)
 		} else {
 			userID := ss[1]
-			if len(t.userObjects[userID]) == 0 {
-				t.userIDs = append(t.userIDs, client.StorageCommonPrefix(path.Join(t.name, userID)))
+			if len(userObjects[userID]) == 0 {
+				userIDs = append(userIDs, client.StorageCommonPrefix(path.Join(t.name, userID)))
 			}
-			t.userObjects[userID] = append(t.userObjects[userID], object)
+			userObjects[userID] = append(userObjects[userID], object)
 		}
 	}
 
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+
+	t.commonObjects = commonObjects
+	t.userObjects = userObjects
+	t.userIDs = userIDs
 	t.cacheBuiltAt = time.Now()
 	return nil
 }

--- a/pkg/storage/stores/shipper/indexshipper/storage/cached_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/cached_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -129,7 +130,8 @@ func (c *cachedObjectClient) listTableNames(ctx context.Context) ([]client.Stora
 	c.tablesMtx.RLock()
 	defer c.tablesMtx.RUnlock()
 
-	return c.tableNames, nil
+	// Copy so callers can use the slice after we unlock; buildTableNamesCache replaces the backing array.
+	return slices.Clone(c.tableNames), nil
 }
 
 func (c *cachedObjectClient) listTable(ctx context.Context, tableName string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
@@ -146,7 +148,8 @@ func (c *cachedObjectClient) listTable(ctx context.Context, tableName string) ([
 	tbl.mtx.RLock()
 	defer tbl.mtx.RUnlock()
 
-	return tbl.commonObjects, tbl.userIDs, nil
+	// Copy so callers can use the slices after we unlock; buildCache mutates the cached slices in place.
+	return slices.Clone(tbl.commonObjects), slices.Clone(tbl.userIDs), nil
 }
 
 func (c *cachedObjectClient) listUserIndexInTable(ctx context.Context, tableName, userID string) ([]client.StorageObject, error) {
@@ -164,7 +167,7 @@ func (c *cachedObjectClient) listUserIndexInTable(ctx context.Context, tableName
 	defer tbl.mtx.RUnlock()
 
 	if objects, ok := tbl.userObjects[userID]; ok {
-		return objects, nil
+		return slices.Clone(objects), nil
 	}
 
 	return []client.StorageObject{}, nil

--- a/pkg/storage/stores/shipper/indexshipper/storage/cached_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/cached_client_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ var objectsMtime = time.Now().Local()
 type mockObjectClient struct {
 	client.ObjectClient
 	errResp        error
-	listCallsCount int
+	listCallsCount atomic.Int64
 	listDelay      time.Duration
 }
 
@@ -45,7 +46,7 @@ func newMockObjectClient(t *testing.T, objects []string) *mockObjectClient {
 func (m *mockObjectClient) List(ctx context.Context, prefix, delimiter string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
 	defer func() {
 		time.Sleep(m.listDelay)
-		m.listCallsCount++
+		m.listCallsCount.Add(1)
 	}()
 
 	if m.errResp != nil {
@@ -150,14 +151,14 @@ func TestCachedObjectClient(t *testing.T) {
 	// list tables
 	objects, commonPrefixes, err := cachedObjectClient.List(context.Background(), "", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 1, objectClient.listCallsCount)
+	require.Equal(t, int64(1), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{"table1", "table2", "table3"}, commonPrefixes)
 
 	// list objects in all 3 tables
 	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table1/", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 2, objectClient.listCallsCount)
+	require.Equal(t, int64(2), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{
 		{Key: "table1/db1.gz", ModifiedAt: objectsMtime},
 		{Key: "table1/db2.gz", ModifiedAt: objectsMtime},
@@ -166,7 +167,7 @@ func TestCachedObjectClient(t *testing.T) {
 
 	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table2/", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 3, objectClient.listCallsCount)
+	require.Equal(t, int64(3), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{
 		{Key: "table2/db1.gz", ModifiedAt: objectsMtime},
 	}, objects)
@@ -174,14 +175,14 @@ func TestCachedObjectClient(t *testing.T) {
 
 	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 4, objectClient.listCallsCount)
+	require.Equal(t, int64(4), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{"table3/user1"}, commonPrefixes)
 
 	// list user objects from table2 and table3, which should not make any new list calls
 	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table2/user1/", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 4, objectClient.listCallsCount)
+	require.Equal(t, int64(4), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{
 		{
 			Key:        "table2/user1/db1.gz",
@@ -192,7 +193,7 @@ func TestCachedObjectClient(t *testing.T) {
 
 	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/user1/", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 4, objectClient.listCallsCount)
+	require.Equal(t, int64(4), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{
 		{Key: "table3/user1/db1.gz", ModifiedAt: objectsMtime},
 		{Key: "table3/user1/db2.gz", ModifiedAt: objectsMtime},
@@ -202,14 +203,14 @@ func TestCachedObjectClient(t *testing.T) {
 	// list non-existent table
 	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table4/", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 5, objectClient.listCallsCount)
+	require.Equal(t, int64(5), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{}, commonPrefixes)
 
 	// list non-existent user
 	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/user2/", "", false)
 	require.NoError(t, err)
-	require.Equal(t, 5, objectClient.listCallsCount)
+	require.Equal(t, int64(5), objectClient.listCallsCount.Load())
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{}, commonPrefixes)
 }
@@ -262,7 +263,7 @@ func TestCachedObjectClient_errors(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedObjects, objects)
 			require.Equal(t, tc.expectedCommonPrefixes, commonPrefixes)
-			expectedListCallsCount := objectClient.listCallsCount
+			expectedListCallsCount := objectClient.listCallsCount.Load()
 
 			// timeout the cache and call List concurrently with objectClient throwing an error
 			// objectClient must receive just one request and all the cachedObjectClient.List calls should get an error
@@ -278,7 +279,7 @@ func TestCachedObjectClient_errors(t *testing.T) {
 					defer wg.Done()
 					_, _, err := cachedObjectClient.List(context.Background(), tc.prefix, "", false)
 					require.Error(t, err)
-					require.Equal(t, expectedListCallsCount, objectClient.listCallsCount)
+					require.Equal(t, expectedListCallsCount, objectClient.listCallsCount.Load())
 				}()
 			}
 
@@ -294,7 +295,7 @@ func TestCachedObjectClient_errors(t *testing.T) {
 					defer wg.Done()
 					objects, commonPrefixes, err := cachedObjectClient.List(context.Background(), tc.prefix, "", false)
 					require.NoError(t, err)
-					require.Equal(t, expectedListCallsCount, objectClient.listCallsCount)
+					require.Equal(t, expectedListCallsCount, objectClient.listCallsCount.Load())
 					require.Equal(t, tc.expectedObjects, objects)
 					require.Equal(t, tc.expectedCommonPrefixes, commonPrefixes)
 				}()
@@ -302,4 +303,64 @@ func TestCachedObjectClient_errors(t *testing.T) {
 			wg.Wait()
 		})
 	}
+}
+
+func TestCachedObjectClient_ListConcurrentRefresh(t *testing.T) {
+	objectClient := newMockObjectClient(t, []string{
+		"table1/db1.gz",
+		"table1/user1/db1.gz",
+		"table1/user1/db2.gz",
+		"table1/user2/db1.gz",
+	})
+	cached := newCachedObjectClient(objectClient)
+
+	_, _, err := cached.List(context.Background(), "", "", false)
+	require.NoError(t, err)
+	_, _, err = cached.List(context.Background(), "table1/", "", false)
+	require.NoError(t, err)
+
+	const (
+		readers    = 8
+		iterations = 100
+	)
+	var wg sync.WaitGroup
+	wg.Add(readers + 1)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			cached.RefreshIndexTableNamesCache(context.Background())
+			cached.RefreshIndexTableCache(context.Background(), "table1")
+		}
+	}()
+
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				objects, prefixes, err := cached.List(context.Background(), "table1/", "", false)
+				require.NoError(t, err)
+				for _, o := range objects {
+					_ = o.Key
+				}
+				for _, p := range prefixes {
+					_ = string(p)
+				}
+
+				objects, _, err = cached.List(context.Background(), "table1/user1/", "", false)
+				require.NoError(t, err)
+				for _, o := range objects {
+					_ = o.Key
+				}
+
+				_, prefixes, err = cached.List(context.Background(), "", "", false)
+				require.NoError(t, err)
+				for _, p := range prefixes {
+					_ = string(p)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/pkg/storage/stores/shipper/indexshipper/storage/cached_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/cached_client_test.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Compaction workers can `List` a table while another worker is rebuilding that table's object-name cache. `listTable` / `listUserIndexInTable` / `listTableNames` returned the live backing slices after dropping the lock, so `buildCache` could `append` or replace them while the caller was still iterating.
- Clone the slices under the lock so callers own a stable copy. This showed up under `go test -race` on the in-process integration suite (`buildCache` vs `ListFiles` / `tableHasUncompactedIndex`).
- Concurrent List/Refresh test plus making the mock's list-call counter atomic so the race detector does not flag the harness.


**Which issue(s) this PR fixes**:
In support of: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
