### PR TITLE
fix(logql): Interpolate sharded quantile_over_time to match the exact aggregator

### DIFF
--- a/pkg/logql/internal/logqltest/README.md
+++ b/pkg/logql/internal/logqltest/README.md
@@ -155,22 +155,43 @@ eval instant at 60s sort(count_over_time({app=~"a|b"}[1m]))
 
 `expect ordered` is instant-only; use distinct, non-`NaN` values so the order is unambiguous.
 
-### Skipping value comparison on one stack
+### Relaxing or skipping value comparison on one stack
 
-Every query runs on multiple [execution stacks](#execution-stacks). When one stack returns values that
-legitimately differ skip its value check while keeping every other stack exact:
+Every query runs on multiple [execution stacks](#execution-stacks). Loosen the comparison, or skip
+it, when one stack legitimately returns different values. Keep every other stack exact.
+
+`expect values-toleration <epsilon> on "<stack>"` compares values on the named stack, but with
+`<epsilon>` in place of the default `1e-9` tolerance. Use this when a stack's result is
+approximate, but the query still exercises a real assertion — e.g. a sharded query whose value goes
+through a probabilistic sketch:
 
 ```
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
-  skip values-comparison on "query-frontend + query-scheduler (sharding)"
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {pod="1"} 3
   {pod="2"} 15
+```
+
+- `<epsilon>` is a plain positive, finite number, the same dual absolute/relative bound the
+  default `1e-9` uses: a match if the absolute difference is within `<epsilon>`, or the
+  difference relative to the larger magnitude is.
+- May repeat for multiple stacks, one directive per stack.
+
+`skip values-comparison on "<stack>"` drops the value check entirely for the named stack:
+
+```
+eval instant at 60s some_query_with_a_nondeterministic_value({app="a"}[1m])
+  skip values-comparison on "query-frontend + query-scheduler (sharding)"
+  {app="a"} 3
 ```
 
 - `<stack>` is the exact stack name, in double quotes.
 - The named stack still runs the query, must not error, and is still checked for series/stream
   count, sample/line count, and timestamps. Only the float value comparison (or, for a
   log-selection query, the log line text) is skipped.
+
+A stack can have `skip values-comparison` or `expect values-toleration`, not both — they're
+contradictory ("don't compare" vs. "compare, loosely").
 
 ## Execution stacks
 

--- a/pkg/logql/internal/logqltest/parser.go
+++ b/pkg/logql/internal/logqltest/parser.go
@@ -41,6 +41,9 @@ var (
 	// reSkip matches a `skip <what> on "<stack>"` directive in an expectation block.
 	reSkip = regexp.MustCompile(`^skip\s+(\S+)\s+on\s+"([^"]+)"$`)
 
+	// reValuesToleration matches an `expect values-toleration <epsilon> on "<stack>"` directive.
+	reValuesToleration = regexp.MustCompile(`^expect\s+values-toleration\s+(\S+)\s+on\s+"([^"]+)"$`)
+
 	// reMetadataKeyValue scans the key="value" pairs inside an already-extracted metadata block; it
 	// is intentionally not anchored.
 	reMetadataKeyValue = regexp.MustCompile(`(?:"([^"]*)"|([^\s"=]+))="([^"]*)"`)
@@ -327,6 +330,11 @@ type expectations struct {
 	// compared, set by a `skip values-comparison on "<stack>"` directive. The stack still runs and
 	// must not error; only the value/series comparison is skipped.
 	isValueComparisonSkipped map[string]bool
+
+	// valuesToleration holds, for a stack named by an `expect values-toleration <epsilon> on
+	// "<stack>"` directive, the relative tolerance to use for that stack's value comparison
+	// instead of defaultEpsilon.
+	valuesToleration map[string]float64
 }
 
 // validate ensures an eval asserts exactly one result kind: series, log streams, a scalar,
@@ -383,8 +391,9 @@ func newExpectationsParser() *expectationsParser {
 }
 
 // parse consumes one expectation line: an `expect` annotation (`fail [msg:|regex:]` / `empty` /
-// `ordered`), a `{labels} p0 p1 ...` series line, a `{labels} "line" @ <ts>` log-stream line, or a
-// bare scalar value.
+// `ordered` / `values-toleration <epsilon> on "<stack>"`), a `skip values-comparison on
+// "<stack>"` directive, a `{labels} p0 p1 ...` series line, a `{labels} "line" @ <ts>` log-stream
+// line, or a bare scalar value.
 func (p *expectationsParser) parse(line string) error {
 	switch {
 	case strings.HasPrefix(line, "expect fail"):
@@ -415,6 +424,29 @@ func (p *expectationsParser) parse(line string) error {
 	case line == "expect ordered":
 		// Compare the following series positionally rather than as a set (for sort/sort_desc).
 		p.exp.ordered = true
+	case strings.HasPrefix(line, "expect values-toleration"):
+		m := reValuesToleration.FindStringSubmatch(line)
+		if m == nil {
+			return fmt.Errorf(`invalid values-toleration directive %q (use: expect values-toleration <epsilon> on "<stack>")`, line)
+		}
+		epsilon, err := strconv.ParseFloat(m[1], 64)
+		if err != nil || !(epsilon > 0) || math.IsInf(epsilon, 0) {
+			return fmt.Errorf("invalid values-toleration value %q: must be a positive, finite number", m[1])
+		}
+		stack := m[2]
+		if !isKnownStackName(stack) {
+			return fmt.Errorf("unknown stack %q in values-toleration directive (known: %s)", stack, strings.Join(stackNames, ", "))
+		}
+		if p.exp.isValueComparisonSkipped[stack] {
+			return fmt.Errorf("stack %q already has values-comparison skipped; cannot also set a toleration", stack)
+		}
+		if _, dup := p.exp.valuesToleration[stack]; dup {
+			return fmt.Errorf("duplicate values-toleration directive for stack %q", stack)
+		}
+		if p.exp.valuesToleration == nil {
+			p.exp.valuesToleration = map[string]float64{}
+		}
+		p.exp.valuesToleration[stack] = epsilon
 	case strings.HasPrefix(line, "expect "):
 		// Reject unrecognized `expect` annotations rather than silently skipping them,
 		// which would let a script assert something the harness never actually checks.
@@ -430,6 +462,9 @@ func (p *expectationsParser) parse(line string) error {
 		}
 		if !isKnownStackName(stack) {
 			return fmt.Errorf("unknown stack %q in skip directive (known: %s)", stack, strings.Join(stackNames, ", "))
+		}
+		if _, hasToleration := p.exp.valuesToleration[stack]; hasToleration {
+			return fmt.Errorf("stack %q already has a values-toleration; cannot also skip values-comparison", stack)
 		}
 		if p.exp.isValueComparisonSkipped == nil {
 			p.exp.isValueComparisonSkipped = map[string]bool{}

--- a/pkg/logql/internal/logqltest/parser_test.go
+++ b/pkg/logql/internal/logqltest/parser_test.go
@@ -300,6 +300,69 @@ func TestExpectationsParser(t *testing.T) {
 		require.ErrorContains(t, newExpectationsParser().parse(`skip values-comparison "`+directStackName+`"`), "invalid skip directive")
 		require.ErrorContains(t, newExpectationsParser().parse(`skip values-comparison on `+directStackName), "invalid skip directive")
 	})
+
+	t.Run("values-toleration sets one stack's tolerance", func(t *testing.T) {
+		p := newExpectationsParser()
+		require.NoError(t, p.parse(`expect values-toleration 0.02 on "`+queryFrontendShardStackName+`"`))
+		require.NoError(t, p.parse(`{app="a"} 1`))
+		exp := p.get()
+		require.Equal(t, 0.02, exp.valuesToleration[queryFrontendShardStackName])
+		require.NotContains(t, exp.valuesToleration, directStackName)
+	})
+
+	t.Run("values-toleration directives accumulate across stacks", func(t *testing.T) {
+		p := newExpectationsParser()
+		require.NoError(t, p.parse(`expect values-toleration 0.01 on "`+directStackName+`"`))
+		require.NoError(t, p.parse(`expect values-toleration 0.02 on "`+queryFrontendShardStackName+`"`))
+		exp := p.get()
+		require.Equal(t, 0.01, exp.valuesToleration[directStackName])
+		require.Equal(t, 0.02, exp.valuesToleration[queryFrontendShardStackName])
+	})
+
+	t.Run("values-toleration with unknown stack is rejected", func(t *testing.T) {
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration 0.02 on "nope"`), "unknown stack")
+	})
+
+	t.Run("values-toleration with a non-positive, non-finite, or non-numeric value is rejected", func(t *testing.T) {
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration 0 on "`+directStackName+`"`), "must be a positive, finite number")
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration -0.01 on "`+directStackName+`"`), "must be a positive, finite number")
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration abc on "`+directStackName+`"`), "must be a positive, finite number")
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration NaN on "`+directStackName+`"`), "must be a positive, finite number")
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration Inf on "`+directStackName+`"`), "must be a positive, finite number")
+	})
+
+	t.Run("malformed values-toleration directive is rejected", func(t *testing.T) {
+		// Missing `on`, or an unquoted stack name.
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration 0.02 "`+directStackName+`"`), "invalid values-toleration directive")
+		require.ErrorContains(t, newExpectationsParser().parse(`expect values-toleration 0.02 on `+directStackName), "invalid values-toleration directive")
+	})
+
+	t.Run("a stack cannot both skip values-comparison and have a toleration", func(t *testing.T) {
+		// skip, then toleration, on the same stack.
+		p := newExpectationsParser()
+		require.NoError(t, p.parse(`skip values-comparison on "`+directStackName+`"`))
+		require.ErrorContains(t, p.parse(`expect values-toleration 0.02 on "`+directStackName+`"`), "cannot also set a toleration")
+
+		// toleration, then skip, on the same stack.
+		p = newExpectationsParser()
+		require.NoError(t, p.parse(`expect values-toleration 0.02 on "`+directStackName+`"`))
+		require.ErrorContains(t, p.parse(`skip values-comparison on "`+directStackName+`"`), "cannot also skip values-comparison")
+	})
+
+	t.Run("duplicate values-toleration directive for the same stack is rejected", func(t *testing.T) {
+		p := newExpectationsParser()
+		require.NoError(t, p.parse(`expect values-toleration 0.02 on "`+directStackName+`"`))
+		require.ErrorContains(t, p.parse(`expect values-toleration 0.03 on "`+directStackName+`"`), "duplicate values-toleration directive")
+	})
+
+	t.Run("skip and values-toleration on different stacks both apply", func(t *testing.T) {
+		p := newExpectationsParser()
+		require.NoError(t, p.parse(`skip values-comparison on "`+directStackName+`"`))
+		require.NoError(t, p.parse(`expect values-toleration 0.02 on "`+queryFrontendShardStackName+`"`))
+		exp := p.get()
+		require.True(t, exp.isValueComparisonSkipped[directStackName])
+		require.Equal(t, 0.02, exp.valuesToleration[queryFrontendShardStackName])
+	})
 }
 
 func TestExpectationsValidate(t *testing.T) {

--- a/pkg/logql/internal/logqltest/runner.go
+++ b/pkg/logql/internal/logqltest/runner.go
@@ -125,16 +125,27 @@ func runEval(t *testing.T, name string, stacks []executionStack, cmd evalCmd, ex
 					t.Skipf("%s: stack does not support this query", stack.name())
 				}
 				res, err := stack.eval(cmd)
-				assertResult(t, name, cmd, exp, res, err, stack.isQueryShardingSupported(), exp.isValueComparisonSkipped[stack.name()])
+				assertResult(t, name, cmd, exp, res, err, stack.isQueryShardingSupported(),
+					exp.isValueComparisonSkipped[stack.name()], effectiveEpsilon(exp, stack.name()))
 			})
 		}
 	})
 }
 
+// effectiveEpsilon returns the floating point comparison tolerance for stackName: the value set
+// by an `expect values-toleration <epsilon> on "<stack>"` directive if the eval has one for this
+// stack, or defaultEpsilon otherwise.
+func effectiveEpsilon(exp expectations, stackName string) float64 {
+	if v, ok := exp.valuesToleration[stackName]; ok {
+		return v
+	}
+	return defaultEpsilon
+}
+
 // assertResult applies exp to a result any execution stack produces. On a fail expectation it
 // checks the error; otherwise it compares the data and, for a sharding stack running a shardable
 // query, asserts the response reported at least two shards.
-func assertResult(t *testing.T, name string, cmd evalCmd, exp expectations, res logqlmodel.Result, err error, queryShardingEnabled, isValueComparisonSkipped bool) {
+func assertResult(t *testing.T, name string, cmd evalCmd, exp expectations, res logqlmodel.Result, err error, queryShardingEnabled, isValueComparisonSkipped bool, epsilon float64) {
 	t.Helper()
 
 	if exp.fail {
@@ -149,7 +160,7 @@ func assertResult(t *testing.T, name string, cmd evalCmd, exp expectations, res 
 	}
 
 	require.NoError(t, err, "%s: query %q", name, cmd.query)
-	require.NoError(t, compareResult(name, cmd, exp, res.Data, isValueComparisonSkipped))
+	require.NoError(t, compareResult(name, cmd, exp, res.Data, isValueComparisonSkipped, epsilon))
 
 	if queryShardingEnabled && isQueryShardingSupported(cmd.query) {
 		require.GreaterOrEqualf(t, res.Statistics.Summary.Shards, int64(2),
@@ -217,14 +228,15 @@ func consumeBlock(lines []string, i int, fn func(content string)) int {
 // Each compare* function below self-guards against every other expectation kind (so it gives a
 // clear "expected X, got Y" error even when called directly, as the tests do). With skipValues
 // true the comparators check result shape only — series count, timestamps, and present/absent
-// samples (or log lines) — and skip value equality.
-func compareResult(name string, cmd evalCmd, exp expectations, data any, skipValues bool) error {
+// samples (or log lines) — and skip value equality. Otherwise, values are compared within epsilon
+// (see floatsEqual).
+func compareResult(name string, cmd evalCmd, exp expectations, data any, skipValues bool, epsilon float64) error {
 	switch v := data.(type) {
 	case promql.Scalar:
 		if exp.empty {
 			return fmt.Errorf("%s: expected an empty result, got scalar %v", name, v.V)
 		}
-		return compareScalar(name, exp, v, skipValues)
+		return compareScalar(name, exp, v, skipValues, epsilon)
 	case promql.Vector:
 		if exp.empty {
 			if len(v) != 0 {
@@ -232,7 +244,7 @@ func compareResult(name string, cmd evalCmd, exp expectations, data any, skipVal
 			}
 			return nil
 		}
-		return compareVector(name, cmd, exp, v, skipValues)
+		return compareVector(name, cmd, exp, v, skipValues, epsilon)
 	case promql.Matrix:
 		if exp.empty {
 			if len(v) != 0 {
@@ -240,7 +252,7 @@ func compareResult(name string, cmd evalCmd, exp expectations, data any, skipVal
 			}
 			return nil
 		}
-		return compareMatrix(name, cmd, exp, v, skipValues)
+		return compareMatrix(name, cmd, exp, v, skipValues, epsilon)
 	case logqlmodel.Streams:
 		if exp.empty {
 			if len(v) != 0 {
@@ -254,7 +266,7 @@ func compareResult(name string, cmd evalCmd, exp expectations, data any, skipVal
 	}
 }
 
-func compareScalar(name string, exp expectations, s promql.Scalar, skipValues bool) error {
+func compareScalar(name string, exp expectations, s promql.Scalar, skipValues bool, epsilon float64) error {
 	if len(exp.series) > 0 {
 		return fmt.Errorf("%s: expected series, got a scalar", name)
 	}
@@ -264,13 +276,13 @@ func compareScalar(name string, exp expectations, s promql.Scalar, skipValues bo
 	if exp.scalar == nil {
 		return fmt.Errorf("%s: scalar result but no scalar value expected", name)
 	}
-	if !skipValues && !floatsEqual(*exp.scalar, s.V) {
+	if !skipValues && !floatsEqual(*exp.scalar, s.V, epsilon) {
 		return fmt.Errorf("%s: scalar mismatch: want %v, got %v", name, *exp.scalar, s.V)
 	}
 	return nil
 }
 
-func compareVector(name string, cmd evalCmd, exp expectations, v promql.Vector, skipValues bool) error {
+func compareVector(name string, cmd evalCmd, exp expectations, v promql.Vector, skipValues bool, epsilon float64) error {
 	if exp.scalar != nil {
 		return fmt.Errorf("%s: expected a scalar, got a vector", name)
 	}
@@ -299,7 +311,7 @@ func compareVector(name string, cmd evalCmd, exp expectations, v promql.Vector, 
 			if v[i].T != wantTS {
 				return fmt.Errorf("%s: series %s has timestamp %dms, expected %dms", name, v[i].Metric.String(), v[i].T, wantTS)
 			}
-			if !skipValues && !floatsEqual(es.samples[0].value, v[i].F) {
+			if !skipValues && !floatsEqual(es.samples[0].value, v[i].F, epsilon) {
 				return fmt.Errorf("%s: series %s (position %d) value mismatch: want %v, got %v", name, es.labels, i, es.samples[0].value, v[i].F)
 			}
 		}
@@ -340,14 +352,14 @@ func compareVector(name string, cmd evalCmd, exp expectations, v promql.Vector, 
 		if !ok {
 			return fmt.Errorf("%s: missing expected series %s; got %v", name, k, got)
 		}
-		if !skipValues && !floatsEqual(wv, gv) {
+		if !skipValues && !floatsEqual(wv, gv, epsilon) {
 			return fmt.Errorf("%s: series %s value mismatch: want %v, got %v", name, k, wv, gv)
 		}
 	}
 	return nil
 }
 
-func compareMatrix(name string, cmd evalCmd, exp expectations, m promql.Matrix, skipValues bool) error {
+func compareMatrix(name string, cmd evalCmd, exp expectations, m promql.Matrix, skipValues bool, epsilon float64) error {
 	if exp.scalar != nil {
 		return fmt.Errorf("%s: expected a scalar, got a matrix", name)
 	}
@@ -421,7 +433,7 @@ func compareMatrix(name string, cmd evalCmd, exp expectations, m promql.Matrix, 
 			if !has {
 				return fmt.Errorf("%s: series %s missing point at step %d (t=%dms)", name, k, i, ts)
 			}
-			if !skipValues && !floatsEqual(p.value, gv) {
+			if !skipValues && !floatsEqual(p.value, gv, epsilon) {
 				return fmt.Errorf("%s: series %s step %d value mismatch: want %v, got %v", name, k, i, p.value, gv)
 			}
 		}
@@ -490,7 +502,9 @@ func streamKeys(m map[string][]push.Entry) []string {
 	return out
 }
 
-func floatsEqual(a, b float64) bool {
+// floatsEqual reports whether a and b are equal within epsilon: the absolute difference is within
+// epsilon, or the difference relative to the larger magnitude is.
+func floatsEqual(a, b, epsilon float64) bool {
 	if math.IsNaN(a) || math.IsNaN(b) {
 		return math.IsNaN(a) && math.IsNaN(b)
 	}
@@ -498,10 +512,10 @@ func floatsEqual(a, b float64) bool {
 		return a == b
 	}
 	diff := math.Abs(a - b)
-	if diff <= defaultEpsilon {
+	if diff <= epsilon {
 		return true
 	}
-	return diff/math.Max(math.Abs(a), math.Abs(b)) <= defaultEpsilon
+	return diff/math.Max(math.Abs(a), math.Abs(b)) <= epsilon
 }
 
 func keys(m map[string]map[int64]float64) []string {

--- a/pkg/logql/internal/logqltest/runner_test.go
+++ b/pkg/logql/internal/logqltest/runner_test.go
@@ -107,125 +107,125 @@ func TestComparators_DetectMismatches(t *testing.T) {
 		want string
 	}{
 		"scalar value": {
-			err:  compareScalar("n", scalar(5), promql.Scalar{V: 6}, false),
+			err:  compareScalar("n", scalar(5), promql.Scalar{V: 6}, false, defaultEpsilon),
 			want: "scalar mismatch: want 5, got 6",
 		},
 		"vector value": {
-			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 6, T: ts}}, false),
+			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 6, T: ts}}, false, defaultEpsilon),
 			want: `series {app="a"} value mismatch: want 5, got 6`,
 		},
 		"vector wrong timestamp": {
-			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: 1000}}, false),
+			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: 1000}}, false, defaultEpsilon),
 			want: fmt.Sprintf(`series {app="a"} has timestamp 1000ms, expected %dms`, ts),
 		},
 		"vector ordered wrong timestamp": {
-			err:  compareVector("n", instantCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 5, T: 1000}}, false),
+			err:  compareVector("n", instantCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 5, T: 1000}}, false, defaultEpsilon),
 			want: fmt.Sprintf(`series {app="a"} has timestamp 1000ms, expected %dms`, ts),
 		},
 		"vector missing series": {
-			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{}, false),
+			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{}, false, defaultEpsilon),
 			want: `series count mismatch: want map[{app="a"}:5], got map[]`,
 		},
 		"vector extra series": {
-			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: ts}, {Metric: labels.FromStrings("app", "b"), F: 9, T: ts}}, false),
+			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: ts}, {Metric: labels.FromStrings("app", "b"), F: 9, T: ts}}, false, defaultEpsilon),
 			want: `series count mismatch: want map[{app="a"}:5], got map[{app="a"}:5 {app="b"}:9]`,
 		},
 		"vector duplicate result series": {
-			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: ts}, {Metric: foo, F: 5, T: ts}}, false),
+			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: ts}, {Metric: foo, F: 5, T: ts}}, false, defaultEpsilon),
 			want: `engine returned duplicate series {app="a"}`,
 		},
 		"matrix value": {
-			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 6}}}}, false),
+			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 6}}}}, false, defaultEpsilon),
 			want: `series {app="a"} step 0 value mismatch: want 5, got 6`,
 		},
 		"matrix missing point": {
-			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{}}}, false),
+			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{}}}, false, defaultEpsilon),
 			want: `series {app="a"} missing point at step 0`,
 		},
 		"matrix point at unexpected timestamp": {
-			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts + 1000, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts + 1000, F: 5}}}}, false, defaultEpsilon),
 			want: `series {app="a"} has point at unexpected timestamp`,
 		},
 		"matrix duplicate result series": {
 			err: compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{
 				{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}},
 				{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}},
-			}, false),
+			}, false, defaultEpsilon),
 			want: `engine returned duplicate series {app="a"}`,
 		},
 		"matrix duplicate point": {
-			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}, {T: ts, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}, {T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: `engine returned duplicate point for series {app="a"}`,
 		},
 		"empty expected but non-empty result": {
-			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Vector{{Metric: foo, F: 5}}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Vector{{Metric: foo, F: 5}}, false, defaultEpsilon),
 			want: "expected an empty result",
 		},
 		"scalar expected but empty vector": {
-			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, scalar(5), promql.Vector{}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, scalar(5), promql.Vector{}, false, defaultEpsilon),
 			want: "expected a scalar, got a vector",
 		},
 		"scalar expected but empty matrix": {
-			err:  compareResult("n", rangeCmd, scalar(5), promql.Matrix{}, false),
+			err:  compareResult("n", rangeCmd, scalar(5), promql.Matrix{}, false, defaultEpsilon),
 			want: "expected a scalar, got a matrix",
 		},
 		"empty expected but scalar result": {
-			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Scalar{V: 5}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Scalar{V: 5}, false, defaultEpsilon),
 			want: "expected an empty result, got scalar 5",
 		},
 		"empty expected but non-empty matrix": {
-			err:  compareResult("n", rangeCmd, expectations{empty: true}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			err:  compareResult("n", rangeCmd, expectations{empty: true}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: "expected an empty result, got 1 series",
 		},
 		"scalar result but no scalar expected": {
-			err:  compareScalar("n", expectations{}, promql.Scalar{V: 5}, false),
+			err:  compareScalar("n", expectations{}, promql.Scalar{V: 5}, false, defaultEpsilon),
 			want: "scalar result but no scalar value expected",
 		},
 		"vector missing series (count matches)": {
-			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: labels.FromStrings("app", "b"), F: 5, T: ts}}, false),
+			err:  compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: labels.FromStrings("app", "b"), F: 5, T: ts}}, false, defaultEpsilon),
 			want: `missing expected series {app="a"}`,
 		},
 		"matrix missing series (count matches)": {
-			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: labels.FromStrings("app", "b"), Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: labels.FromStrings("app", "b"), Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: `missing expected series {app="a"}`,
 		},
 		"matrix expected points vs steps": {
-			err:  compareMatrix("n", rangeCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}, {present: true, value: 6}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}, {present: true, value: 6}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: "has 2 points, expected 1 steps",
 		},
 		"matrix gap but value present": {
-			err:  compareMatrix("n", rangeCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: false}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: false}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: "should be empty, got 5",
 		},
 		"duplicate expected vector series": {
-			err:  compareVector("n", instantCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}, {labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 5}}, false),
+			err:  compareVector("n", instantCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}, {labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 5}}, false, defaultEpsilon),
 			want: `duplicate expected series {app="a"}`,
 		},
 		"duplicate expected matrix series": {
-			err:  compareMatrix("n", rangeCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}, {labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}, {labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: `duplicate expected series {app="a"}`,
 		},
 		"ordered value mismatch": {
-			err:  compareVector("n", instantCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 6, T: ts}}, false),
+			err:  compareVector("n", instantCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 6, T: ts}}, false, defaultEpsilon),
 			want: `series {app="a"} (position 0) value mismatch: want 5, got 6`,
 		},
 		"ordered count mismatch": {
-			err:  compareVector("n", instantCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 5}, {Metric: labels.FromStrings("app", "b"), F: 5}}, false),
+			err:  compareVector("n", instantCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Vector{{Metric: foo, F: 5}, {Metric: labels.FromStrings("app", "b"), F: 5}}, false, defaultEpsilon),
 			want: "series count mismatch: want 1, got 2",
 		},
 		"ordered position mismatch": {
 			err: compareVector("n", instantCmd, expectations{ordered: true, series: []expectedSeries{
 				{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}},
 				{labels: `{app="b"}`, samples: []sample{{present: true, value: 6}}},
-			}}, promql.Vector{{Metric: labels.FromStrings("app", "b"), F: 6}, {Metric: foo, F: 5}}, false),
+			}}, promql.Vector{{Metric: labels.FromStrings("app", "b"), F: 6}, {Metric: foo, F: 5}}, false, defaultEpsilon),
 			want: `series at position 0: want {app="a"}, got {app="b"}`,
 		},
 		"matrix ordered unsupported": {
-			err:  compareMatrix("n", rangeCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, expectations{ordered: true, series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}}}}}, promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: "`expect ordered` is only supported for instant queries",
 		},
 		"unsupported result type": {
-			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, oneSeries(5), nil, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, oneSeries(5), nil, false, defaultEpsilon),
 			want: "unsupported result type",
 		},
 		"streams line mismatch": {
@@ -286,23 +286,23 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			want: `engine returned duplicate stream {app="a"}`,
 		},
 		"vector expected but got streams": {
-			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, oneSeries(5), logqlmodel.Streams{}, false),
+			err:  compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, oneSeries(5), logqlmodel.Streams{}, false, defaultEpsilon),
 			want: "expected series, got log streams",
 		},
 		"streams expected but got vector": {
-			err:  compareVector("n", instantCmd, oneStream("a"), promql.Vector{{Metric: foo, F: 5}}, false),
+			err:  compareVector("n", instantCmd, oneStream("a"), promql.Vector{{Metric: foo, F: 5}}, false, defaultEpsilon),
 			want: "expected log streams, got a vector",
 		},
 		"streams expected but got matrix": {
-			err:  compareMatrix("n", rangeCmd, oneStream("a"), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false),
+			err:  compareMatrix("n", rangeCmd, oneStream("a"), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon),
 			want: "expected log streams, got a matrix",
 		},
 		"streams expected but got scalar": {
-			err:  compareScalar("n", oneStream("a"), promql.Scalar{V: 5}, false),
+			err:  compareScalar("n", oneStream("a"), promql.Scalar{V: 5}, false, defaultEpsilon),
 			want: "expected log streams, got a scalar",
 		},
 		"series expected but got scalar": {
-			err:  compareScalar("n", oneSeries(5), promql.Scalar{V: 5}, false),
+			err:  compareScalar("n", oneSeries(5), promql.Scalar{V: 5}, false, defaultEpsilon),
 			want: "expected series, got a scalar",
 		},
 		"scalar expected but got streams": {
@@ -314,7 +314,7 @@ func TestComparators_DetectMismatches(t *testing.T) {
 		"empty expected but non-empty streams": {
 			err: compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{
 				{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
-			}, false),
+			}, false, defaultEpsilon),
 			want: "expected an empty result, got 1 streams",
 		},
 	} {
@@ -331,16 +331,16 @@ func TestComparators_AcceptMatches(t *testing.T) {
 	instantCmd := evalCmd{mode: evalInstant, ts: time.Minute}
 	ts := epoch.Add(time.Minute).UnixMilli()
 
-	require.NoError(t, compareScalar("n", expectations{scalar: &scalar}, promql.Scalar{V: 5}, false))
-	require.NoError(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: ts}}, false))
-	require.NoError(t, compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false))
-	require.NoError(t, compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Vector{}, false))
+	require.NoError(t, compareScalar("n", expectations{scalar: &scalar}, promql.Scalar{V: 5}, false, defaultEpsilon))
+	require.NoError(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 5, T: ts}}, false, defaultEpsilon))
+	require.NoError(t, compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon))
+	require.NoError(t, compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, promql.Vector{}, false, defaultEpsilon))
 
 	// A matrix gap (`_`) matches a step the engine legitimately omitted.
 	require.NoError(t, compareMatrix("n",
 		evalCmd{mode: evalRange, start: time.Minute, end: 2 * time.Minute, step: time.Minute},
 		expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: true, value: 5}, {present: false}}}}},
-		promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false))
+		promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, false, defaultEpsilon))
 
 	// Ordered series in the expected order.
 	require.NoError(t, compareVector("n", instantCmd,
@@ -348,7 +348,7 @@ func TestComparators_AcceptMatches(t *testing.T) {
 			{labels: `{app="a"}`, samples: []sample{{present: true, value: 1}}},
 			{labels: `{app="b"}`, samples: []sample{{present: true, value: 2}}},
 		}},
-		promql.Vector{{Metric: foo, F: 1, T: ts}, {Metric: labels.FromStrings("app", "b"), F: 2, T: ts}}, false))
+		promql.Vector{{Metric: foo, F: 1, T: ts}, {Metric: labels.FromStrings("app", "b"), F: 2, T: ts}}, false, defaultEpsilon))
 
 	// Log streams: matched as a set by label, lines compared in order within each stream.
 	require.NoError(t, compareStreams("n",
@@ -360,7 +360,7 @@ func TestComparators_AcceptMatches(t *testing.T) {
 			{Labels: `{app="b"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "x"}}},
 			{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "1st"}, {Timestamp: epoch.Add(time.Second), Line: "2nd"}}},
 		}, false))
