### PR TITLE
feat: Add a gauge for the max inflight bytes limit

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -211,52 +211,56 @@ type metrics struct {
 	kafkaWriteBytesTotal   prometheus.Counter
 	kafkaWriteLatency      prometheus.Histogram
 	kafkaRecordsPerRequest prometheus.Histogram
+
+	// Track the max inflight bytes in the last 1 minute.
+	maxInflightBytes           prometheus.Gauge
+	inflightBytesHighWatermark prometheus.Summary
 }
 
-func newMetrics(registerer prometheus.Registerer) *metrics {
+func newMetrics(reg prometheus.Registerer) *metrics {
 	return &metrics{
-		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		ingesterAppends: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_ingester_appends_total",
 			Help:      "The total number of batch appends sent to ingesters.",
 		}, []string{"ingester"}),
-		ingesterAppendTimeouts: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		ingesterAppendTimeouts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_ingester_append_timeouts_total",
 			Help:      "The total number of failed batch appends sent to ingesters due to timeouts.",
 		}, []string{"ingester"}),
-		replicationFactor: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+		replicationFactor: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_replication_factor",
 			Help:      "The configured replication factor.",
 		}),
-		streamShardCount: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+		streamShardCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "stream_sharding_count",
 			Help:      "Total number of times the distributor has sharded streams",
 		}),
-		zeroStreamCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		zeroStreamCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_push_zero_streams_count",
 			Help:      "Total number of push requests with 0 streams",
 		}, []string{"tenant", "stage"}),
-		pushStatsCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		pushStatsCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_push_stats_count",
 			Help:      "Total number of successfully parsed push requests aggregated by tenant, content-type, encoding, version, format",
 		}, []string{"tenant", "content_type", "content_encoding", "content_version", "format"}),
-		tenantPushSanitizedStructuredMetadata: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		tenantPushSanitizedStructuredMetadata: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_push_structured_metadata_sanitized_total",
 			Help:      "The total number of times we've had to sanitize structured metadata (names or values) at ingestion time per tenant.",
 		}, []string{"tenant", "format"}),
 
-		kafkaAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		kafkaAppends: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_kafka_appends_total",
 			Help:      "The total number of appends sent to kafka ingest path.",
 		}, []string{"partition", "status"}),
-		kafkaWriteLatency: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+		kafkaWriteLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace:                       constants.Loki,
 			Name:                            "distributor_kafka_latency_seconds",
 			Help:                            "Latency to write an incoming request to the ingest storage.",
@@ -265,16 +269,27 @@ func newMetrics(registerer prometheus.Registerer) *metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			Buckets:                         prometheus.DefBuckets,
 		}),
-		kafkaWriteBytesTotal: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+		kafkaWriteBytesTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_kafka_sent_bytes_total",
 			Help:      "Total number of bytes sent to the ingest storage.",
 		}),
-		kafkaRecordsPerRequest: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+		kafkaRecordsPerRequest: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_kafka_records_per_write_request",
 			Help:      "The number of records a single per-partition write request has been split into.",
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 8),
+		}),
+
+		maxInflightBytes: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_distributor_max_inflight_bytes",
+			Help: "The max permitted inflight bytes. 0 if disabled.",
+		}),
+		inflightBytesHighWatermark: promauto.With(reg).NewSummary(prometheus.SummaryOpts{
+			Name:       "loki_distributor_inflight_bytes_high_watermark",
+			Help:       "The most observed inflight bytes in the last 1 minute.",
+			Objectives: map[float64]float64{1.0: 0.1},
+			MaxAge:     time.Minute,
 		}),
 	}
 }
@@ -335,10 +350,8 @@ type Distributor struct {
 	// are consumed.
 	numMetadataPartitions int
 
-	// Track the max inflight bytes in the last 1 minute.
-	inflightBytesHighWatermark prometheus.Summary
-	inflightBytes              atomic.Int64
-	circuitBreaker             circuitBreaker
+	inflightBytes  atomic.Int64
+	circuitBreaker circuitBreaker
 }
 
 // New a distributor creates.
@@ -487,12 +500,6 @@ func New(
 		partitionRing:         partitionRing,
 		ingestLimits:          ingestLimits,
 		numMetadataPartitions: numMetadataPartitions,
-		inflightBytesHighWatermark: promauto.With(registerer).NewSummary(prometheus.SummaryOpts{
-			Name:       "loki_distributor_inflight_bytes_high_watermark",
-			Help:       "The max inflight bytes in the last 1 minute.",
-			Objectives: map[float64]float64{1.0: 0.1},
-			MaxAge:     time.Minute,
-		}),
 	}
 
 	if cfg.CircuitBreaker.Enabled {
@@ -529,6 +536,8 @@ func New(
 
 	d.m.replicationFactor.Set(float64(ingestersRing.ReplicationFactor()))
 	rfStats.Set(int64(ingestersRing.ReplicationFactor()))
+
+	d.m.maxInflightBytes.Set(float64(d.cfg.MaxInflightBytes))
 
 	rs := NewRateStore(
 		d.cfg.RateStore,
@@ -660,7 +669,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 func (d *Distributor) pushWithResolver(ctx context.Context, req *logproto.PushRequest, streamResolver *requestScopedStreamResolver, format string) (*logproto.PushResponse, error) {
 	requestSize := int64(req.Size())
 	newInflightBytes := d.inflightBytes.Add(requestSize)
-	d.inflightBytesHighWatermark.Observe(float64(newInflightBytes))
+	d.m.inflightBytesHighWatermark.Observe(float64(newInflightBytes))
 	defer d.inflightBytes.Add(-requestSize)
 
 	maxInflightBytes := int64(d.cfg.MaxInflightBytes)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a gauge that, in combination with the high watermark summary, can be used to autoscale distributors that are near or at their limit. This could be useful if distributors have so much CPU that it is possible to reach their inflight limit under normal steady state. In such case, we would want to scale up and add more pods to prevent 503s.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
