### PR TITLE
test(logql): Add a direction to log-selection queries in the logqltest DSL

### DIFF
--- a/pkg/logql/internal/logqltest/README.md
+++ b/pkg/logql/internal/logqltest/README.md
@@ -60,11 +60,14 @@ eval instant at <time> <logql>
 eval range from <t0> to <t1> step <step> <logql>
   <expected series...>
 
-eval select from <t0> to <t1> <logql>
+eval select from <t0> to <t1> <forward|backward> <logql>
   <expected streams...>
 ```
 
 - Times (`<time>`, `<t0>`, `<t1>`, `<step>`) are Go durations offset from the script epoch.
+- `forward` / `backward` — **required** on `select`, and `select` only: the order log lines are
+  returned in, which is the order the expected block is written in (see "Log-selection direction"
+  below).
 - Expected results follow on indented lines. The block ends at a blank line, a dedented line,
   or EOF.
 
@@ -77,8 +80,8 @@ eval select from <t0> to <t1> <logql>
 - **Streams** (log-selection queries, e.g. `{app="foo"} |= "bar"`): one line per log entry,
   `{labels} "<line>" @ <ts>` (or `` `<line>` `` for a raw line). Several lines sharing the same
   `{labels}` belong to one stream and are checked as an exact, ordered sequence — a stream's line
-  order is meaningful, unlike the set of series in a vector/matrix. Distinct label sets are
-  compared as a set (order-independent), like series.
+  order is meaningful (it follows the query direction), unlike the set of series in a
+  vector/matrix. Distinct label sets are compared as a set (order-independent), like series.
 
 Point syntax (from promqltest):
 
@@ -112,12 +115,30 @@ load
   {app="foo"} "in range"    @ 10s
   {app="foo"} "at boundary" @ 20s
 
-eval select from 0 to 20s {app="foo"}
+eval select from 0 to 20s forward {app="foo"}
   {app="foo"} "in range" @ 10s
 ```
 
-A log-selection `eval` always runs in the default `FORWARD` direction with a fixed 1000-line
-limit; direction and limit are not yet configurable from the DSL.
+### Log-selection direction
+
+Every `eval select` states its direction between the window and the query: `forward` reads the
+window oldest line first, `backward` newest line first.
+
+```
+load
+  {app="foo"} "1st" @ 10s
+  {app="foo"} "2nd" @ 20s
+
+eval select from 0 to 30s backward {app="foo"}
+  {app="foo"} "2nd" @ 20s
+  {app="foo"} "1st" @ 10s
+```
+
+The direction only changes the order lines come back in, never which lines match: the window
+bounds and the pipeline are unaffected. Expected lines within one stream are compared in the order
+they are written, so a `backward` block lists them newest first. Streams themselves are still
+compared as a set, and each is ordered independently.
+
 
 ### Empty results
 
@@ -194,7 +215,7 @@ eval instant at 60s sum by (app) (count_over_time({app=~"foo|bar"}[1m]))
 eval range from 0 to 60s step 30s count_over_time({app="foo"}[30s])
   {app="foo"} _ 3 3
 
-eval select from 0 to 60s {app="foo"} |= "status=200"
+eval select from 0 to 60s forward {app="foo"} |= "status=200"
   {app="foo"} "level=info status=200" @ 10s
   {app="foo"} "level=info status=200" @ 20s
   {app="foo"} "level=info status=200" @ 30s