-	require.NoError(t, compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{}, false))
+	require.NoError(t, compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{}, false, defaultEpsilon))
 }
 
 func TestComparators_SkipValues(t *testing.T) {
@@ -374,9 +374,9 @@ func TestComparators_SkipValues(t *testing.T) {
 	)
 
 	t.Run("value mismatches are ignored", func(t *testing.T) {
-		require.NoError(t, compareScalar("n", scalar(5), promql.Scalar{V: 6}, true))
-		require.NoError(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 6, T: ts}}, true))
-		require.NoError(t, compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 6}}}}, true))
+		require.NoError(t, compareScalar("n", scalar(5), promql.Scalar{V: 6}, true, defaultEpsilon))
+		require.NoError(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{{Metric: foo, F: 6, T: ts}}, true, defaultEpsilon))
+		require.NoError(t, compareMatrix("n", rangeCmd, oneSeries(5), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 6}}}}, true, defaultEpsilon))
 		require.NoError(t, compareStreams("n", oneStream("a"),
 			logqlmodel.Streams{{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "wrong line"}}}}, true))
 	})
@@ -384,18 +384,18 @@ func TestComparators_SkipValues(t *testing.T) {
 	// The values below are deliberately wrong (6, not 5): the shape check must still fire.
 	t.Run("sample count mismatches still error", func(t *testing.T) {
 		// Vector: too few, too many, or a differently-labelled series.
-		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{}, true), "series count mismatch")
+		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(5), promql.Vector{}, true, defaultEpsilon), "series count mismatch")
 		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(5),
