### PR TITLE
fix(kafka): Reset every field of the reused stream before decoding a record

### DIFF
--- a/pkg/kafka/encoding.go
+++ b/pkg/kafka/encoding.go
@@ -155,7 +155,10 @@ func NewDecoder() (*Decoder, error) {
 //
 // Returns the decoded logproto.Stream, parsed labels, and any error encountered.
 func (d *Decoder) Decode(data []byte) (logproto.Stream, labels.Labels, error) {
+	d.stream.Labels = ""
+	d.stream.Hash = 0
 	d.stream.Entries = d.stream.Entries[:0]
+
 	if err := d.stream.Unmarshal(data); err != nil {
 		return logproto.Stream{}, labels.EmptyLabels(), fmt.Errorf("failed to unmarshal stream: %w", err)
 	}

--- a/pkg/kafka/encoding_test.go
+++ b/pkg/kafka/encoding_test.go
@@ -104,6 +104,39 @@ func TestEncoderDecoderEmptyStream(t *testing.T) {
 	require.Empty(t, decodedStream.Entries)
 }
 
+func TestDecoderDoesNotCarryFieldsBetweenRecords(t *testing.T) {
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	encode := func(stream logproto.Stream) []byte {
+		records, err := Encode(0, "test-tenant", stream, 10<<20)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		return records[0].Value
+	}
+
+	withHash := encode(logproto.Stream{
+		Labels:  `{app="test"}`,
+		Hash:    999,
+		Entries: []logproto.Entry{{Timestamp: time.Unix(0, 1), Line: "first"}},
+	})
+	withoutHash := encode(logproto.Stream{
+		Labels:  `{app="other"}`,
+		Entries: []logproto.Entry{{Timestamp: time.Unix(0, 2), Line: "second"}},
+	})
+
+	decoded, _, err := decoder.Decode(withHash)
+	require.NoError(t, err)
+	require.Equal(t, uint64(999), decoded.Hash)
+
+	decoded, ls, err := decoder.Decode(withoutHash)
+	require.NoError(t, err)
+	require.Zero(t, decoded.Hash, "hash of the previous record leaked into this one")
+	require.Equal(t, `{app="other"}`, ls.String())
+	require.Len(t, decoded.Entries, 1)
+	require.Equal(t, "second", decoded.Entries[0].Line)
+}
+
 func BenchmarkEncodeDecode(b *testing.B) {
 	decoder, _ := NewDecoder()
 	stream := generateStream(1000, 200)


### PR DESCRIPTION
## What this PR does / why we need it

`Decoder.Decode` unmarshals into a `logproto.Stream` it holds across calls, but only reset the entries slice:

```go
d.stream.Entries = d.stream.Entries[:0]
if err := d.stream.Unmarshal(data); err != nil {
```

`Unmarshal` assigns only the fields a record actually carries, and proto3 omits zero values. So a record with a zero hash, or an empty label set, inherited whatever the previous record left behind.

The hash is the visible half — decoding a record encoded with `Hash: 0` returned the previous record's hash. The labels are the dangerous half: a record carrying no labels would have been attributed to the previous record's stream rather than failing to parse.

`DecodeWithoutLabels` — the variant both production consumers use (`pkg/ingester/kafka_consumer.go`, `pkg/dataobj/consumer/processor.go`) — is unaffected, because it unmarshals into a fresh stream on each call. `Decode` currently has no production caller in this repo, but `pkg/kafka` is consumed outside it, so the fix is worth having on its own.

The added test fails on `main` with `Should be zero, but was 999` and passes with the fix.

## Which issue(s) this PR fixes

None filed; found while reading the decoder ahead of adding support for a second record encoding.

## Special notes for your reviewer

The entries slice is truncated rather than set to `nil` so its backing array is still reused — the allocation-reuse intent of holding the stream across calls is preserved.

## Checklist

- [x] Tests updated
- [x] `CHANGELOG.md` — not needed, this repo generates it from commit messages
- [x] Documentation — no user-facing surface changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)