--- a/pkg/logql/internal/logqltest/exec_direct.go
+++ b/pkg/logql/internal/logqltest/exec_direct.go
@@ -53,7 +53,7 @@ func (s *directExecutionStack) eval(cmd evalCmd) (logqlmodel.Result, error) {
 	params, err := logql.NewLiteralParams(
 		cmd.query,
 		epoch.Add(start), epoch.Add(end), step, 0,
-		logproto.FORWARD, 1000, nil, nil,
+		cmd.direction, 1000, nil, nil,
 	)
 	if err != nil {
 		return logqlmodel.Result{}, err

--- a/pkg/logql/internal/logqltest/exec_query_frontend.go
+++ b/pkg/logql/internal/logqltest/exec_query_frontend.go
@@ -223,7 +223,7 @@ func (s *queryFrontendExecutionStack) eval(cmd evalCmd) (logqlmodel.Result, erro
 			Query:     cmd.query,
 			Limit:     1000,
 			TimeTs:    epoch.Add(cmd.ts),
-			Direction: logproto.FORWARD,
+			Direction: cmd.direction,
 			Path:      "/loki/api/v1/query",
 		}
 	} else {
@@ -233,7 +233,7 @@ func (s *queryFrontendExecutionStack) eval(cmd evalCmd) (logqlmodel.Result, erro
 			Step:      cmd.step.Milliseconds(),
 			StartTs:   epoch.Add(cmd.start),
 			EndTs:     epoch.Add(cmd.end),
-			Direction: logproto.FORWARD,
+			Direction: cmd.direction,
 			Path:      "/loki/api/v1/query_range",
 		}
 	}

--- a/pkg/logql/internal/logqltest/parser.go
+++ b/pkg/logql/internal/logqltest/parser.go
@@ -28,9 +28,6 @@ var epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 var (
 	// reInstant, reRange, and reSelect match the remainder of an `eval instant`/`eval range`/
 	// `eval select` line (after the mode keyword), capturing the trailing query to end of line.
-	// `eval select` requires a bare `forward`/`backward` direction before the query: the order the
-	// expected log lines are written in follows it, so a script that left it out would put the
-	// reader (and a default) in charge of reading the expectation block.
 	reInstant = regexp.MustCompile(`^at\s+(\S+)\s+(.+)$`)
 	reRange   = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+step\s+(\S+)\s+(.+)$`)
 	reSelect  = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+((?i:forward|backward))\s+(.+)$`)

--- a/pkg/logql/internal/logqltest/parser.go
+++ b/pkg/logql/internal/logqltest/parser.go
@@ -28,9 +28,12 @@ var epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 var (
 	// reInstant, reRange, and reSelect match the remainder of an `eval instant`/`eval range`/
 	// `eval select` line (after the mode keyword), capturing the trailing query to end of line.
+	// `eval select` requires a bare `forward`/`backward` direction before the query: the order the
+	// expected log lines are written in follows it, so a script that left it out would put the
+	// reader (and a default) in charge of reading the expectation block.
 	reInstant = regexp.MustCompile(`^at\s+(\S+)\s+(.+)$`)
 	reRange   = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+step\s+(\S+)\s+(.+)$`)
-	reSelect  = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+(.+)$`)
+	reSelect  = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+((?i:forward|backward))\s+(.+)$`)
 
 	// reAt, reRepeat and reMetadata are anchored to the head so each load-line directive matches
 	// only its own leading segment and can never reach into a later [metadata …] value.
@@ -215,8 +218,9 @@ const (
 
 type evalCmd struct {
 	mode             evalMode
-	ts               time.Duration // instant queries
-	start, end, step time.Duration // range and select queries
+	ts               time.Duration      // instant queries
+	start, end, step time.Duration      // range and select queries
+	direction        logproto.Direction // select queries
 	query            string
 }
 
@@ -287,10 +291,14 @@ func parseEval(line string) (evalCmd, error) {
 		if end <= start {
 			return evalCmd{}, fmt.Errorf("select end %q must be after start %q", m[2], m[1])
 		}
+		direction := logproto.FORWARD
+		if strings.EqualFold(m[3], "backward") {
+			direction = logproto.BACKWARD
+		}
 		// A log-selection query has no notion of a step; use one step covering the whole
 		// window so a query that unexpectedly turns out to be a metric query fails fast
 		// (wrong result shape) instead of hanging the step evaluator on a zero step.
-		return evalCmd{mode: evalSelect, start: start, end: end, step: end - start, query: strings.TrimSpace(m[3])}, nil
+		return evalCmd{mode: evalSelect, start: start, end: end, step: end - start, direction: direction, query: strings.TrimSpace(m[4])}, nil
 	default:
 		return evalCmd{}, fmt.Errorf("expected 'instant', 'range', or 'select' after eval: %q", line)
 	}

--- a/pkg/logql/internal/logqltest/parser_test.go
+++ b/pkg/logql/internal/logqltest/parser_test.go
@@ -166,12 +166,13 @@ func TestParseEval(t *testing.T) {
 	require.Equal(t, time.Minute, cmd.step)
 	require.Equal(t, `count_over_time({app="foo"}[1m])`, cmd.query)
 
-	cmd, err = parseEval(`eval select from 0 to 10m {app="foo"}`)
+	cmd, err = parseEval(`eval select from 0 to 10m forward {app="foo"}`)
 	require.NoError(t, err)
 	require.Equal(t, evalSelect, cmd.mode)
 	require.Equal(t, time.Duration(0), cmd.start)
 	require.Equal(t, 10*time.Minute, cmd.end)
 	require.Equal(t, 10*time.Minute, cmd.step)
+	require.Equal(t, logproto.FORWARD, cmd.direction)
 	require.Equal(t, `{app="foo"}`, cmd.query)
 
 	_, err = parseEval(`eval sideways at 0s foo`)
@@ -189,10 +190,56 @@ func TestParseEval(t *testing.T) {
 	require.Error(t, err)
 
 	// An empty or backwards select window has no valid step to derive.
-	_, err = parseEval(`eval select from 10s to 10s {app="foo"}`)
+	_, err = parseEval(`eval select from 10s to 10s forward {app="foo"}`)
 	require.Error(t, err)
-	_, err = parseEval(`eval select from 10s to 0s {app="foo"}`)
+	_, err = parseEval(`eval select from 10s to 0s forward {app="foo"}`)
 	require.Error(t, err)
+}
+
+func TestParseEval_SelectDirection(t *testing.T) {
+	for name, tc := range map[string]struct {
+		line      string
+		direction logproto.Direction
+		query     string
+	}{
+		"forward":          {`eval select from 0 to 10m forward {app="foo"}`, logproto.FORWARD, `{app="foo"}`},
+		"backward":         {`eval select from 0 to 10m backward {app="foo"}`, logproto.BACKWARD, `{app="foo"}`},
+		"case insensitive": {`eval select from 0 to 10m BackWard {app="foo"}`, logproto.BACKWARD, `{app="foo"}`},
+		"pipeline follows": {`eval select from 0 to 10m backward {app="foo"} |= "x" | logfmt`, logproto.BACKWARD, `{app="foo"} |= "x" | logfmt`},
+		"extra whitespace": {`eval select from 0 to 10m   backward   {app="foo"}`, logproto.BACKWARD, `{app="foo"}`},
+		// The direction is the token before the query, so the same word inside the query is
+		// query text.
+		"direction word inside the query": {`eval select from 0 to 10m forward {app="foo"} |= "backward"`, logproto.FORWARD, `{app="foo"} |= "backward"`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cmd, err := parseEval(tc.line)
+			require.NoError(t, err)
+			require.Equal(t, evalSelect, cmd.mode)
+			require.Equal(t, tc.direction, cmd.direction)
+			require.Equal(t, tc.query, cmd.query)
+		})
+	}
+
+	// The direction is required: a select line without one, or with a misspelled one, must be
+	// rejected rather than have the stray text folded into the query.
+	for name, line := range map[string]string{
+		"missing":             `eval select from 0 to 10m {app="foo"}`,
+		"misspelled":          `eval select from 0 to 10m backwards {app="foo"}`,
+		"unknown word":        `eval select from 0 to 10m sideways {app="foo"}`,
+		"direction, no query": `eval select from 0 to 10m backward`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseEval(line)
+			require.ErrorContains(t, err, "malformed 'eval select'")
+		})
+	}
+
+	// A metric query has no line order, so instant and range take no direction: one written there
+	// stays part of the query text, where LogQL rejects it.
+	cmd, err := parseEval(`eval instant at 60s backward count_over_time({app="foo"}[1m])`)
+	require.NoError(t, err)
+	require.Equal(t, `backward count_over_time({app="foo"}[1m])`, cmd.query)
+	require.Equal(t, logproto.FORWARD, cmd.direction)
 }
 
 func TestExpectationsParser(t *testing.T) {

--- a/pkg/logql/internal/logqltest/runner.go
+++ b/pkg/logql/internal/logqltest/runner.go
@@ -113,7 +113,7 @@ func runEval(t *testing.T, name string, stacks []executionStack, cmd evalCmd, ex
 	case evalRange:
 		label = "range: " + label
 	case evalSelect:
-		label = "select: " + label
+		label = "select " + strings.ToLower(cmd.direction.String()) + ": " + label
 	default:
 		panic(fmt.Sprintf("unknown eval mode %v", cmd.mode))
 	}

--- a/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
+++ b/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
@@ -81,15 +81,17 @@
     },
 
     "eval-select": {
+      "comment": "The bare `forward`/`backward` direction between the window and the query is required, and is matched by name so that a line with a misspelled one falls through to #eval-fallback instead of coloring the typo as a direction.",
       "name": "meta.command.eval.logqltest",
-      "begin": "^[ \\t]*(eval)[ \\t]+(select)[ \\t]+(from)[ \\t]+(\\S+)[ \\t]+(to)[ \\t]+(\\S+)[ \\t]+",
+      "begin": "^[ \\t]*(eval)[ \\t]+(select)[ \\t]+(from)[ \\t]+(\\S+)[ \\t]+(to)[ \\t]+(\\S+)[ \\t]+((?i:forward|backward))[ \\t]+",
       "beginCaptures": {
         "1": { "name": "keyword.control.eval.logqltest" },
         "2": { "name": "keyword.other.eval-mode.logqltest" },
         "3": { "name": "keyword.other.eval-argument.logqltest" },
         "4": { "name": "constant.numeric.duration.logqltest" },
         "5": { "name": "keyword.other.eval-argument.logqltest" },
-        "6": { "name": "constant.numeric.duration.logqltest" }
+        "6": { "name": "constant.numeric.duration.logqltest" },
+        "7": { "name": "constant.language.direction.logqltest" }
       },
       "end": "$",
       "patterns": [

--- a/pkg/logql/internal/logqltest/testdata/AGENTS.md
+++ b/pkg/logql/internal/logqltest/testdata/AGENTS.md
@@ -144,6 +144,10 @@ A log-selection query (e.g. `{app="foo"} |= "bar"`) uses `eval select`, not `eva
 instant`, and returns streams, not series — see README.md "Streams" expected results. The
 instant/range cross-check in the checklist above doesn't apply to log selection.
 
+Every `eval select` states a `forward` or `backward` direction, and expected lines within one
+stream are compared **in that order** — oldest first under `forward`, newest first under
+`backward`.
+
 ## Files
 
 One feature per file: `range_aggregations`, `vector_aggregations`, `binary_operations`,

--- a/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
@@ -11,18 +11,18 @@ load
   {app="bar"} "bar line" @ 15s
   {app="baz"} "noise"    @ 15s
 
-eval select from 0 to 30s {app="foo"}
+eval select from 0 to 30s forward {app="foo"}
   {app="foo"} "1st line" @ 10s
   {app="foo"} "2nd line" @ 20s
 
 # A regex selector across streams returns one result stream per match.
-eval select from 0 to 30s {app=~"foo|bar"}
+eval select from 0 to 30s forward {app=~"foo|bar"}
   {app="foo"} "1st line" @ 10s
   {app="foo"} "2nd line" @ 20s
   {app="bar"} "bar line" @ 15s
 
 # A selector matching nothing returns no streams.
-eval select from 0 to 30s {app="missing"}
+eval select from 0 to 30s forward {app="missing"}
   expect empty
 
 # The query window is start-inclusive, end-exclusive: unlike a metric range vector's (start,end],
@@ -32,7 +32,7 @@ load
   {app="foo"} "in range"    @ 10s
   {app="foo"} "at boundary" @ 20s
 
-eval select from 0 to 20s {app="foo"}
+eval select from 0 to 20s forward {app="foo"}
   {app="foo"} "in range" @ 10s
 
 # A `|=` line filter drops lines that don't contain the substring.
@@ -41,5 +41,47 @@ load
   {app="foo"} "status=200" @ 10s
   {app="foo"} "status=500" @ 20s   # noise: same stream, the filter must drop it
 
-eval select from 0 to 30s {app="foo"} |= "200"
+eval select from 0 to 30s forward {app="foo"} |= "200"
   {app="foo"} "status=200" @ 10s
+
+#
+# Direction. The window and the set of matching lines are the same either way; only the order the
+# lines come back in changes: oldest-first for `forward`, newest-first for `backward`.
+#
+clear
+load
+  {app="foo"} "1st line" @ 10s
+  {app="foo"} "2nd line" @ 20s
+  {app="foo"} "3rd line" @ 30s
+  {app="bar"} "bar 1st"  @ 15s
+  {app="bar"} "bar 2nd"  @ 25s
+
+eval select from 0 to 40s forward {app="foo"}
+  {app="foo"} "1st line" @ 10s
+  {app="foo"} "2nd line" @ 20s
+  {app="foo"} "3rd line" @ 30s
+
+eval select from 0 to 40s backward {app="foo"}
+  {app="foo"} "3rd line" @ 30s
+  {app="foo"} "2nd line" @ 20s
+  {app="foo"} "1st line" @ 10s
+
+eval select from 0 to 40s backward {app=~"foo|bar"}
+  {app="foo"} "3rd line" @ 30s
+  {app="foo"} "2nd line" @ 20s
+  {app="foo"} "1st line" @ 10s
+  {app="bar"} "bar 2nd"  @ 25s
+  {app="bar"} "bar 1st"  @ 15s
+
+# Direction does not widen the window: the `[start, end)` bounds still apply.
+eval select from 20s to 30s backward {app="foo"}
+  {app="foo"} "2nd line" @ 20s
+
+# A line filter runs before the ordering, so `backward` returns the surviving lines newest-first.
+eval select from 0 to 40s backward {app="foo"} |~ "1st|3rd"
+  {app="foo"} "3rd line" @ 30s
+  {app="foo"} "1st line" @ 10s
+
+# A selector matching nothing returns no streams, whichever direction it is read in.
+eval select from 0 to 40s backward {app="missing"}
+  expect empty


### PR DESCRIPTION
`eval select from <t0> to <t1> <forward|backward> <query>` — the direction is required, since it is also the order the expected stream block is written in. Basic ordering tests also added.

[This test](https://github.com/grafana/loki/pull/24211/changes#diff-4507337513763aa30c2c587ac6e2a49ed24437b5f0a7c0e431eecf1f862ebeffR69-R74) has me wondering if we should impose constraints on the way the expected values are represented.

The following two examples would also pass. Note the ordering differences of the expected results. This is due to the fact that Loki returns results ordered by time and grouped by stream. The test harness loads the expected lines and groups them by stream while preserving the time order. So both of the below expected results are equivalent.

```
# lines in time order
eval select from 0 to 40s backward {app=~"foo|bar"}
  {app="foo"} "3rd line" @ 30s
  {app="bar"} "bar 2nd"  @ 25s
  {app="foo"} "2nd line" @ 20s
  {app="bar"} "bar 1st"  @ 15s
  {app="foo"} "1st line" @ 10s

# bar stream split
eval select from 0 to 40s backward {app=~"foo|bar"}
  {app="bar"} "bar 2nd"  @ 25s
  {app="foo"} "3rd line" @ 30s
  {app="foo"} "2nd line" @ 20s
  {app="foo"} "1st line" @ 10s
  {app="bar"} "bar 1st"  @ 15s
```

Should we impose constraints at parse time on expected results for clarity? The two most obvious options to me are: 

- require that expected lines are ordered across all streams by time
- require that expected lines are grouped by stream