-			promql.Vector{{Metric: foo, F: 6, T: ts}, {Metric: bar, F: 6, T: ts}}, true), "series count mismatch")
+			promql.Vector{{Metric: foo, F: 6, T: ts}, {Metric: bar, F: 6, T: ts}}, true, defaultEpsilon), "series count mismatch")
 		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(5),
-			promql.Vector{{Metric: bar, F: 6, T: ts}}, true), "missing expected series")
+			promql.Vector{{Metric: bar, F: 6, T: ts}}, true, defaultEpsilon), "missing expected series")
 
 		// Matrix: a step the engine omitted, or a gap the engine filled.
 		require.ErrorContains(t, compareMatrix("n", rangeCmd, oneSeries(5),
-			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{}}}, true), "missing point at step 0")
+			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{}}}, true, defaultEpsilon), "missing point at step 0")
 		require.ErrorContains(t, compareMatrix("n", rangeCmd,
 			expectations{series: []expectedSeries{{labels: `{app="a"}`, samples: []sample{{present: false}}}}},
-			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, true), "should be empty")
+			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 5}}}}, true, defaultEpsilon), "should be empty")
 
 		// Streams: a missing stream, or a missing line within one, still errors even though a
 		// present line's text would have been skipped.
@@ -409,9 +409,9 @@ func TestComparators_SkipValues(t *testing.T) {
 
 	t.Run("timestamp mismatches still error", func(t *testing.T) {
 		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(5),
-			promql.Vector{{Metric: foo, F: 6, T: 1000}}, true), "has timestamp 1000ms")
+			promql.Vector{{Metric: foo, F: 6, T: 1000}}, true, defaultEpsilon), "has timestamp 1000ms")
 		require.ErrorContains(t, compareMatrix("n", rangeCmd, oneSeries(5),
-			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts + 1000, F: 6}}}}, true), "unexpected timestamp")
+			promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts + 1000, F: 6}}}}, true, defaultEpsilon), "unexpected timestamp")
 		require.ErrorContains(t, compareStreams("n", oneStream("a"),
 			logqlmodel.Streams{{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch.Add(time.Second), Line: "a"}}}}, true),
 			fmt.Sprintf("has timestamp %dms", epoch.Add(time.Second).UnixMilli()))
