### PR TITLE
fix(logql): Reject converting comparisons against __error__ and __error_details__

### DIFF
--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -233,7 +233,7 @@ We support multiple **value** types which are automatically inferred from the qu
 
 String type work exactly like Prometheus label matchers use in [log stream selector](#log-stream-selector). This means you can use the same operations (`=`,`!=`,`=~`,`!~`).
 
-> The string type is the only one that can test the `__error__` label, as in `| __error__=""`. The other comparison operators convert the label value before they compare it, and cannot read `__error__`, so a predicate such as `| __error__ > 0` matches no log line at all.
+> The string type is the only one that can test the `__error__` label, as in `| __error__=""`. The other comparison operators convert the label value before they compare it, and cannot read `__error__` or `__error_details__`. A predicate such as `| __error__ > 0` fails to parse; use a string comparison instead, such as `| __error__ != ""`.
 
 Using Duration, Number and Bytes will convert the label value prior to comparison and support the following comparators:
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -43,6 +43,10 @@ The default value of `-frontend.encoding` / `frontend.encoding` changed from `js
 
 Schedulers and queriers already accept both encodings, so mixed frontends during a rolling upgrade are safe. To keep the previous behavior, set `frontend.encoding: json` explicitly.
 
+### LogQL rejects numeric, duration, bytes, and `ip()` comparisons against `__error__` and `__error_details__`
+
+A query such as `| __error__ > 0`, `| __error__ != 1s`, `| __error_details__ == 1MB`, or `| __error__ = ip("1.2.3.4")` now fails to parse. These two labels always hold a string (or are unset), so a numeric, duration, bytes, or IP comparison against them could never find a match; such a query used to parse successfully and then silently return no results. This also applies after `| unwrap`. Use a string comparison instead, for example `| __error__ != ""` or `| __error__=""`.
+
 ### `frontend.compress_responses` default changed to `true`
 
 The default value of `frontend.compress_responses` changed to `true`. A bug in Loki 3.4.0 unintentionally switched it to `false`. If you don't want the query-frontend to compress HTTP responses, set `frontend.compress_responses` to `false` explicitly.

--- a/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
@@ -1065,9 +1065,31 @@ eval instant at 60s count_over_time({app="a"} | logfmt | __error_details__="" | 
 # A string filter reads __error__, so it keeps the failing line and the error reaches the result.
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__!="" [1m])
   expect fail msg: LabelFilterErr
-# A converting filter cannot read __error__, so the same intent drops every line instead.
+# A converting filter cannot read __error__ or __error_details__ and is rejected at
+# parse time.
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ > 0 [1m])
-  expect empty
+  expect fail msg: __error__ is a string label and cannot be compared with __error__>0
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ >= 0 [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__>=0
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ < 1 [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__<1
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ <= 1 [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__<=1
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ != 0 [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__!=0
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ == 0 [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__==0
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error_details__ > 0 [1m])
+  expect fail msg: __error_details__ is a string label and cannot be compared with __error_details__>0
+# The ip() filter is a converting comparison too and is rejected the same way.
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ = ip("127.0.0.1") [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__=ip("127.0.0.1")
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ != ip("127.0.0.1") [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__!=ip("127.0.0.1")
+# __error__ is only ever set by the unwrap conversion itself here, so a
+# converting filter placed after "unwrap" is rejected the same way.
+eval instant at 60s sum_over_time({app="a"} | logfmt | unwrap bytes(size) | __error__ > 0 [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__>0
 # A line skipped by a comparison (e.g. size < 1MB) doesn't fail the query even if
 # another comparison in the query has failed (e.g. took > 1s).
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s and size < 1MB [1m])

--- a/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
@@ -1069,18 +1069,18 @@ eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__!=
 # parse time.
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ > 0 [1m])
   expect fail msg: __error__ is a string label and cannot be compared with __error__>0
-eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ >= 0 [1m])
-  expect fail msg: __error__ is a string label and cannot be compared with __error__>=0
-eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ < 1 [1m])
-  expect fail msg: __error__ is a string label and cannot be compared with __error__<1
-eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ <= 1 [1m])
-  expect fail msg: __error__ is a string label and cannot be compared with __error__<=1
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ != 0 [1m])
   expect fail msg: __error__ is a string label and cannot be compared with __error__!=0
-eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ == 0 [1m])
-  expect fail msg: __error__ is a string label and cannot be compared with __error__==0
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ > 1s [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__>1s
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error_details__ > 0 [1m])
   expect fail msg: __error_details__ is a string label and cannot be compared with __error_details__>0
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error_details__ != 1s [1m])
+  expect fail msg: __error_details__ is a string label and cannot be compared with __error_details__!=1s
+# The check applies wherever the filter appears, including combined with
+# another filter via "and".
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s and __error__ > 0 [1m])
+  expect fail msg: __error__ is a string label and cannot be compared with __error__>0
 # The ip() filter is a converting comparison too and is rejected the same way.
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ = ip("127.0.0.1") [1m])
   expect fail msg: __error__ is a string label and cannot be compared with __error__=ip("127.0.0.1")

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -1126,7 +1126,39 @@ func mustNewNumericLabelFilter(t log.LabelFilterType, name string, lit *LiteralE
 	if err != nil {
 		panic(err)
 	}
-	return log.NewNumericLabelFilter(t, name, v)
+	f := log.NewNumericLabelFilter(t, name, v)
+	mustNotCompareReservedErrorLabel(name, f)
+	return f
+}
+
+func mustNewDurationLabelFilter(t log.LabelFilterType, name string, d time.Duration) log.LabelFilterer {
+	f := log.NewDurationLabelFilter(t, name, d)
+	mustNotCompareReservedErrorLabel(name, f)
+	return f
+}
+
+func mustNewBytesLabelFilter(t log.LabelFilterType, name string, b uint64) log.LabelFilterer {
+	f := log.NewBytesLabelFilter(t, name, b)
+	mustNotCompareReservedErrorLabel(name, f)
+	return f
+}
+
+func mustNewIPLabelFilter(pattern, name string, t log.LabelFilterType) log.LabelFilterer {
+	f := log.NewIPLabelFilter(pattern, name, t)
+	mustNotCompareReservedErrorLabel(name, f)
+	return f
+}
+
+// mustNotCompareReservedErrorLabel panics if name is __error__ or
+// __error_details__.
+func mustNotCompareReservedErrorLabel(name string, filter fmt.Stringer) {
+	if name != logqlmodel.ErrorLabel && name != logqlmodel.ErrorDetailsLabel {
+		return
+	}
+	panic(logqlmodel.NewParseError(fmt.Sprintf(
+		"%s is a string label and cannot be compared with %s; use a string comparison instead, for example %s=\"\" or %s!=\"\"",
+		name, filter.String(), name, name,
+	), 0, 0))
 }
 
 type UnwrapExpr struct {

--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
-	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -235,9 +234,6 @@ func validateSampleExpr(expr SampleExpr) error {
 }
 
 func validateSampleSelector(expr SampleExpr) error {
-	if err := validateUnwrapPostFilters(expr); err != nil {
-		return err
-	}
 	selector, err := expr.Selector()
 	if err != nil {
 		return err
@@ -245,103 +241,13 @@ func validateSampleSelector(expr SampleExpr) error {
 	return validateLogSelectorExpression(selector)
 }
 
-// validateUnwrapPostFilters validates the label filters placed after
-// "unwrap".
-func validateUnwrapPostFilters(expr SampleExpr) error {
-	var r *LogRangeExpr
-
-	// Every SampleExpr implementation has its own case here, so a new one that
-	// wraps a LogRangeExpr is never silently skipped.
-	//
-	// A new implementation falls into default below instead, which fails
-	// until someone decides whether it can wrap unwrap post-filters.
-	switch e := expr.(type) {
-	case *RangeAggregationExpr:
-		r = e.Left
-	case *LabelAggregationExpr:
-		r = e.Left
-	case *CountDistinctSketchExpr:
-		r = e.Left
-	case *BinOpExpr, *VectorAggregationExpr, *LabelReplaceExpr, *LiteralExpr, *VectorExpr:
-		return nil
-	default:
-		return logqlmodel.NewParseError(fmt.Sprintf("unknown sample expr: %T", expr), 0, 0)
-	}
-	if r == nil || r.Unwrap == nil {
-		return nil
-	}
-	for _, f := range r.Unwrap.PostFilters {
-		if err := validateLabelFilterer(f); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func validateLogSelectorExpression(expr LogSelectorExpr) error {
 	switch e := expr.(type) {
 	case *VectorExpr:
 		return nil
 	default:
-		if err := validateMatchers(e.Matchers()); err != nil {
-			return err
-		}
-		return validateLabelFilters(e)
+		return validateMatchers(e.Matchers())
 	}
-}
-
-// validateLabelFilters returns the first invalid label filter error found
-// in expr, or nil if expr has none.
-func validateLabelFilters(expr Expr) error {
-	var err error
-	visitor := &DepthFirstTraversal{
-		VisitLabelFilterFn: func(_ RootVisitor, e *LabelFilterExpr) {
-			if err == nil {
-				err = validateLabelFilterer(e.LabelFilterer)
-			}
-		},
-	}
-	expr.Accept(visitor)
-	return err
-}
-
-func validateLabelFilterer(f log.LabelFilterer) error {
-	// Every log.LabelFilterer implementation has its own case here, so a
-	// new implementation is never silently accepted.
-	//
-	// A new implementation falls into default below instead, which fails
-	// until someone decides whether it can read __error__ and __error_details__.
-	switch lf := f.(type) {
-	case *log.BinaryLabelFilter:
-		if err := validateLabelFilterer(lf.Left); err != nil {
-			return err
-		}
-		return validateLabelFilterer(lf.Right)
-	case *log.NumericLabelFilter:
-		return validateNotReservedErrorLabelFilter(lf.Name, lf)
-	case *log.DurationLabelFilter:
-		return validateNotReservedErrorLabelFilter(lf.Name, lf)
-	case *log.BytesLabelFilter:
-		return validateNotReservedErrorLabelFilter(lf.Name, lf)
-	case *log.IPLabelFilter:
-		return validateNotReservedErrorLabelFilter(lf.Label, lf)
-	case *log.StringLabelFilter, *log.LineFilterLabelFilter, *log.NoopLabelFilter:
-		return nil
-	default:
-		return logqlmodel.NewParseError(fmt.Sprintf("unknown label filterer: %T", f), 0, 0)
-	}
-}
-
-// validateNotReservedErrorLabelFilter rejects filter if name is __error__ or
-// __error_details__.
-func validateNotReservedErrorLabelFilter(name string, filter fmt.Stringer) error {
-	if name != logqlmodel.ErrorLabel && name != logqlmodel.ErrorDetailsLabel {
-		return nil
-	}
-	return logqlmodel.NewParseError(fmt.Sprintf(
-		"%s is a string label and cannot be compared with %s; use a string comparison instead, for example %s=\"\" or %s!=\"\"",
-		name, filter.String(), name, name,
-	), 0, 0)
 }
 
 // validateSortGrouping prevent by|without groupings on sort operations.

--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -234,6 +235,9 @@ func validateSampleExpr(expr SampleExpr) error {
 }
 
 func validateSampleSelector(expr SampleExpr) error {
+	if err := validateUnwrapPostFilters(expr); err != nil {
+		return err
+	}
 	selector, err := expr.Selector()
 	if err != nil {
 		return err
@@ -241,13 +245,103 @@ func validateSampleSelector(expr SampleExpr) error {
 	return validateLogSelectorExpression(selector)
 }
 
+// validateUnwrapPostFilters validates the label filters placed after
+// "unwrap".
+func validateUnwrapPostFilters(expr SampleExpr) error {
+	var r *LogRangeExpr
+
+	// Every SampleExpr implementation has its own case here, so a new one that
+	// wraps a LogRangeExpr is never silently skipped.
+	//
+	// A new implementation falls into default below instead, which fails
+	// until someone decides whether it can wrap unwrap post-filters.
+	switch e := expr.(type) {
+	case *RangeAggregationExpr:
+		r = e.Left
+	case *LabelAggregationExpr:
+		r = e.Left
+	case *CountDistinctSketchExpr:
+		r = e.Left
+	case *BinOpExpr, *VectorAggregationExpr, *LabelReplaceExpr, *LiteralExpr, *VectorExpr:
+		return nil
+	default:
+		return logqlmodel.NewParseError(fmt.Sprintf("unknown sample expr: %T", expr), 0, 0)
+	}
+	if r == nil || r.Unwrap == nil {
+		return nil
+	}
+	for _, f := range r.Unwrap.PostFilters {
+		if err := validateLabelFilterer(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func validateLogSelectorExpression(expr LogSelectorExpr) error {
 	switch e := expr.(type) {
 	case *VectorExpr:
 		return nil
 	default:
-		return validateMatchers(e.Matchers())
+		if err := validateMatchers(e.Matchers()); err != nil {
+			return err
+		}
+		return validateLabelFilters(e)
 	}
+}
+
+// validateLabelFilters returns the first invalid label filter error found
+// in expr, or nil if expr has none.
+func validateLabelFilters(expr Expr) error {
+	var err error
+	visitor := &DepthFirstTraversal{
+		VisitLabelFilterFn: func(_ RootVisitor, e *LabelFilterExpr) {
+			if err == nil {
+				err = validateLabelFilterer(e.LabelFilterer)
+			}
+		},
+	}
+	expr.Accept(visitor)
+	return err
+}
+
+func validateLabelFilterer(f log.LabelFilterer) error {
+	// Every log.LabelFilterer implementation has its own case here, so a
+	// new implementation is never silently accepted.
+	//
+	// A new implementation falls into default below instead, which fails
+	// until someone decides whether it can read __error__ and __error_details__.
+	switch lf := f.(type) {
+	case *log.BinaryLabelFilter:
+		if err := validateLabelFilterer(lf.Left); err != nil {
+			return err
+		}
+		return validateLabelFilterer(lf.Right)
+	case *log.NumericLabelFilter:
+		return validateNotReservedErrorLabelFilter(lf.Name, lf)
+	case *log.DurationLabelFilter:
+		return validateNotReservedErrorLabelFilter(lf.Name, lf)
+	case *log.BytesLabelFilter:
+		return validateNotReservedErrorLabelFilter(lf.Name, lf)
+	case *log.IPLabelFilter:
+		return validateNotReservedErrorLabelFilter(lf.Label, lf)
+	case *log.StringLabelFilter, *log.LineFilterLabelFilter, *log.NoopLabelFilter:
+		return nil
+	default:
+		return logqlmodel.NewParseError(fmt.Sprintf("unknown label filterer: %T", f), 0, 0)
+	}
+}
+
+// validateNotReservedErrorLabelFilter rejects filter if name is __error__ or
+// __error_details__.
+func validateNotReservedErrorLabelFilter(name string, filter fmt.Stringer) error {
+	if name != logqlmodel.ErrorLabel && name != logqlmodel.ErrorDetailsLabel {
+		return nil
+	}
+	return logqlmodel.NewParseError(fmt.Sprintf(
+		"%s is a string label and cannot be compared with %s; use a string comparison instead, for example %s=\"\" or %s!=\"\"",
+		name, filter.String(), name, name,
+	), 0, 0)
 }
 
 // validateSortGrouping prevent by|without groupings on sort operations.

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -2,6 +2,7 @@ package syntax
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -3790,4 +3791,91 @@ func TestParseUnreservedWordsAsLabelNames(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestParseExpr_ShouldValidateLabelComparison(t *testing.T) {
+	t.Run("rejects converting comparisons against __error__ and __error_details__", func(t *testing.T) {
+		operators := []string{">", ">=", "<", "<=", "!=", "==", "="}
+		for _, label := range []string{"__error__", "__error_details__"} {
+			for _, rhs := range []string{"0", "1s", "1MB"} {
+				for _, op := range operators {
+					query := fmt.Sprintf(`{app="foo"} | logfmt | %s %s %s`, label, op, rhs)
+					t.Run(query, func(t *testing.T) {
+						_, err := ParseExpr(query)
+						require.Error(t, err)
+						require.ErrorIs(t, err, logqlmodel.ErrParse)
+						require.Contains(t, err.Error(), label)
+						require.Contains(t, err.Error(), "cannot be compared")
+					})
+				}
+			}
+
+			for _, op := range []string{"=", "!="} {
+				query := fmt.Sprintf(`{app="foo"} | logfmt | %s %s ip("127.0.0.1")`, label, op)
+				t.Run(query, func(t *testing.T) {
+					_, err := ParseExpr(query)
+					require.Error(t, err)
+					require.ErrorIs(t, err, logqlmodel.ErrParse)
+					require.Contains(t, err.Error(), label)
+					require.Contains(t, err.Error(), "cannot be compared")
+				})
+			}
+		}
+
+		for _, query := range []string{
+			`{app="foo"} | logfmt | foo > 1 and __error__ > 0`,
+			`{app="foo"} | logfmt | __error__ > 0 and foo > 1`,
+			`{app="foo"} | logfmt | foo > 1 or __error__ > 0`,
+			`{app="foo"} | logfmt | __error__ > 0 and __error_details__ > 0`,
+			`count_over_time({app="foo"} | logfmt | __error__ > 0 [5m])`,
+			`label_replace(count_over_time({app="foo"} | logfmt | __error__ > 0 [5m]), "foo", "bar", "src", "dst")`,
+		} {
+			t.Run(query, func(t *testing.T) {
+				_, err := ParseExpr(query)
+				require.Error(t, err)
+				require.ErrorIs(t, err, logqlmodel.ErrParse)
+			})
+		}
+	})
+
+	t.Run("rejects converting comparisons after unwrap", func(t *testing.T) {
+		// __error__ is only ever set by the unwrap conversion itself for these
+		// queries, so a filter placed after "| unwrap" is exactly where users
+		// write the predicate.
+		for _, query := range []string{
+			`sum_over_time({app="foo"} | logfmt | unwrap bytes | __error__ > 0 [5m])`,
+			`avg_over_time({app="foo"} | logfmt | unwrap duration(latency) | __error_details__ > 1s [5m])`,
+			`sum_over_time({app="foo"} | logfmt | unwrap bytes | __error__ != ip("127.0.0.1") [5m])`,
+			`quantile_over_time(0.99, {app="foo"} | logfmt | unwrap bytes | __error_details__ >= 1MB [5m])`,
+		} {
+			t.Run(query, func(t *testing.T) {
+				_, err := ParseExpr(query)
+				require.Error(t, err)
+				require.ErrorIs(t, err, logqlmodel.ErrParse)
+				require.Contains(t, err.Error(), "cannot be compared")
+			})
+		}
+	})
+
+	t.Run("allows string comparisons against __error__ and __error_details__, and converting comparisons against ordinary labels", func(t *testing.T) {
+		for _, query := range []string{
+			`{app="foo"} | logfmt | __error__=""`,
+			`{app="foo"} | logfmt | __error__!=""`,
+			`{app="foo"} | logfmt | __error__=~".+"`,
+			`{app="foo"} | logfmt | __error__!~".+"`,
+			`{app="foo"} | logfmt | __error__="JSONParserErr"`,
+			`{app="foo"} | logfmt | __error_details__=""`,
+			`{app="foo"} | logfmt | latency > 1s`,
+			`{app="foo"} | logfmt | latency <= 1s`,
+			`{app="foo"} | logfmt | size == 1MB`,
+			`sum_over_time({app="foo"} | logfmt | unwrap bytes [5m])`,
+			`sum_over_time({app="foo"} | logfmt | unwrap bytes | __error__="" [5m])`,
+			`sum_over_time({app="foo"} | logfmt | unwrap bytes | bytes > 1MB [5m])`,
+		} {
+			t.Run(query, func(t *testing.T) {
+				_, err := ParseExpr(query)
+				require.NoError(t, err)
+			})
+		}
+	})
 }

--- a/pkg/logql/syntax/syntax.y
+++ b/pkg/logql/syntax/syntax.y
@@ -318,8 +318,8 @@ labelExtractionExpressionList:
   ;
 
 ipLabelFilter:
-    IDENTIFIER EQ IP OPEN_PARENTHESIS STRING CLOSE_PARENTHESIS { $$ = log.NewIPLabelFilter($5, $1,log.LabelFilterEqual) }
-  | IDENTIFIER NEQ IP OPEN_PARENTHESIS STRING CLOSE_PARENTHESIS { $$ = log.NewIPLabelFilter($5, $1, log.LabelFilterNotEqual) }
+    IDENTIFIER EQ IP OPEN_PARENTHESIS STRING CLOSE_PARENTHESIS { $$ = mustNewIPLabelFilter($5, $1, log.LabelFilterEqual) }
+  | IDENTIFIER NEQ IP OPEN_PARENTHESIS STRING CLOSE_PARENTHESIS { $$ = mustNewIPLabelFilter($5, $1, log.LabelFilterNotEqual) }
   ;
 
 unitFilter:
@@ -327,23 +327,23 @@ unitFilter:
     | bytesFilter    { $$ = $1 }
 
 durationFilter:
-      IDENTIFIER GT DURATION      { $$ = log.NewDurationLabelFilter(log.LabelFilterGreaterThan, $1, $3) }
-    | IDENTIFIER GTE DURATION     { $$ = log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, $1, $3) }
-    | IDENTIFIER LT DURATION      { $$ = log.NewDurationLabelFilter(log.LabelFilterLesserThan, $1, $3) }
-    | IDENTIFIER LTE DURATION     { $$ = log.NewDurationLabelFilter(log.LabelFilterLesserThanOrEqual, $1, $3) }
-    | IDENTIFIER NEQ DURATION     { $$ = log.NewDurationLabelFilter(log.LabelFilterNotEqual, $1, $3) }
-    | IDENTIFIER EQ DURATION      { $$ = log.NewDurationLabelFilter(log.LabelFilterEqual, $1, $3) }
-    | IDENTIFIER CMP_EQ DURATION  { $$ = log.NewDurationLabelFilter(log.LabelFilterEqual, $1, $3) }
+      IDENTIFIER GT DURATION      { $$ = mustNewDurationLabelFilter(log.LabelFilterGreaterThan, $1, $3) }
+    | IDENTIFIER GTE DURATION     { $$ = mustNewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, $1, $3) }
+    | IDENTIFIER LT DURATION      { $$ = mustNewDurationLabelFilter(log.LabelFilterLesserThan, $1, $3) }
+    | IDENTIFIER LTE DURATION     { $$ = mustNewDurationLabelFilter(log.LabelFilterLesserThanOrEqual, $1, $3) }
+    | IDENTIFIER NEQ DURATION     { $$ = mustNewDurationLabelFilter(log.LabelFilterNotEqual, $1, $3) }
+    | IDENTIFIER EQ DURATION      { $$ = mustNewDurationLabelFilter(log.LabelFilterEqual, $1, $3) }
+    | IDENTIFIER CMP_EQ DURATION  { $$ = mustNewDurationLabelFilter(log.LabelFilterEqual, $1, $3) }
     ;
 
 bytesFilter:
-      IDENTIFIER GT BYTES     { $$ = log.NewBytesLabelFilter(log.LabelFilterGreaterThan, $1, $3) }
-    | IDENTIFIER GTE BYTES    { $$ = log.NewBytesLabelFilter(log.LabelFilterGreaterThanOrEqual, $1, $3) }
-    | IDENTIFIER LT BYTES     { $$ = log.NewBytesLabelFilter(log.LabelFilterLesserThan, $1, $3) }
-    | IDENTIFIER LTE BYTES    { $$ = log.NewBytesLabelFilter(log.LabelFilterLesserThanOrEqual, $1, $3) }
-    | IDENTIFIER NEQ BYTES    { $$ = log.NewBytesLabelFilter(log.LabelFilterNotEqual, $1, $3) }
-    | IDENTIFIER EQ BYTES     { $$ = log.NewBytesLabelFilter(log.LabelFilterEqual, $1, $3) }
-    | IDENTIFIER CMP_EQ BYTES { $$ = log.NewBytesLabelFilter(log.LabelFilterEqual, $1, $3) }
+      IDENTIFIER GT BYTES     { $$ = mustNewBytesLabelFilter(log.LabelFilterGreaterThan, $1, $3) }
+    | IDENTIFIER GTE BYTES    { $$ = mustNewBytesLabelFilter(log.LabelFilterGreaterThanOrEqual, $1, $3) }
+    | IDENTIFIER LT BYTES     { $$ = mustNewBytesLabelFilter(log.LabelFilterLesserThan, $1, $3) }
+    | IDENTIFIER LTE BYTES    { $$ = mustNewBytesLabelFilter(log.LabelFilterLesserThanOrEqual, $1, $3) }
+    | IDENTIFIER NEQ BYTES    { $$ = mustNewBytesLabelFilter(log.LabelFilterNotEqual, $1, $3) }
+    | IDENTIFIER EQ BYTES     { $$ = mustNewBytesLabelFilter(log.LabelFilterEqual, $1, $3) }
+    | IDENTIFIER CMP_EQ BYTES { $$ = mustNewBytesLabelFilter(log.LabelFilterEqual, $1, $3) }
     ;
 
 numberFilter:

--- a/pkg/logql/syntax/syntax.y.go
+++ b/pkg/logql/syntax/syntax.y.go
@@ -1499,12 +1499,12 @@ syntaxdefault:
 	case 129:
 		syntaxDollar = syntaxS[syntaxpt-6 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewIPLabelFilter(syntaxDollar[5].str, syntaxDollar[1].str, log.LabelFilterEqual)
+			syntaxVAL.filterer = mustNewIPLabelFilter(syntaxDollar[5].str, syntaxDollar[1].str, log.LabelFilterEqual)
 		}
 	case 130:
 		syntaxDollar = syntaxS[syntaxpt-6 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewIPLabelFilter(syntaxDollar[5].str, syntaxDollar[1].str, log.LabelFilterNotEqual)
+			syntaxVAL.filterer = mustNewIPLabelFilter(syntaxDollar[5].str, syntaxDollar[1].str, log.LabelFilterNotEqual)
 		}
 	case 131:
 		syntaxDollar = syntaxS[syntaxpt-1 : syntaxpt+1]
@@ -1519,72 +1519,72 @@ syntaxdefault:
 	case 133:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewDurationLabelFilter(log.LabelFilterGreaterThan, syntaxDollar[1].str, syntaxDollar[3].dur)
+			syntaxVAL.filterer = mustNewDurationLabelFilter(log.LabelFilterGreaterThan, syntaxDollar[1].str, syntaxDollar[3].dur)
 		}
 	case 134:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
+			syntaxVAL.filterer = mustNewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
 		}
 	case 135:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewDurationLabelFilter(log.LabelFilterLesserThan, syntaxDollar[1].str, syntaxDollar[3].dur)
+			syntaxVAL.filterer = mustNewDurationLabelFilter(log.LabelFilterLesserThan, syntaxDollar[1].str, syntaxDollar[3].dur)
 		}
 	case 136:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewDurationLabelFilter(log.LabelFilterLesserThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
+			syntaxVAL.filterer = mustNewDurationLabelFilter(log.LabelFilterLesserThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
 		}
 	case 137:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewDurationLabelFilter(log.LabelFilterNotEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
+			syntaxVAL.filterer = mustNewDurationLabelFilter(log.LabelFilterNotEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
 		}
 	case 138:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewDurationLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
+			syntaxVAL.filterer = mustNewDurationLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
 		}
 	case 139:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewDurationLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
+			syntaxVAL.filterer = mustNewDurationLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].dur)
 		}
 	case 140:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewBytesLabelFilter(log.LabelFilterGreaterThan, syntaxDollar[1].str, syntaxDollar[3].bytes)
+			syntaxVAL.filterer = mustNewBytesLabelFilter(log.LabelFilterGreaterThan, syntaxDollar[1].str, syntaxDollar[3].bytes)
 		}
 	case 141:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewBytesLabelFilter(log.LabelFilterGreaterThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
+			syntaxVAL.filterer = mustNewBytesLabelFilter(log.LabelFilterGreaterThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
 		}
 	case 142:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewBytesLabelFilter(log.LabelFilterLesserThan, syntaxDollar[1].str, syntaxDollar[3].bytes)
+			syntaxVAL.filterer = mustNewBytesLabelFilter(log.LabelFilterLesserThan, syntaxDollar[1].str, syntaxDollar[3].bytes)
 		}
 	case 143:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewBytesLabelFilter(log.LabelFilterLesserThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
+			syntaxVAL.filterer = mustNewBytesLabelFilter(log.LabelFilterLesserThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
 		}
 	case 144:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewBytesLabelFilter(log.LabelFilterNotEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
+			syntaxVAL.filterer = mustNewBytesLabelFilter(log.LabelFilterNotEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
 		}
 	case 145:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewBytesLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
+			syntaxVAL.filterer = mustNewBytesLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
 		}
 	case 146:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewBytesLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
+			syntaxVAL.filterer = mustNewBytesLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].bytes)
 		}
 	case 147:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]


### PR DESCRIPTION
**What this PR does / why we need it**:

`__error__` and `__error_details__` are string-only pseudo-labels: their value is always one of a small set of known strings, or unset. A numeric, duration, bytes, or `ip()` comparison against them (e.g. `| __error__ > 0`) can never find the label through that code path, because it's stored outside the normal label set and only a string comparison (`=`, `!=`, `=~`, `!~`) knows how to read it. Such a query used to parse successfully and then silently return no results, with no indication anything was wrong.

This PR rejects the query at parse time instead, with an error pointing at the correct alternative (e.g. `__error__ != ""`). This also covers the same comparison placed after `| unwrap`, where `__error__` is most commonly tested in practice.

**Breaking change**: technically yes — a query that previously parsed (and always silently returned empty) now fails to parse. I don't consider this a severe break: the old behavior was indistinguishable from a bug, the new result (a clear parse error) is strictly more useful than the old one (empty results with no explanation), and no query relying on this pattern could ever have produced meaningful results. Noted in the upgrade guide.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
See the added `docs/sources/setup/upgrade/_index.md` entry for the breaking-change note shown to users.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