@@ -422,16 +422,58 @@ func oneStream(line string) expectations {
 	return expectations{streams: []expectedStream{{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: line}}}}}
 }
 
+func TestComparators_ValuesToleration(t *testing.T) {
+	var (
+		foo        = labels.FromStrings("app", "a")
+		instantCmd = evalCmd{mode: evalInstant, ts: time.Minute}
+		rangeCmd   = evalCmd{mode: evalRange, start: time.Minute, end: time.Minute, step: time.Minute}
+		ts         = epoch.Add(time.Minute).UnixMilli()
+		scalar     = func(v float64) expectations { return expectations{scalar: &v} }
+	)
+
+	t.Run("a value within the given tolerance passes", func(t *testing.T) {
+		require.NoError(t, compareScalar("n", scalar(100), promql.Scalar{V: 102}, false, 0.02))
+		require.NoError(t, compareVector("n", instantCmd, oneSeries(100), promql.Vector{{Metric: foo, F: 102, T: ts}}, false, 0.02))
+		require.NoError(t, compareMatrix("n", rangeCmd, oneSeries(100), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 102}}}}, false, 0.02))
+	})
+
+	t.Run("a value outside the given tolerance still fails", func(t *testing.T) {
+		require.ErrorContains(t, compareScalar("n", scalar(100), promql.Scalar{V: 103}, false, 0.02), "scalar mismatch")
+		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(100), promql.Vector{{Metric: foo, F: 103, T: ts}}, false, 0.02), "value mismatch")
+		require.ErrorContains(t, compareMatrix("n", rangeCmd, oneSeries(100), promql.Matrix{{Metric: foo, Floats: []promql.FPoint{{T: ts, F: 103}}}}, false, 0.02), "value mismatch")
+	})
+
+	t.Run("shape checks still fire regardless of tolerance", func(t *testing.T) {
+		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(100), promql.Vector{}, false, 0.02), "series count mismatch")
+		require.ErrorContains(t, compareVector("n", instantCmd, oneSeries(100),
+			promql.Vector{{Metric: foo, F: 102, T: 1000}}, false, 0.02), "has timestamp 1000ms")
+	})
+}
+
+func TestEffectiveEpsilon(t *testing.T) {
+	exp := expectations{valuesToleration: map[string]float64{directStackName: 0.1}}
+
+	require.Equal(t, 0.1, effectiveEpsilon(exp, directStackName))
+	// A stack not named in a values-toleration directive keeps the tight default, rather than
+	// inheriting a toleration meant for a different stack.
+	require.Equal(t, defaultEpsilon, effectiveEpsilon(exp, queryFrontendShardStackName))
+	require.Equal(t, defaultEpsilon, effectiveEpsilon(expectations{}, directStackName))
+}
+
 func TestFloatsEqual(t *testing.T) {
-	require.True(t, floatsEqual(1, 1))
-	require.True(t, floatsEqual(1, 1+1e-12))   // within absolute epsilon
-	require.True(t, floatsEqual(1e10, 1e10+1)) // within relative epsilon
-	require.True(t, floatsEqual(math.NaN(), math.NaN()))
-	require.True(t, floatsEqual(math.Inf(1), math.Inf(1)))
-	require.False(t, floatsEqual(1, 1.1))
-	require.False(t, floatsEqual(100, 101))
-	require.False(t, floatsEqual(math.NaN(), 1))
-	require.False(t, floatsEqual(math.Inf(1), math.Inf(-1)))
+	require.True(t, floatsEqual(1, 1, defaultEpsilon))
+	require.True(t, floatsEqual(1, 1+1e-12, defaultEpsilon))   // within absolute epsilon
+	require.True(t, floatsEqual(1e10, 1e10+1, defaultEpsilon)) // within relative epsilon
+	require.True(t, floatsEqual(math.NaN(), math.NaN(), defaultEpsilon))
+	require.True(t, floatsEqual(math.Inf(1), math.Inf(1), defaultEpsilon))
+	require.False(t, floatsEqual(1, 1.1, defaultEpsilon))
+	require.False(t, floatsEqual(100, 101, defaultEpsilon))
+	require.False(t, floatsEqual(math.NaN(), 1, defaultEpsilon))
+	require.False(t, floatsEqual(math.Inf(1), math.Inf(-1), defaultEpsilon))
+
+	// A custom epsilon widens (or narrows) the bound.
+	require.True(t, floatsEqual(100, 102, 0.02))
+	require.False(t, floatsEqual(100, 103, 0.02))
 }
 
 func oneSeries(val float64) expectations {

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -281,10 +281,13 @@ eval instant at 60s quantile_over_time(0.5, {app="a"}[1m])
 
 # quantile_over_time() with grouping.
 #
-# Sharded quantile_over_time is computed from an approximate DDSketch, so its value differs from the
-# exact unsharded quantile (sharply on these tiny fixtures: it returns the value at the rank, not the
-# interpolated one). Skip the value comparison on the sharding stack; direct and no-sharding still
-# assert the exact values.
+# Sharded quantile_over_time is computed from an approximate DDSketch, so its value differs
+# from the exact unsharded quantile. Both interpolate between the same two ranked samples, but
+# the sketch only stores which bucket a sample falls into, so each is off by the bucket's ~1%
+# relative error.
+#
+# Allow that on the sharding stack with a 2% toleration; direct and no-sharding still assert the
+# exact values.
 clear
 load
   {app="a", pod="1"} "v=2"  @ 20s
@@ -294,23 +297,47 @@ load
   {app="a", pod="1"} "noise" @ 25s
 
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
-  skip values-comparison on "query-frontend + query-scheduler (sharding)"
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {pod="1"} 3
   {pod="2"} 15
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (app)
-  skip values-comparison on "query-frontend + query-scheduler (sharding)"
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {app="a"} 7
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) without (pod)
-  skip values-comparison on "query-frontend + query-scheduler (sharding)"
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {app="a"} 7
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) without (app)
-  skip values-comparison on "query-frontend + query-scheduler (sharding)"
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {pod="1"} 3
   {pod="2"} 15
 eval range from 60s to 70s step 10s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
-  skip values-comparison on "query-frontend + query-scheduler (sharding)"
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
   {pod="1"} 3 3
   {pod="2"} 15 15
+eval instant at 60s quantile_over_time(0, {app="a"} | logfmt | unwrap v [1m]) by (pod)
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
+  {pod="1"} 2
+  {pod="2"} 10
+eval instant at 60s quantile_over_time(1, {app="a"} | logfmt | unwrap v [1m]) by (pod)
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
+  {pod="1"} 4
+  {pod="2"} 20
+eval instant at 60s quantile_over_time(1.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} +Inf
+  {pod="2"} +Inf
+
+# quantile_over_time() with grouping: a group's unwrapped values are all non-finite (NaN).
+clear
+load
+  {app="a", pod="1"} "v=2"   @ 20s
+  {app="a", pod="1"} "v=4"   @ 30s
+  {app="a", pod="2"} "v=NaN" @ 20s
+  {app="a", pod="2"} "v=NaN" @ 30s
+
+eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
+  expect values-toleration 0.02 on "query-frontend + query-scheduler (sharding)"
+  {pod="1"} 3
+  {pod="2"} NaN
 
 # unwrap of a stream label `bar`.
 clear

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -366,6 +366,7 @@ func (*QuantileSketchMatrixStepEvaluator) Explain(parent Node) {
 type QuantileSketchVectorStepEvaluator struct {
 	inner    StepEvaluator
 	quantile float64
+	err      error
 }
 
 var _ StepEvaluator = NewQuantileSketchVectorStepEvaluator(nil, 0)
@@ -387,7 +388,11 @@ func (e *QuantileSketchVectorStepEvaluator) Next() (bool, int64, StepResult) {
 	vec := make(promql.Vector, len(quantileSketchVec))
 
 	for i, quantileSketch := range quantileSketchVec {
-		f, _ := quantileSketch.F.Quantile(e.quantile)
+		f, err := quantileSketch.F.Quantile(e.quantile)
+		if err != nil {
+			e.err = err
+			return false, 0, SampleVector{}
+		}
 
 		vec[i] = promql.Sample{
 			T:      quantileSketch.T,
@@ -401,4 +406,4 @@ func (e *QuantileSketchVectorStepEvaluator) Next() (bool, int64, StepResult) {
 
 func (*QuantileSketchVectorStepEvaluator) Close() error { return nil }
 
-func (*QuantileSketchVectorStepEvaluator) Error() error { return nil }
+func (e *QuantileSketchVectorStepEvaluator) Error() error { return e.err }

--- a/pkg/logql/quantile_over_time_sketch_test.go
+++ b/pkg/logql/quantile_over_time_sketch_test.go
@@ -73,6 +73,28 @@ func TestJoinQuantileSketchVectorError(t *testing.T) {
 	require.ErrorContains(t, err, "could not evaluate")
 }
 
+func TestQuantileSketchVectorStepEvaluator_Next_ShouldSurfaceUnderlyingError(t *testing.T) {
+	// DDSketchQuantile.Quantile never errors today (it returns NaN/±Inf at the edges
+	// instead), so this uses a TDigestQuantile sample, whose Quantile still rejects a
+	// quantile outside (0, 1).
+	//
+	// We still want to preserve this test to protect for future regressions in case
+	// DDSketchQuantile.Quantile implementation will change.
+	inner := &QuantileSketchStepEvaluator{
+		iter: errorRangeVectorIterator{
+			result: ProbabilisticQuantileVector{
+				{T: 0, F: sketch.NewTDigestSketch(), Metric: labels.FromStrings("foo", "bar")},
+			},
+		},
+	}
+
+	ev := NewQuantileSketchVectorStepEvaluator(inner, -0.1)
+
+	ok, _, _ := ev.Next()
+	require.False(t, ok)
+	require.Error(t, ev.Error())
+}
+
 type errorRangeVectorIterator struct {
 	err    error
 	result StepResult

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -3,6 +3,7 @@ package logql
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 	"testing"
@@ -637,4 +638,90 @@ func TestQuantiles(t *testing.T) {
 			}
 		}
 	}
+}
+
+// FuzzDDSketchQuantileMatchesExact checks that DDSketchQuantile.Quantile stays within the
+// sketch's relative accuracy of the exact (unsharded) Quantile across sample counts, magnitudes,
+// and quantiles, including the edges (an empty sample set, or a quantile outside [0, 1]) where
+// both must agree on the same NaN/±Inf sentinel rather than just a close value.
+func FuzzDDSketchQuantileMatchesExact(f *testing.F) {
+	// The sketch's relative accuracy (1%) plus margin. Same value as TestQuantiles above and
+	// the sharding toleration in range_aggregations.logqltest.
+	const fuzzQuantileEpsilon = 0.02
+
+	f.Add(int64(1), uint8(1), 0.5, 1.0)     // q=0.5, single value
+	f.Add(int64(2), uint8(2), 0.5, 10.0)    // q=0.5, two values
+	f.Add(int64(3), uint8(4), 0.0, 100.0)   // q=0, minimum
+	f.Add(int64(4), uint8(4), 1.0, 100.0)   // q=1, maximum
+	f.Add(int64(5), uint8(255), 0.5, 1e6)   // q=0.5, dense, large magnitude
+	f.Add(int64(8), uint8(255), 0.9, 1e-6)  // q=0.9, dense, small magnitude
+	f.Add(int64(6), uint8(10), 0.25, 1e-6)  // q=0.25, sparse, small magnitude
+	f.Add(int64(7), uint8(20), 0.75, 100.0) // q=0.75, third quartile
+	f.Add(int64(9), uint8(0), 0.5, 100.0)   // q=0.5, empty sample set
+	f.Add(int64(10), uint8(4), 1.5, 100.0)  // q=1.5, out of [0, 1]
+	f.Add(int64(11), uint8(4), -0.5, 100.0) // q=-0.5, out of [0, 1]
+
+	f.Fuzz(func(t *testing.T, seed int64, n uint8, q, scale float64) {
+		if math.IsNaN(q) {
+			t.Skip("quantile is NaN: undefined for both implementations")
+		}
+		if math.IsNaN(scale) || math.IsInf(scale, 0) {
+			t.Skip("non-finite scale")
+		}
+
+		r := rand.New(rand.NewSource(seed))
+		values := make(vector.HeapByMaxValue, n)
+		sk := sketch.NewDDSketch()
+		for i := range values {
+			v := (r.Float64()*2 - 1) * scale // uniform in [-scale, scale]
+			values[i] = promql.Sample{F: v}
+			if err := sk.Add(v); err != nil {
+				t.Skip("value outside the sketch's indexable range")
+			}
+		}
+
+		want := Quantile(q, values)
+		got, err := sk.Quantile(q)
+		require.NoError(t, err)
+
+		switch {
+		case math.IsNaN(want):
+			// An empty sample set: both must return NaN, not just agree numerically (NaN
+			// never equals itself under ==, let alone under a tolerance check).
+			if !math.IsNaN(got) {
+				t.Fatalf("want NaN (empty sample set), got %v: seed=%d n=%d q=%v scale=%v", got, seed, n, q, scale)
+			}
+		case math.IsInf(want, 0):
+			// A quantile outside [0, 1]: both must return the same sentinel infinity exactly,
+			// not just a close value (Inf - Inf is NaN, so a tolerance check can't verify this).
+			if got != want {
+				t.Fatalf("want %v (quantile outside [0, 1]), got %v: seed=%d n=%d q=%v scale=%v", want, got, seed, n, q, scale)
+			}
+		default:
+			// Each bracketing order statistic is only ~1% accurate on its own.
+			//
+			// Averaging two of them can inflate the result's relative error when they nearly
+			// cancel (opposite signs, e.g. a median of {8.5, -20.7}). That is inherent to
+			// interpolating quantized points, not a bug. Bound the divergence against the
+			// inputs' known magnitude (|scale|) instead of the result, which cancellation can
+			// shrink toward zero and hide a real divergence.
+			absTolerance := fuzzQuantileEpsilon * math.Abs(scale)
+			diff := math.Abs(want - got)
+			if diff > absTolerance && !quantilesClose(want, got, fuzzQuantileEpsilon) {
+				t.Fatalf("sketch quantile diverges from exact beyond tolerance: seed=%d n=%d q=%v scale=%v want=%v got=%v diff=%v",
+					seed, n, q, scale, want, got, diff)
+			}
+		}
+	})
+}
+
+// quantilesClose reports whether want and got are within epsilon of each other, as an absolute
+// difference or, if larger, a relative one — the latter alone breaks down when want is 0 or very
+// small.
+func quantilesClose(want, got, epsilon float64) bool {
+	diff := math.Abs(want - got)
+	if diff <= epsilon {
+		return true
+	}
+	return diff/math.Max(math.Abs(want), math.Abs(got)) <= epsilon
 }

--- a/pkg/logql/sketch/quantile.go
+++ b/pkg/logql/sketch/quantile.go
@@ -3,6 +3,7 @@ package sketch
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/DataDog/sketches-go/ddsketch"
@@ -56,11 +57,69 @@ func NewDDSketch() *DDSketchQuantile {
 	return &DDSketchQuantile{s}
 }
 
+// Quantile returns the value at the given quantile.
+//
+// It linearly interpolates between the two order statistics bracketing the
+// quantile's rank, the same way the exact (unsharded) quantile_over_time
+// aggregator does. It also matches that aggregator's contract at the edges:
+// an empty sketch returns NaN, and a quantile outside [0, 1] returns -Inf or
+// +Inf, rather than an error.
 func (d *DDSketchQuantile) Quantile(quantile float64) (float64, error) {
-	if quantile >= 1.0 || quantile <= 0 {
-		return 0.0, errors.New("invalid quantile value, must be between 0.0 and 1.0 ")
+	count := d.GetCount()
+	if count == 0 {
+		return math.NaN(), nil
 	}
-	return d.GetValueAtQuantile(quantile)
+	if quantile < 0 {
+		return math.Inf(-1), nil
+	}
+	if quantile > 1 {
+		return math.Inf(1), nil
+	}
+	if count == 1 {
+		// Rank is always 0: nothing to interpolate.
+		return d.GetValueAtQuantile(quantile)
+	}
+
+	// quantile * (count - 1) can be computed with more precision than a float64 actually
+	// stores. Go lets the compiler carry that extra precision into the calculations below
+	// instead of discarding it right away, and whether it does depends on the CPU and
+	// compiler. The float64(...) conversion discards the extra precision immediately, so
+	// rank is a plain float64 from here on, the same on every machine. GetValueAtQuantile
+	// does this same conversion, for the same reason, on its own rank.
+	rank := float64(quantile * (count - 1))
+	lower := math.Floor(rank)
+	upper := math.Min(count-1, lower+1)
+
+	lowerValue := d.valueAtRank(lower)
+	if lower == upper {
+		return lowerValue, nil
+	}
+
+	weight := rank - lower
+	upperValue := d.valueAtRank(upper)
+	return lowerValue*(1-weight) + upperValue*weight, nil
+}
+
+// valueAtRank returns the sketch's approximate value of the element at the
+// given 0-indexed rank among all added values in ascending order. Rank must
+// be in [0, count-1].
+//
+// This function mirrors the logic that [ddsketch.DDSketch.GetValueAtQuantile]
+// uses internally.
+func (d *DDSketchQuantile) valueAtRank(rank float64) float64 {
+	var (
+		negativeValueCount = d.GetNegativeValueStore().TotalCount()
+		zeroCount          = d.GetZeroCount()
+	)
+
+	switch {
+	case rank < negativeValueCount:
+		return -d.Value(d.GetNegativeValueStore().KeyAtRank(negativeValueCount - 1 - rank))
+	case rank < zeroCount+negativeValueCount:
+		return 0
+	default:
+		return d.Value(d.GetPositiveValueStore().KeyAtRank(rank - zeroCount - negativeValueCount))
+	}
 }
 
 func (d *DDSketchQuantile) Merge(other QuantileSketch) (QuantileSketch, error) {

--- a/pkg/logql/sketch/quantile_test.go
+++ b/pkg/logql/sketch/quantile_test.go
@@ -78,13 +78,13 @@ func TestDDSketchQuantile_Quantile(t *testing.T) {
 	t.Run("0th and 100th quantile", func(t *testing.T) {
 		s := newDDSketchWithValues(t, 2, 4, 10, 20)
 
-		min, err := s.Quantile(0)
+		minQuantile, err := s.Quantile(0)
 		require.NoError(t, err)
-		require.InEpsilon(t, 2.0, min, 0.02)
+		require.InEpsilon(t, 2.0, minQuantile, 0.02)
 
-		max, err := s.Quantile(1)
+		maxQuantile, err := s.Quantile(1)
 		require.NoError(t, err)
-		require.InEpsilon(t, 20.0, max, 0.02)
+		require.InEpsilon(t, 20.0, maxQuantile, 0.02)
 	})
 
 	t.Run("quantile outside [0, 1]", func(t *testing.T) {

--- a/pkg/logql/sketch/quantile_test.go
+++ b/pkg/logql/sketch/quantile_test.go
@@ -1,0 +1,112 @@
+package sketch
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDDSketchQuantile_Quantile(t *testing.T) {
+	t.Run("should linearly interpolate values", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			values []float64
+			q      float64
+			exact  float64
+		}{
+			{name: "two values, median", values: []float64{2, 4}, q: 0.5, exact: 3},
+			{name: "four values, median", values: []float64{2, 4, 10, 20}, q: 0.5, exact: 7},
+			{name: "four values, q=0.25", values: []float64{2, 4, 10, 20}, q: 0.25, exact: 3.5},
+			{name: "four values, q=0.75", values: []float64{2, 4, 10, 20}, q: 0.75, exact: 12.5},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				s := newDDSketchWithValues(t, tc.values...)
+
+				actual, err := s.Quantile(tc.q)
+				require.NoError(t, err)
+				require.InEpsilon(t, tc.exact, actual, 0.02)
+			})
+		}
+	})
+
+	// Exercises interpolation between order statistics that fall on either side of
+	// the sketch's separately tracked negative, zero, and positive stores.
+	t.Run("should linearly interpolate across sign boundary", func(t *testing.T) {
+		for _, tc := range []struct {
+			name           string
+			values         []float64
+			q              float64
+			exact          float64
+			toleratedDelta float64
+		}{
+			// Rank lands exactly on the two zero-valued order statistics: interpolating
+			// between them must still yield exactly 0, not a rounded approximation.
+			{name: "interpolates within the zero bucket", values: []float64{-10, -5, 0, 0, 3, 8}, q: 0.5, exact: 0, toleratedDelta: 0},
+			// Rank lands between a negative and a positive order statistic, with no
+			// zero values in between.
+			{name: "interpolates negative to positive", values: []float64{-4, 6}, q: 0.5, exact: 1, toleratedDelta: 0.1},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				s := newDDSketchWithValues(t, tc.values...)
+
+				actual, err := s.Quantile(tc.q)
+				require.NoError(t, err)
+				require.InDelta(t, tc.exact, actual, tc.toleratedDelta)
+			})
+		}
+	})
+
+	t.Run("empty sketch", func(t *testing.T) {
+		s := NewDDSketch()
+
+		actual, err := s.Quantile(0.5)
+		require.NoError(t, err)
+		require.True(t, math.IsNaN(actual))
+	})
+
+	t.Run("single value", func(t *testing.T) {
+		s := newDDSketchWithValues(t, 5)
+
+		for _, q := range []float64{0, 0.3, 0.5, 1} {
+			actual, err := s.Quantile(q)
+			require.NoError(t, err)
+			require.InEpsilon(t, 5.0, actual, 0.02)
+		}
+	})
+
+	t.Run("0th and 100th quantile", func(t *testing.T) {
+		s := newDDSketchWithValues(t, 2, 4, 10, 20)
+
+		min, err := s.Quantile(0)
+		require.NoError(t, err)
+		require.InEpsilon(t, 2.0, min, 0.02)
+
+		max, err := s.Quantile(1)
+		require.NoError(t, err)
+		require.InEpsilon(t, 20.0, max, 0.02)
+	})
+
+	t.Run("quantile outside [0, 1]", func(t *testing.T) {
+		s := newDDSketchWithValues(t, 1, 2, 3)
+
+		below, err := s.Quantile(-0.1)
+		require.NoError(t, err)
+		require.Equal(t, math.Inf(-1), below)
+
+		above, err := s.Quantile(1.1)
+		require.NoError(t, err)
+		require.Equal(t, math.Inf(1), above)
+	})
+}
+
+// newDDSketchWithValues returns a DDSketchQuantile with each of values added to it.
+func newDDSketchWithValues(t *testing.T, values ...float64) *DDSketchQuantile {
+	t.Helper()
+
+	s := NewDDSketch()
+	for _, v := range values {
+		require.NoError(t, s.Add(v))
+	}
+	return s
+}

--- a/pkg/logql/testdata/fuzz/FuzzDDSketchQuantileMatchesExact/9021d149317bf8d9
+++ b/pkg/logql/testdata/fuzz/FuzzDDSketchQuantileMatchesExact/9021d149317bf8d9
@@ -1,0 +1,5 @@
+go test fuzz v1
+int64(-6)
+byte('\x02')
+float64(0.5)
+float64(30)

--- a/pkg/logql/testdata/fuzz/FuzzDDSketchQuantileMatchesExact/9021d149317bf8d9
+++ b/pkg/logql/testdata/fuzz/FuzzDDSketchQuantileMatchesExact/9021d149317bf8d9
@@ -1,5 +1,0 @@
-go test fuzz v1
-int64(-6)
-byte('\x02')
-float64(0.5)
-float64(30)


### PR DESCRIPTION
**What this PR does / why we need it**:

Sharded `quantile_over_time` computed its result from a DDSketch that returned the value at the nearest bucket for a quantile's rank, instead of interpolating between the two bracketing order statistics the way the exact (unsharded) aggregator does. On sparse data this diverged sharply from the exact result (e.g. two samples `{2, 4}` at `q=0.5`: exact `3`, sharded `~1.98`).

Fixing this also surfaced (and fixes) a related silent-failure bug: an error from the sketch's quantile extraction was discarded instead of surfacing, silently turning a failure into a wrong `0` in the result. Once that error propagates, the sketch's own edge-case behavior mattered: it treated an empty input and a quantile outside `[0, 1]` as errors, where the exact aggregator treats them as `NaN`/`±Inf`. The sketch now matches that contract instead of erroring.

The `logqltest` DSL gains `expect values-toleration <epsilon> on "<stack>"`, a per-stack relative-tolerance override for value comparison (alongside the existing `skip values-comparison`, which drops the check entirely). This lets the sharded `quantile_over_time` test cases assert real values again instead of opting out of the comparison.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/loki-private/issues/2752

**Special notes for your reviewer**:
- `pkg/logql/sketch/quantile.go`: the core fix — `DDSketchQuantile.Quantile` and its new `valueAtRank` helper, plus the NaN/±Inf edge-case contract.
- `pkg/logql/quantile_over_time_sketch.go`: the discarded-error fix in `QuantileSketchVectorStepEvaluator.Next`.
- `pkg/logql/internal/logqltest/{parser,runner}.go` + `README.md`: the new `values-toleration` directive.
- `pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest`: sharded `quantile_over_time` cases now assert real values (including `q=0`, `q=1`, an out-of-range `q`, and an all-`NaN` group) instead of skipping the comparison.
- `pkg/logql/range_vector_test.go`: a new fuzz test (`FuzzDDSketchQuantileMatchesExact`) checking the sketch stays within tolerance of the exact aggregator across sample counts, magnitudes, and quantiles, including the edges.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)