### PR TITLE
test(logql): Expand logqltest coverage for structured metadata

### DIFF
--- a/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
@@ -579,43 +579,49 @@ eval instant at 60s max_over_time({app="a", k="nan"} | logfmt | unwrap v [1m]) =
 eval range from 60s to 180s step 30s max_over_time({app="a", k="nan"} | logfmt | unwrap v [1m]) == ignoring (k) max_over_time({app="a", k="fin"} | logfmt | unwrap v [1m])
   expect empty
 
-# on()/on(<label>)/ignoring(<label>) with the matching label sourced from stream labels.
+# on(<label>)/ignoring(<label>) with the matching label sourced from a stream label.
 clear
 load
-  {app="foo", machine="fuzz"} "x" @ 0s [repeat every 10s for 19]
-  {app="noise"} "noise" @ 0s [repeat every 10s for 19]
+  {app="foo", machine="fuzz"} "x"     @ 0s [repeat every 10s for 19]
+  {app="foo", machine="buzz"} "x"     @ 0s [repeat every 15s for 19]
+  {app="noise"}               "noise" @ 0s [repeat every 10s for 19]
 
-eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on () sum by (app) (count_over_time({app="foo"}[1m]))
-  {} 12
-eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on () sum by (app) (count_over_time({app="foo"}[1m]))
-  {} 12 12 12 12 12
-eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on (app) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 12
-eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on (app) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 12 12 12 12 12
-eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool ignoring (machine) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 0
-eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool ignoring (machine) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 0 0 0 0 0
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo", machine="fuzz"}[1m])) + on (app,machine) sum by (app,machine) (count_over_time({app="foo", machine="fuzz"}[1m]))
+  {app="foo", machine="fuzz"} 12
+eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo", machine="fuzz"}[1m])) + on (app,machine) sum by (app,machine) (count_over_time({app="foo", machine="fuzz"}[1m]))
+  {app="foo", machine="fuzz"} 12 12 12 12 12
+# Default matching requires machine to be equal too, so two different values never match.
+eval instant at 60s count_over_time({app="foo", machine="fuzz"}[1m]) + count_over_time({app="foo", machine="buzz"}[1m])
+  expect empty
+eval range from 60s to 180s step 30s count_over_time({app="foo", machine="fuzz"}[1m]) + count_over_time({app="foo", machine="buzz"}[1m])
+  expect empty
+# ignoring(machine) excludes it from the match key, so the same two values do match.
+eval instant at 60s count_over_time({app="foo", machine="fuzz"}[1m]) + ignoring (machine) count_over_time({app="foo", machine="buzz"}[1m])
+  {app="foo"} 10
+eval range from 60s to 180s step 30s count_over_time({app="foo", machine="fuzz"}[1m]) + ignoring (machine) count_over_time({app="foo", machine="buzz"}[1m])
+  {app="foo"} 10 10 10 10 10
 
-# on()/on(<label>)/ignoring(<label>) with the matching label sourced from structured metadata.
+# on(<label>)/ignoring(<label>) with the matching label sourced from structured metadata.
 clear
 load
-  {app="foo"} "x" @ 0s [repeat every 10s for 19] [metadata machine="fuzz"]
+  {app="foo"}   "x"     @ 0s [repeat every 10s for 19] [metadata machine="fuzz"]
+  {app="foo"}   "x"     @ 0s [repeat every 15s for 19] [metadata machine="buzz"]
   {app="noise"} "noise" @ 0s [repeat every 10s for 19]
 
-eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on () sum by (app) (count_over_time({app="foo"}[1m]))
-  {} 12
-eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on () sum by (app) (count_over_time({app="foo"}[1m]))
-  {} 12 12 12 12 12
-eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on (app) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 12
-eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on (app) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 12 12 12 12 12
-eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool ignoring (machine) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 0
-eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool ignoring (machine) sum by (app) (count_over_time({app="foo"}[1m]))
-  {app="foo"} 0 0 0 0 0
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"} | machine="fuzz" [1m])) + on (app,machine) sum by (app,machine) (count_over_time({app="foo"} | machine="fuzz" [1m]))
+  {app="foo", machine="fuzz"} 12
+eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"} | machine="fuzz" [1m])) + on (app,machine) sum by (app,machine) (count_over_time({app="foo"} | machine="fuzz" [1m]))
+  {app="foo", machine="fuzz"} 12 12 12 12 12
+# Default matching requires machine to be equal too, so two different values never match.
+eval instant at 60s count_over_time({app="foo"} | machine="fuzz" [1m]) + count_over_time({app="foo"} | machine="buzz" [1m])
+  expect empty
+eval range from 60s to 180s step 30s count_over_time({app="foo"} | machine="fuzz" [1m]) + count_over_time({app="foo"} | machine="buzz" [1m])
+  expect empty
+# ignoring(machine) excludes it from the match key, so the same two values do match.
+eval instant at 60s count_over_time({app="foo"} | machine="fuzz" [1m]) + ignoring (machine) count_over_time({app="foo"} | machine="buzz" [1m])
+  {app="foo"} 10
+eval range from 60s to 180s step 30s count_over_time({app="foo"} | machine="fuzz" [1m]) + ignoring (machine) count_over_time({app="foo"} | machine="buzz" [1m])
+  {app="foo"} 10 10 10 10 10
 
 # Default matching (no on()/ignoring()) requires every label, including structured metadata, to
 # be equal.

--- a/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
@@ -579,7 +579,7 @@ eval instant at 60s max_over_time({app="a", k="nan"} | logfmt | unwrap v [1m]) =
 eval range from 60s to 180s step 30s max_over_time({app="a", k="nan"} | logfmt | unwrap v [1m]) == ignoring (k) max_over_time({app="a", k="fin"} | logfmt | unwrap v [1m])
   expect empty
 
-# on()/on(app)/ignoring — one stream carrying a machine label.
+# on()/on(<label>)/ignoring(<label>) with the matching label sourced from stream labels.
 clear
 load
   {app="foo", machine="fuzz"} "x" @ 0s [repeat every 10s for 19]
@@ -597,6 +597,44 @@ eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bo
   {app="foo"} 0
 eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool ignoring (machine) sum by (app) (count_over_time({app="foo"}[1m]))
   {app="foo"} 0 0 0 0 0
+
+# on()/on(<label>)/ignoring(<label>) with the matching label sourced from structured metadata.
+clear
+load
+  {app="foo"} "x" @ 0s [repeat every 10s for 19] [metadata machine="fuzz"]
+  {app="noise"} "noise" @ 0s [repeat every 10s for 19]
+
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on () sum by (app) (count_over_time({app="foo"}[1m]))
+  {} 12
+eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on () sum by (app) (count_over_time({app="foo"}[1m]))
+  {} 12 12 12 12 12
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on (app) sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo"} 12
+eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) + on (app) sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo"} 12 12 12 12 12
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool ignoring (machine) sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo"} 0
+eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool ignoring (machine) sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo"} 0 0 0 0 0
+
+# Default matching (no on()/ignoring()) requires every label, including structured metadata, to
+# be equal.
+clear
+load
+  {app="foo"} "x" @ 0s [repeat every 10s for 19] [metadata env="prod"]
+  {app="foo"} "x" @ 0s [repeat every 10s for 19] [metadata env="staging"]
+  {app="noise"} "noise" @ 0s [repeat every 10s for 19]
+
+eval instant at 60s count_over_time({app="foo"} | env="prod" [1m]) + count_over_time({app="foo"} | env="staging" [1m])
+  expect empty
+eval range from 60s to 180s step 30s count_over_time({app="foo"} | env="prod" [1m]) + count_over_time({app="foo"} | env="staging" [1m])
+  expect empty
+eval instant at 60s count_over_time({app="foo"} | env="prod" [1m]) and count_over_time({app="foo"} | env="staging" [1m])
+  expect empty
+eval instant at 60s count_over_time({app="foo"} | env="prod" [1m]) + ignoring (env) count_over_time({app="foo"} | env="staging" [1m])
+  {app="foo"} 12
+eval range from 60s to 180s step 30s count_over_time({app="foo"} | env="prod" [1m]) + ignoring (env) count_over_time({app="foo"} | env="staging" [1m])
+  {app="foo"} 12 12 12 12 12
 
 # and / unless with on() / ignoring()
 clear
@@ -758,11 +796,45 @@ eval instant at 60s sum by (app,machine) (count_over_time({app="foo", machine=~"
 eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo", machine=~".+"}[1m])) > bool on (app) group_left sum by (app,pool) (count_over_time({app="foo", pool=~".+"}[1m]))
   expect fail msg: found duplicate series on the right hand-side
 
-# group_left() with labels.
+# group_left() with labels: include label sources from stream labels.
 clear
 load
   {app="foo", machine="fuzz", pool="foo"} "x" @ 0s [repeat every 10s for 19]
   {app="foo", machine="buzz", pool="foo"} "x" @ 0s [repeat every 15s for 19]
+  {app="noise"} "noise" @ 0s [repeat every 10s for 19]
+
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (pool) sum by (app,pool) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz", pool="foo"} 0
+  {app="foo", machine="buzz", pool="foo"} 0
+eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (pool) sum by (app,pool) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz", pool="foo"} 0 0 0 0 0
+  {app="foo", machine="buzz", pool="foo"} 0 0 0 0 0
+# Each machine's own share of the app total.
+eval instant at 60s count_over_time({app="foo"}[1m]) / on (app) group_left sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz", pool="foo"} 0.6
+  {app="foo", machine="buzz", pool="foo"} 0.4
+eval range from 60s to 180s step 30s count_over_time({app="foo"}[1m]) / on (app) group_left sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz", pool="foo"} 0.6 0.6 0.6 0.6 0.6
+  {app="foo", machine="buzz", pool="foo"} 0.4 0.4 0.4 0.4 0.4
+# The shares collapse to 1 when summed.
+eval instant at 60s sum(count_over_time({app="foo"}[1m]) / on (app) group_left sum by (app) (count_over_time({app="foo"}[1m])))
+  {} 1
+eval range from 60s to 180s step 30s sum(count_over_time({app="foo"}[1m]) / on (app) group_left sum by (app) (count_over_time({app="foo"}[1m])))
+  {} 1 1 1 1 1
+# Include-label deletion: the RHS lacks `pool` (aggregated away), so group_left(pool)
+# deletes it from the result rather than keeping the many side's own value.
+eval instant at 60s sum by (app,machine,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (pool) sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz"} 0
+  {app="foo", machine="buzz"} 0
+eval range from 60s to 180s step 30s sum by (app,machine,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (pool) sum by (app) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz"} 0 0 0 0 0
+  {app="foo", machine="buzz"} 0 0 0 0 0
+
+# group_left() with labels: include label sourced from structured metadata.
+clear
+load
+  {app="foo", machine="fuzz"} "x" @ 0s [repeat every 10s for 19] [metadata pool="foo"]
+  {app="foo", machine="buzz"} "x" @ 0s [repeat every 15s for 19] [metadata pool="foo"]
   {app="noise"} "noise" @ 0s [repeat every 10s for 19]
 
 eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (pool) sum by (app,pool) (count_over_time({app="foo"}[1m]))
@@ -863,11 +935,33 @@ eval instant at 60s sum by (app,pool) (count_over_time({app="foo", pool=~".+"}[1
 eval range from 60s to 180s step 30s sum by (app,pool) (count_over_time({app="foo", pool=~".+"}[1m])) > bool on (app) group_right sum by (app,machine) (count_over_time({app="foo", machine=~".+"}[1m]))
   expect fail msg: found duplicate series on the left hand-side
 
-# group_right() with labels.
+# group_right() with labels; include label sources from stream labels.
 clear
 load
   {app="foo", machine="fuzz", pool="foo"} "x" @ 0s [repeat every 10s for 19]
   {app="foo", machine="buzz", pool="foo"} "x" @ 0s [repeat every 15s for 19]
+  {app="noise"} "noise" @ 0s [repeat every 10s for 19]
+
+eval instant at 60s sum by (app,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz", pool="foo"} 1
+  {app="foo", machine="buzz", pool="foo"} 1
+eval range from 60s to 180s step 30s sum by (app,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz", pool="foo"} 1 1 1 1 1
+  {app="foo", machine="buzz", pool="foo"} 1 1 1 1 1
+# Include-label deletion: the LHS lacks `pool` (aggregated away), so group_right(pool)
+# deletes it from the result rather than keeping the many side's own value.
+eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine,pool) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz"} 1
+  {app="foo", machine="buzz"} 1
+eval range from 60s to 180s step 30s sum by (app) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine,pool) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz"} 1 1 1 1 1
+  {app="foo", machine="buzz"} 1 1 1 1 1
+
+# group_right() with labels: include label sourced from structured metadata.
+clear
+load
+  {app="foo", machine="fuzz"} "x" @ 0s [repeat every 10s for 19] [metadata pool="foo"]
+  {app="foo", machine="buzz"} "x" @ 0s [repeat every 15s for 19] [metadata pool="foo"]
   {app="noise"} "noise" @ 0s [repeat every 10s for 19]
 
 eval instant at 60s sum by (app,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine) (count_over_time({app="foo"}[1m]))

--- a/pkg/logql/internal/logqltest/testdata/conversions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/conversions.logqltest
@@ -18,6 +18,7 @@ load
   {unit="frac"}  "b=1.5B"     @ 10s [repeat every 10s for 18]
   {unit="noise"} "noise"      @ 10s [repeat every 10s for 18]
   {unit="bytes"} "bytes=25MB" @ 10s [repeat every 10s for 18]
+  {unit="meta"}  "noise"      @ 10s [repeat every 10s for 18] [metadata b="4MiB"]
 
 # A line without the unwrapped field (e.g. "noise" line has no "b") is dropped by unwrap.
 eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [1m]) by (unit)
@@ -36,6 +37,7 @@ eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [1m])
   {unit="mixed"} 2000
   {unit="comma"} 2048
   {unit="frac"}  1
+  {unit="meta"}  4194304
 eval range from 60s to 180s step 60s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [30s]) by (unit)
   {unit="kb"}    1000 1000 1000
   {unit="kib"}   1024 1024 1024
@@ -52,6 +54,7 @@ eval range from 60s to 180s step 60s max_over_time({unit=~".+"} | logfmt | unwra
   {unit="mixed"} 2000 2000 2000
   {unit="comma"} 2048 2048 2048
   {unit="frac"}  1 1 1
+  {unit="meta"}  4194304 4194304 4194304
 # The unwrapped label can itself be named "bytes".
 eval instant at 120s max_over_time({unit="bytes"} | logfmt | unwrap bytes(bytes) [1m])
   {unit="bytes"} 25000000
@@ -78,6 +81,7 @@ load
   {unit="neg"}   "d=-5s"        @ 10s [repeat every 10s for 18]
   {unit="noise"} "noise"        @ 10s [repeat every 10s for 18]
   {unit="dur"}   "duration=90s" @ 10s [repeat every 10s for 18]
+  {unit="meta"}  "noise"        @ 10s [repeat every 10s for 18] [metadata d="1h30m"]
 
 # A line without the unwrapped field (e.g. "noise" line has no "d") is dropped by unwrap.
 eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) [1m]) by (unit)
@@ -87,6 +91,7 @@ eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) [1
   {unit="hm"}  5400
   {unit="fh"}  5400
   {unit="neg"} -5
+  {unit="meta"} 5400
 # duration_seconds() is identical to duration().
 eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap duration_seconds(d) [1m]) by (unit)
   {unit="s"}   2
@@ -95,6 +100,7 @@ eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap duration_secon
   {unit="hm"}  5400
   {unit="fh"}  5400
   {unit="neg"} -5
+  {unit="meta"} 5400
 
 eval range from 60s to 120s step 30s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) [1m]) by (unit)
   {unit="s"}   2 2 2
@@ -103,6 +109,7 @@ eval range from 60s to 120s step 30s max_over_time({unit=~".+"} | logfmt | unwra
   {unit="hm"}  5400 5400 5400
   {unit="fh"}  5400 5400 5400
   {unit="neg"} -5 -5 -5
+  {unit="meta"} 5400 5400 5400
 eval range from 60s to 120s step 30s max_over_time({unit=~".+"} | logfmt | unwrap duration_seconds(d) [1m]) by (unit)
   {unit="s"}   2 2 2
   {unit="ms"}  0.5 0.5 0.5
@@ -110,6 +117,7 @@ eval range from 60s to 120s step 30s max_over_time({unit=~".+"} | logfmt | unwra
   {unit="hm"}  5400 5400 5400
   {unit="fh"}  5400 5400 5400
   {unit="neg"} -5 -5 -5
+  {unit="meta"} 5400 5400 5400
 # The unwrapped label can itself be named "duration".
 eval instant at 120s max_over_time({unit="dur"} | logfmt | unwrap duration(duration) [1m])
   {unit="dur"} 90

--- a/pkg/logql/internal/logqltest/testdata/formatters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/formatters.logqltest
@@ -28,25 +28,46 @@ eval instant at 60s bytes_over_time({app="a", level="error"} | line_format "V={{
 eval instant at 60s bytes_over_time({app="a"} | line_format "{{ nosuchfunc }}" [1m])
   expect fail msg: not defined
 
+# line_format reads a structured-metadata field the same way it reads a stream label.
+clear
+load
+  {app="a"} "x" @ 20s [repeat every 20s for 4] [metadata level="error"]
+  {app="a"} "x" @ 30s [repeat every 20s for 2] [metadata level="warn"]
+
+eval instant at 60s count_over_time({app="a"} | line_format "L={{.level}}" |= "L=error" [1m])
+  {app="a", level="error"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | line_format "L={{.level}}" |= "L=error" [1m])   # overlapping
+  {app="a", level="error"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | line_format "L={{.level}}" |= "L=error" [1m]) # non-overlapping
+  {app="a", level="error"} 3 _
+eval instant at 60s bytes_over_time({app="a"} | level="error" | line_format "{{.level}}" [1m])
+  {app="a", level="error"} 15
+
 # label_format renames a label (dst=src) or sets one from a template (dst="...").
 clear
 load
   {app="a", method="get"} "msg" @ 20s [repeat every 20s for 4]
+  {app="a"}               "msg" @ 30s [repeat every 20s for 2] [metadata method="post"]
   {app="noise"}           "msg" @ 30s [repeat every 20s for 2]
 
 # Rename copies the source value to the new label and removes the source.
 eval instant at 60s count_over_time({app="a"} | label_format verb=method [1m])
   {app="a", verb="get"} 3
+  {app="a", verb="post"} 2
 eval range from 40s to 80s step 20s count_over_time({app="a"} | label_format verb=method [1m])   # overlapping
   {app="a", verb="get"} 2 3 3
+  {app="a", verb="post"} 1 2 2
 eval range from 60s to 180s step 120s count_over_time({app="a"} | label_format verb=method [1m]) # non-overlapping
   {app="a", verb="get"} 3 _
+  {app="a", verb="post"} 2 _
 # Template sets a new label from another label and keeps the source.
 eval instant at 60s count_over_time({app="a"} | label_format route="{{.method}}-ok" [1m])
   {app="a", method="get", route="get-ok"} 3
+  {app="a", method="post", route="post-ok"} 2
 # A template that targets an existing label overwrites it in place.
 eval instant at 60s count_over_time({app="a"} | label_format method="{{.method}}!" [1m])
   {app="a", method="get!"} 3
+  {app="a", method="post!"} 2
 # An invalid template fails at parse time.
 eval instant at 60s count_over_time({app="a"} | label_format x="{{" [1m])
   expect fail msg: unclosed action
@@ -74,54 +95,63 @@ eval range from 40s to 80s step 20s bytes_over_time({app="a"} | line_format `{{ 
 eval range from 60s to 180s step 120s bytes_over_time({app="a"} | line_format `{{ printf "\x1b[31m%s\x1b[0m" .msg }}` | decolorize [1m]) # non-overlapping
   {app="a", msg="hello"} 15 _
 
-# drop removes labels by name, or by name and value. A dropped stream label leaves the series.
+# drop removes labels by name, or by name and value, from a stream label or from structured
+# metadata alike. A dropped label leaves the series.
 clear
 load
   {app="a", code="500", zone="eu"} "msg" @ 20s [repeat every 20s for 4]
   {app="a", code="200", zone="eu"} "msg" @ 30s [repeat every 20s for 2]
+  {app="a", zone="eu"}             "msg" @ 30s [repeat every 20s for 2] [metadata code="300"]
   {app="noise"}                    "msg" @ 20s [repeat every 20s for 4]
 
-# Dropping both labels here merges the two streams into {app="a"}.
+# Dropping both labels here merges all three streams into {app="a"}.
 eval instant at 60s count_over_time({app="a"} | drop code, zone [1m])
-  {app="a"} 5
+  {app="a"} 7
 eval range from 40s to 80s step 20s count_over_time({app="a"} | drop code, zone [1m])   # overlapping
-  {app="a"} 3 5 5
+  {app="a"} 4 7 7
 eval range from 60s to 180s step 120s count_over_time({app="a"} | drop code, zone [1m]) # non-overlapping
-  {app="a"} 5 _
-# Dropping one label keeps the streams distinct.
+  {app="a"} 7 _
+# Dropping one label keeps the streams distinct, whether code came from a stream label or,
+# for "300", structured metadata.
 eval instant at 60s count_over_time({app="a"} | drop zone [1m])
   {app="a", code="500"} 3
   {app="a", code="200"} 2
+  {app="a", code="300"} 2
 # Name and value drops the label only from lines where it matches.
 eval instant at 60s count_over_time({app="a"} | drop code="500" [1m])
   {app="a", zone="eu"} 3
   {app="a", code="200", zone="eu"} 2
+  {app="a", code="300", zone="eu"} 2
 # drop needs at least one label name; a bare drop is a parse error.
 eval instant at 60s count_over_time({app="a"} | drop [1m])
   expect fail msg: expecting IDENTIFIER
 
-# keep removes every label not listed.
+# keep removes every label not listed, whether it came from a stream label or structured
+# metadata.
 clear
 load
   {app="a", code="500", zone="eu"} "msg" @ 20s [repeat every 20s for 4]
   {app="a", code="200", zone="eu"} "msg" @ 30s [repeat every 20s for 2]
+  {app="a", code="300"}            "msg" @ 30s [repeat every 20s for 2] [metadata zone="eu"]
   {app="noise"}                    "msg" @ 20s [repeat every 20s for 4]
 
-# Keeping only zone drops app and code, so the two streams merge into {zone="eu"}.
+# Keeping only zone drops app and code, so all three streams merge into {zone="eu"}.
 eval instant at 60s count_over_time({app="a"} | keep zone [1m])
-  {zone="eu"} 5
+  {zone="eu"} 7
 eval range from 40s to 80s step 20s count_over_time({app="a"} | keep zone [1m])   # overlapping
-  {zone="eu"} 3 5 5
+  {zone="eu"} 4 7 7
 eval range from 60s to 180s step 120s count_over_time({app="a"} | keep zone [1m]) # non-overlapping
-  {zone="eu"} 5 _
+  {zone="eu"} 7 _
 # Keeping several labels leaves the streams distinct.
 eval instant at 60s count_over_time({app="a"} | keep code, zone [1m])
   {code="500", zone="eu"} 3
   {code="200", zone="eu"} 2
-# Name and value keeps the label only where it matches; the other lines lose every label.
+  {code="300", zone="eu"} 2
+# Name and value keeps the label only where it matches; the other lines lose every label,
+# including a metadata-origin one not in the keep list.
 eval instant at 60s count_over_time({app="a"} | keep code="500" [1m])
   {code="500"} 3
-  {} 2
+  {} 4
 # keep needs at least one label name; a bare keep is a parse error.
 eval instant at 60s count_over_time({app="a"} | keep [1m])
   expect fail msg: expecting IDENTIFIER

--- a/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
@@ -1093,6 +1093,23 @@ eval instant at 60s count_over_time({app="a"} [1m])
   {app="a", lvl="error"} 3
   {app="a", lvl="info"} 2
 
+# structured metadata label filter: logical operators parsed fields and structured metadata.
+clear
+load
+  {app="a"} "code=500" @ 20s [repeat every 20s for 4] [metadata lvl="error"]
+  {app="a"} "code=200" @ 25s [repeat every 20s for 4] [metadata lvl="error"]
+  {app="a"} "code=500" @ 35s [repeat every 20s for 4] [metadata lvl="info"]
+
+eval instant at 60s count_over_time({app="a"} | logfmt | lvl="error" and code="500" [1m])
+  {app="a", code="500", lvl="error"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | logfmt | lvl="error" and code="500" [1m])   # overlapping
+  {app="a", code="500", lvl="error"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt | lvl="error" and code="500" [1m]) # non-overlapping
+  {app="a", code="500", lvl="error"} 3 _
+eval instant at 60s count_over_time({app="a"} | logfmt | lvl="info" or code="200" [1m])
+  {app="a", code="200", lvl="error"} 2
+  {app="a", code="500", lvl="info"} 2
+
 # label conflicts: a name can be a stream label, structured metadata, and a parsed field at once.
 #
 # Two separate rules resolve conflicts:
@@ -1124,6 +1141,18 @@ eval instant at 60s count_over_time({app="a"} | logfmt | sp="p" [1m])
 eval instant at 60s count_over_time({app="a"} | logfmt | tri="m" [1m])
   expect empty
 eval instant at 60s count_over_time({app="a"} | logfmt | tri_extracted="m" [1m])
+  expect empty
+
+# label conflicts: duplicated structured metadata keys.
+#
+# When a duplicate structured metadata key is encountered, on the last key is preserved.
+clear
+load
+  {app="a"} "msg" @ 20s [repeat every 20s for 3] [metadata dup="first" dup="second"]
+
+eval instant at 60s count_over_time({app="a"} | dup="second" [1m])
+  {app="a", dup="second"} 3
+eval instant at 60s count_over_time({app="a"} | dup="first" [1m])
   expect empty
 
 # label filter after unwrap

--- a/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
@@ -1145,7 +1145,7 @@ eval instant at 60s count_over_time({app="a"} | logfmt | tri_extracted="m" [1m])
 
 # label conflicts: duplicated structured metadata keys.
 #
-# When a duplicate structured metadata key is encountered, on the last key is preserved.
+# When a duplicate structured metadata key is encountered, only the last key is preserved.
 clear
 load
   {app="a"} "msg" @ 20s [repeat every 20s for 3] [metadata dup="first" dup="second"]

--- a/pkg/logql/internal/logqltest/testdata/parsers.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/parsers.logqltest
@@ -43,21 +43,28 @@ eval instant at 60s count_over_time({app="a"} | logfmt [1m])
   {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
 eval range from 40s to 60s step 20s count_over_time({app="a"} | logfmt [1m])
   {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 2 3
+# logfmt() label-expression form resolves the same clashes the same way.
+eval instant at 60s count_over_time({app="a"} | logfmt sl, md, sm, tri [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
 
 # logfmt() partially malformed line: the parser keeps the valid pairs and drops the bad one, or
 # fails the whole line under --strict.
 clear
 load
-  {app="a"} `good=1 bad="unterminated` @ 20s [repeat every 20s for 3]
+  {app="a"} `good=1 bad="unterminated` @ 20s [repeat every 20s for 3] [metadata env="prod"]
   {app="noise"} "z=1" @ 20s [repeat every 20s for 3]
 
 eval instant at 60s count_over_time({app="a"} | logfmt [1m])
-  {app="a", good="1"} 3
+  {app="a", good="1", env="prod"} 3
 eval instant at 60s count_over_time({app="a"} | logfmt --strict [1m])
   expect fail msg: LogfmtParserErr
 # A __error__ filter drops the failing line.
 eval instant at 60s count_over_time({app="a"} | logfmt --strict | __error__="" [1m])
   expect empty
+# Structured metadata is attached before any parser runs, so it survives on the errored line: a
+# filter on it still matches, and the error still reaches the result.
+eval instant at 60s count_over_time({app="a"} | logfmt --strict | env="prod" [1m])
+  expect fail msg: LogfmtParserErr
 
 # logfmt() with label expressions.
 clear
@@ -112,6 +119,21 @@ eval instant at 60s count_over_time({app="a"} | json [1m])
   {app="a", level="stream", level_extracted="parsed", a_b="1", dup="first"} 3
 eval range from 40s to 60s step 20s count_over_time({app="a"} | json [1m])  # overlapping
   {app="a", level="stream", level_extracted="parsed", a_b="1", dup="first"} 2 3
+
+# json() clashing labels keep the loser under `<name>_extracted`, following the base-name
+# precedence stream > metadata > parsed (the same for every parser).
+clear
+load
+  {app="a", sl="s", sm="s", tri="s"} `{"sl":"p","md":"p","tri":"p"}` @ 20s [repeat every 20s for 3] [metadata md="m" sm="m" tri="m"]
+  {app="noise"} `{"x":1}` @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | json [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | json [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 2 3
+# json()'s label-expression form resolves the same clashes the same way.
+eval instant at 60s count_over_time({app="a"} | json sl, md, sm, tri [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
 
 # json() malformed line: the query fails, unless a __error__ filter drops the bad line.
 clear
@@ -182,6 +204,18 @@ eval instant at 60s count_over_time({app="a"} | regexp `(?P<x>.)(?P<x>.)` [1m])
 eval instant at 60s count_over_time({app="a"} | regexp `(` [1m])
   expect fail msg: error parsing regexp
 
+# regexp() clashing labels keep the loser under `<name>_extracted`, following the base-name
+# precedence stream > metadata > parsed (the same for every parser).
+clear
+load
+  {app="a", sl="s", sm="s", tri="s"} "p p p" @ 20s [repeat every 20s for 3] [metadata md="m" sm="m" tri="m"]
+  {app="noise"} "y" @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | regexp `(?P<sl>\S+) (?P<md>\S+) (?P<tri>\S+)` [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | regexp `(?P<sl>\S+) (?P<md>\S+) (?P<tri>\S+)` [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 2 3
+
 # pattern()
 clear
 load
@@ -214,6 +248,18 @@ eval range from 40s to 60s step 20s count_over_time({app="a"} | pattern `<method
 eval instant at 60s count_over_time({app="a"} | pattern `no captures here` [1m])
   expect fail msg: at least one capture is required
 
+# pattern() clashing labels keep the loser under `<name>_extracted`, following the base-name
+# precedence stream > metadata > parsed (the same for every parser).
+clear
+load
+  {app="a", sl="s", sm="s", tri="s"} "p p p" @ 20s [repeat every 20s for 3] [metadata md="m" sm="m" tri="m"]
+  {app="noise"} "y" @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | pattern `<sl> <md> <tri>` [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | pattern `<sl> <md> <tri>` [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 2 3
+
 # unpack() promotes the string fields of a json line to labels. It skips a non-string field (num) and
 # the reserved `_entry` key, whose value replaces the log line instead of becoming a label.
 clear
@@ -242,6 +288,19 @@ eval instant at 60s count_over_time({app="a"} | unpack | logfmt [1m])
   {app="a", lvl="stream", lvl_extracted="packed", code="42"} 3
 eval range from 40s to 60s step 20s count_over_time({app="a"} | unpack | logfmt [1m])  # overlapping
   {app="a", lvl="stream", lvl_extracted="packed", code="42"} 2 3
+
+# unpack() clashing labels keep the loser under `<name>_extracted`, following the base-name
+# precedence stream > metadata > parsed (the same for every parser). unpack() only promotes
+# fields when the line carries the reserved `_entry` key, so the fixture needs one.
+clear
+load
+  {app="a", sl="s", sm="s", tri="s"} `{"sl":"p","md":"p","tri":"p","_entry":"x"}` @ 20s [repeat every 20s for 3] [metadata md="m" sm="m" tri="m"]
+  {app="noise"} `{"_entry":"x"}` @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | unpack [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | unpack [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 2 3
 
 # unpack() fails on a non-json line; a __error__ filter drops it.
 clear

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -96,17 +96,6 @@ eval instant at 60s bytes_rate({app=~"a|b"} | logfmt | unwrap v [30s])
 eval instant at 60s bytes_rate({app=~"a|b"} |~".+bar" [30s]) by (app)
   expect fail msg: grouping not allowed for bytes_rate aggregation
 
-# unwrap of a stream label `foo` (no parser stage).
-clear
-load
-  {app="foo", foo="2"} "xbar" @ 0s [repeat every 10s for 13]
-  {app="noise"} "noise" @ 0s [repeat every 10s for 13]
-
-eval instant at 60s rate({app="foo"} | unwrap foo [30s])
-  {app="foo"} 0.2
-eval range from 60s to 120s step 15s rate({app="foo"} | unwrap foo [30s])
-  {app="foo"} 0.2 0.2 0.2 0.2 0.2
-
 # first_over_time() / last_over_time()
 clear
 load
@@ -312,32 +301,18 @@ eval range from 60s to 70s step 10s quantile_over_time(0.5, {app="a"} | logfmt |
   {pod="1"} 3 3
   {pod="2"} 15 15
 
-# unwrap of a stream label `bar`.
+# quantile_over_time() over a structured metadata field.
 clear
 load
-  {app="foo", bar="3"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="foo", bar="3"} "noise" @ 5s [repeat every 10s for 19]
-  {app="bar", bar="6"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="bar", bar="6"} "noise" @ 5s [repeat every 10s for 19]
+  {app="a"} "msg"   @ 10s [metadata v="1"]
+  {app="a"} "msg"   @ 20s [metadata v="2"]
+  {app="a"} "msg"   @ 30s [metadata v="3"]
+  {app="a"} "noise" @ 25s
 
-eval instant at 120s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m])
-  {app="foo"} 0.3
-  {app="bar"} 0.6
-eval range from 60s to 180s step 30s rate(({app=~"foo|bar"} |~".+bar" | unwrap bar)[1m])
-  {app="foo"} 0.3 0.3 0.3 0.3 0.3
-  {app="bar"} 0.6 0.6 0.6 0.6 0.6
-
-# Combines a numeric label filter with unwrap: after logfmt, `bar > 0` drops the bar=0 lines
-# before unwrapping bazz.
-clear
-load
-  {job="foo"} "bar=1 bazz=10" @ 10s [repeat every 10s for 12]
-  {job="foo"} "bar=0 bazz=99" @ 15s [repeat every 10s for 12]
-
-eval instant at 120s sum(rate({job="foo"} | logfmt | bar > 0 | unwrap bazz [30s]))
-  {} 1
-eval range from 60s to 120s step 30s sum(rate({job="foo"} | logfmt | bar > 0 | unwrap bazz [30s]))
-  {} 1 1 1
+eval instant at 60s quantile_over_time(0.5, {app="a"} | unwrap v [1m])
+  {app="a"} 2
+eval range from 30s to 60s step 30s quantile_over_time(0.5, {app="a"} | unwrap v [1m])
+  {app="a"} 2 2
 
 # rate_counter() treats the unwrapped value as a counter: the per-second increase over the range with
 # counter resets added back, using Prometheus-style boundary extrapolation.
@@ -480,6 +455,18 @@ load
 eval instant at 210s rate_counter({app="a"} | logfmt | unwrap c [90s])
   {app="a"} 1
 
+# rate_counter() over a structured metadata field.
+clear
+load
+  {app="a"} "msg" @ 180s [metadata c="40"]
+  {app="a"} "msg" @ 210s [metadata c="100"]
+  {app="a"} "msg" @ 150s
+
+eval instant at 210s rate_counter({app="a"} | unwrap c [90s])
+  {app="a"} 1
+eval range from 180s to 210s step 30s rate_counter({app="a"} | unwrap c [90s])
+  {app="a"} 0 1
+
 # count_over_time()
 clear
 load
@@ -583,6 +570,42 @@ eval instant at 1300ms rate({app="b"} |= "keep" [500ms] offset 500ms)
   {app="b"} 4
 eval range from 1000ms to 1600ms step 300ms rate({app="b"} |= "keep" [500ms] offset 500ms)
   {app="b"} 6 4 6
+
+# rate() with unwrap, from a stream label, structured metadata, or a parsed field.
+clear
+load
+  {app="p"}        "v=2"   @ 0s  [repeat every 10s for 13]
+  {app="s", v="2"} "x"     @ 0s  [repeat every 10s for 13]
+  {app="m"}        "x"     @ 0s  [repeat every 10s for 13] [metadata v="2"]
+  {app="noise"}    "noise" @ 0s  [repeat every 10s for 13]
+  {app="err"}      "msg"   @ 20s [metadata v="oops"]
+  {app="err"}      "msg"   @ 40s [metadata v="6"]
+
+# parsed field
+eval instant at 60s rate({app="p"} | logfmt | unwrap v [30s])
+  {app="p"} 0.2
+eval range from 60s to 120s step 15s rate({app="p"} | logfmt | unwrap v [30s])
+  {app="p"} 0.2 0.2 0.2 0.2 0.2
+# stream label
+eval instant at 60s rate({app="s"} | logfmt | unwrap v [30s])
+  {app="s"} 0.2
+eval range from 60s to 120s step 15s rate({app="s"} | logfmt | unwrap v [30s])
+  {app="s"} 0.2 0.2 0.2 0.2 0.2
+# structured metadata
+eval instant at 60s rate({app="m"} | logfmt | unwrap v [30s])
+  {app="m"} 0.2
+eval range from 60s to 120s step 15s rate({app="m"} | logfmt | unwrap v [30s])
+  {app="m"} 0.2 0.2 0.2 0.2 0.2
+# all sources
+eval instant at 60s rate({app=~"p|s|m"} | logfmt | unwrap v [30s])
+  {app="p"} 0.2
+  {app="s"} 0.2
+  {app="m"} 0.2
+# A non-numeric value, from any source, sets the extraction error. A __error__ filter drops it.
+eval instant at 60s rate({app="err"} | unwrap v [1m])
+  expect fail
+eval instant at 60s rate({app="err"} | unwrap v | __error__="" [1m])
+  {app="err"} 0.1
 
 # avg_over_time() edge cases:
 # - any NaN -> NaN
@@ -784,6 +807,80 @@ eval range from 60s to 180s step 60s avg_over_time({app="a"} | json | unwrap v |
   {pod="1"} 4 4 _
   {pod="2"} 9 9 _
 
+# avg_over_time() with grouping on structured metadata.
+clear
+load
+  {app="a"} "msg"   @ 10s [repeat every 60s for 2] [metadata v="2" pod="1"]
+  {app="a"} "msg"   @ 20s [repeat every 60s for 2] [metadata v="4" pod="1"]
+  {app="a"} "noise" @ 25s [repeat every 60s for 2] [metadata pod="1"]
+  {app="a"} "msg"   @ 15s [repeat every 60s for 2] [metadata v="6" pod="2"]
+  {app="a"} "msg"   @ 35s [repeat every 60s for 2] [metadata v="12" pod="2"]
+  {app="a"} "junk"  @ 15s [repeat every 60s for 2] [metadata pod="3"]
+  {app="a"} "moar"  @ 35s [repeat every 60s for 2] [metadata pod="3"]
+
+# by() a single label
+eval instant at 60s avg_over_time({app="a"} | unwrap v [1m]) by (pod)
+  {pod="1"} 3
+  {pod="2"} 9
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v [1m]) by (pod)
+  {pod="1"} 3 3 _
+  {pod="2"} 9 9 _
+eval instant at 60s avg_over_time({app="a"} | unwrap v [1m]) by (app)
+  {app="a"} 6
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v [1m]) by (app)
+  {app="a"} 6 6 _
+eval instant at 60s sum(avg_over_time({app="a"} | unwrap v [1m]) by (pod))
+  {} 12
+eval range from 60s to 180s step 60s sum(avg_over_time({app="a"} | unwrap v [1m]) by (pod))
+  {} 12 12 _
+# by() multiple labels
+eval instant at 60s avg_over_time({app="a"} | unwrap v [1m]) by (pod, app)
+  {app="a", pod="1"} 3
+  {app="a", pod="2"} 9
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v [1m]) by (pod, app)
+  {app="a", pod="1"} 3 3 _
+  {app="a", pod="2"} 9 9 _
+# by() with no labels
+eval instant at 60s avg_over_time({app="a"} | unwrap v [1m]) by ()
+  {} 6
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v [1m]) by ()
+  {} 6 6 _
+# without() a single label
+eval instant at 60s avg_over_time({app="a"} | unwrap v [1m]) without (pod)
+  {app="a"} 6
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v [1m]) without (pod)
+  {app="a"} 6 6 _
+# drop <label>
+eval instant at 60s avg_over_time({app="a"} | drop pod | unwrap v [1m])
+  {app="a"} 6
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | drop pod | unwrap v [1m])
+  {app="a"} 6 6 _
+# drop <label> then group by(<label>)
+eval instant at 60s avg_over_time({app="a"} | drop pod | unwrap v [1m]) by (pod)
+  {} 6
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | drop pod | unwrap v [1m]) by (pod)
+  {} 6 6 _
+# binary operation
+eval instant at 60s avg_over_time({app="a"} | unwrap v [1m]) by (pod) > 5
+  {pod="2"} 9
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v [1m]) by (pod) > 5
+  {pod="2"} 9 9 _
+# filtering stage after unwrap
+eval instant at 60s avg_over_time({app="a"} | unwrap v | pod="1" [1m]) by (app)
+  {app="a"} 3
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v | pod="1" [1m]) by (app)
+  {app="a"} 3 3 _
+eval instant at 60s avg_over_time({app="a"} | unwrap v | pod!="1" [1m]) by (pod)
+  {pod="2"} 9
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v | pod!="1" [1m]) by (pod)
+  {pod="2"} 9 9 _
+eval instant at 60s avg_over_time({app="a"} | unwrap v | v > 3 [1m]) by (pod)
+  {pod="1"} 4
+  {pod="2"} 9
+eval range from 60s to 180s step 60s avg_over_time({app="a"} | unwrap v | v > 3 [1m]) by (pod)
+  {pod="1"} 4 4 _
+  {pod="2"} 9 9 _
+
 # min_over_time() / max_over_time()
 # - a leading NaN is ignored
 # - all NaN -> NaN
@@ -880,6 +977,28 @@ eval range from 60s to 70s step 10s min_over_time({app="a"} | logfmt | unwrap v 
   {pod="1"} 2 2
   {pod="2"} 10 10
 
+# min_over_time() / max_over_time() over a structured metadata field.
+clear
+load
+  {app="a", pod="1"} "msg" @ 20s [metadata v="2"]
+  {app="a", pod="1"} "msg" @ 30s [metadata v="4"]
+  {app="a", pod="2"} "msg" @ 40s [metadata v="10"]
+  {app="a", pod="2"} "msg" @ 50s [metadata v="20"]
+  {app="a", pod="1"} "noise" @ 25s
+
+eval instant at 60s min_over_time({app="a"} | unwrap v [1m]) by (pod)
+  {pod="1"} 2
+  {pod="2"} 10
+eval instant at 60s max_over_time({app="a"} | unwrap v [1m]) by (pod)
+  {pod="1"} 4
+  {pod="2"} 20
+eval range from 60s to 70s step 10s min_over_time({app="a"} | unwrap v [1m]) by (pod)
+  {pod="1"} 2 2
+  {pod="2"} 10 10
+eval range from 60s to 70s step 10s max_over_time({app="a"} | unwrap v [1m]) by (pod)
+  {pod="1"} 4 4
+  {pod="2"} 20 20
+
 # sum_over_time()
 #
 # - any NaN -> NaN
@@ -922,6 +1041,18 @@ eval instant at 60s sum_over_time({app="a"}[1m])
 # sum_over_time() doesn't allow grouping.
 eval instant at 60s sum_over_time({app="a"} | logfmt | unwrap v [1m]) by (app)
   expect fail msg: grouping not allowed for sum_over_time aggregation
+
+# sum_over_time() over a structured metadata field.
+clear
+load
+  {app="a"} "msg"   @ 20s [metadata v="7"]
+  {app="a"} "msg"   @ 40s [metadata v="5"]
+  {app="a"} "noise" @ 30s
+
+eval instant at 60s sum_over_time({app="a"} | unwrap v [1m])
+  {app="a"} 12
+eval range from 40s to 60s step 20s sum_over_time({app="a"} | unwrap v [1m])
+  {app="a"} 12 12
 
 # stddev_over_time() / stdvar_over_time()
 clear
@@ -1010,6 +1141,22 @@ eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) without
 eval range from 60s to 70s step 10s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 1 1
   {pod="2"} 5 5
+
+# stddev_over_time() / stdvar_over_time() over a structured metadata field.
+clear
+load
+  {app="a"} "msg"   @ 20s [metadata v="2"]
+  {app="a"} "msg"   @ 40s [metadata v="4"]
+  {app="a"} "noise" @ 30s
+
+eval instant at 60s stdvar_over_time({app="a"} | unwrap v [1m])
+  {app="a"} 1
+eval instant at 60s stddev_over_time({app="a"} | unwrap v [1m])
+  {app="a"} 1
+eval range from 40s to 60s step 20s stdvar_over_time({app="a"} | unwrap v [1m])
+  {app="a"} 1 1
+eval range from 40s to 60s step 20s stddev_over_time({app="a"} | unwrap v [1m])
+  {app="a"} 1 1
 
 # absent_over_time()
 clear

--- a/pkg/logql/internal/logqltest/testdata/vector_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/vector_aggregations.logqltest
@@ -40,6 +40,26 @@ eval instant at 90s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m] offset 3
   {app="foo", namespace="a"} 18
   {app="bar", namespace="b"} 6
 
+# sum() grouping on structured metadata.
+clear
+load
+  {app="foo"} "xbar"  @ 10s [repeat every 10s for 18] [metadata cluster="c1"]
+  {app="foo"} "noise" @ 15s [repeat every 10s for 18] [metadata cluster="c1"]
+  {app="foo"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata cluster="c2"]
+  {app="foo"} "noise" @ 7s  [repeat every 5s  for 36] [metadata cluster="c2"]
+  {app="bar"} "xbar"  @ 10s [repeat every 10s for 18] [metadata cluster="c2"]
+  {app="bar"} "noise" @ 15s [repeat every 10s for 18] [metadata cluster="c2"]
+
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (cluster)
+  {cluster="c1"} 6
+  {cluster="c2"} 18
+eval range from 20s to 60s step 20s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (cluster)
+  {cluster="c1"} 2 4 6
+  {cluster="c2"} 6 12 18
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (cluster)
+  {app="foo"} 18
+  {app="bar"} 6
+
 # sum() with special inputs.
 clear
 load
@@ -97,6 +117,28 @@ eval instant at 60s avg without () (count_over_time({app=~"foo|bar"} |~".+bar" [
   {app="foo", pod="b", zone="eu"} 12
   {app="bar", pod="a", zone="us"} 12
   {app="bar", pod="b", zone="us"} 30
+
+# avg() grouping on structured metadata.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="bar", pod="a"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="a"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90] [metadata zone="us"]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90] [metadata zone="us"]
+
+eval instant at 60s avg by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 9
+  {zone="us"} 21
+eval range from 20s to 60s step 20s avg by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 3 6 9
+  {zone="us"} 7 14 21
+eval instant at 60s avg without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 9
+  {app="bar", zone="us"} 21
 
 # avg() with special inputs.
 clear
@@ -156,6 +198,28 @@ eval instant at 60s min without () (count_over_time({app=~"foo|bar"} |~".+bar" [
   {app="bar", pod="a", zone="us"} 12
   {app="bar", pod="b", zone="us"} 30
 
+# min() grouping on structured metadata.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="bar", pod="a"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="a"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90] [metadata zone="us"]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90] [metadata zone="us"]
+
+eval instant at 60s min by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 6
+  {zone="us"} 12
+eval range from 20s to 60s step 20s min by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 2 4 6
+  {zone="us"} 4 8 12
+eval instant at 60s min without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 6
+  {app="bar", zone="us"} 12
+
 # min() with special inputs.
 clear
 load
@@ -214,6 +278,28 @@ eval instant at 60s max without () (count_over_time({app=~"foo|bar"} |~".+bar" [
   {app="bar", pod="a", zone="us"} 12
   {app="bar", pod="b", zone="us"} 30
 
+# max() grouping on structured metadata.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="bar", pod="a"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="a"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90] [metadata zone="us"]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90] [metadata zone="us"]
+
+eval instant at 60s max by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 12
+  {zone="us"} 30
+eval range from 20s to 60s step 20s max by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 4 8 12
+  {zone="us"} 10 20 30
+eval instant at 60s max without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 12
+  {app="bar", zone="us"} 30
+
 # max() with special inputs.
 clear
 load
@@ -269,6 +355,26 @@ eval instant at 60s count without () (count_over_time({app=~"foo|bar"} |~".+bar"
   {app="foo", pod="a", zone="eu"} 1
   {app="foo", pod="b", zone="eu"} 1
   {app="bar", pod="a", zone="us"} 1
+
+# count() grouping on structured metadata.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="b"} "xbar"  @ 30s [repeat every 10s for 16] [metadata zone="eu"]
+  {app="foo", pod="b"} "noise" @ 35s [repeat every 10s for 16] [metadata zone="eu"]
+  {app="bar", pod="a"} "xbar"  @ 50s [repeat every 10s for 14] [metadata zone="us"]
+  {app="bar", pod="a"} "noise" @ 55s [repeat every 10s for 14] [metadata zone="us"]
+
+eval instant at 60s count by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 2
+  {zone="us"} 1
+eval range from 20s to 60s step 20s count by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 1 2 2
+  {zone="us"} _ _ 1
+eval instant at 60s count without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 2
+  {app="bar", zone="us"} 1
 
 # count() with special inputs.
 clear
@@ -326,6 +432,28 @@ eval instant at 60s stddev without () (count_over_time({app=~"foo|bar"} |~".+bar
   {app="foo", pod="b", zone="eu"} 0
   {app="bar", pod="a", zone="us"} 0
   {app="bar", pod="b", zone="us"} 0
+
+# stddev() grouping on structured metadata.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="bar", pod="a"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="a"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90] [metadata zone="us"]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90] [metadata zone="us"]
+
+eval instant at 60s stddev by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 3
+  {zone="us"} 9
+eval range from 20s to 60s step 20s stddev by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 1 2 3
+  {zone="us"} 3 6 9
+eval instant at 60s stddev without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 3
+  {app="bar", zone="us"} 9
 
 # stddev() with special inputs.
 clear
@@ -385,6 +513,28 @@ eval instant at 60s stdvar without () (count_over_time({app=~"foo|bar"} |~".+bar
   {app="foo", pod="b", zone="eu"} 0
   {app="bar", pod="a", zone="us"} 0
   {app="bar", pod="b", zone="us"} 0
+
+# stdvar() grouping on structured metadata.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18] [metadata zone="eu"]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="eu"]
+  {app="bar", pod="a"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="a"} "noise" @ 7s  [repeat every 5s  for 36] [metadata zone="us"]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90] [metadata zone="us"]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90] [metadata zone="us"]
+
+eval instant at 60s stdvar by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 9
+  {zone="us"} 81
+eval range from 20s to 60s step 20s stdvar by (zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {zone="eu"} 1 4 9
+  {zone="us"} 9 36 81
+eval instant at 60s stdvar without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 9
+  {app="bar", zone="us"} 81
 
 # stdvar() with special inputs.
 clear
@@ -450,6 +600,27 @@ eval instant at 60s topk(1.5, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
 eval instant at 60s topk(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   expect fail msg: parameter required
 
+# topk() grouping on structured metadata. topk() selects rather than aggregates, so the
+# winning series keeps its full label set either way; grouping decides only which series
+# compete against which.
+clear
+load
+  {app="foo"} "xbar"  @ 10s [repeat every 10s for 18] [metadata pod="a"]
+  {app="foo"} "noise" @ 15s [repeat every 10s for 18] [metadata pod="a"]
+  {app="foo"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata pod="b"]
+  {app="foo"} "noise" @ 7s  [repeat every 5s  for 36] [metadata pod="b"]
+  {app="bar"} "xbar"  @ 4s  [repeat every 4s  for 45] [metadata pod="a"]
+  {app="bar"} "noise" @ 2s  [repeat every 4s  for 45] [metadata pod="a"]
+  {app="bar"} "xbar"  @ 2s  [repeat every 2s  for 90] [metadata pod="b"]
+  {app="bar"} "noise" @ 1s  [repeat every 2s  for 90] [metadata pod="b"]
+
+eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
+  {app="foo", pod="b"} 12
+  {app="bar", pod="b"} 30
+eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)
+  {app="bar", pod="a"} 15
+  {app="bar", pod="b"} 30
+
 # topk() with special inputs.
 clear
 load
@@ -508,6 +679,27 @@ eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   {app="foo", pod="b"} 12
   {app="bar", pod="a"} 15
   {app="bar", pod="b"} 30
+
+# bottomk() grouping on structured metadata. bottomk() selects rather than aggregates, so the
+# winning series keeps its full label set either way; grouping decides only which series
+# compete against which.
+clear
+load
+  {app="foo"} "xbar"  @ 10s [repeat every 10s for 18] [metadata pod="a"]
+  {app="foo"} "noise" @ 15s [repeat every 10s for 18] [metadata pod="a"]
+  {app="foo"} "xbar"  @ 5s  [repeat every 5s  for 36] [metadata pod="b"]
+  {app="foo"} "noise" @ 7s  [repeat every 5s  for 36] [metadata pod="b"]
+  {app="bar"} "xbar"  @ 4s  [repeat every 4s  for 45] [metadata pod="a"]
+  {app="bar"} "noise" @ 2s  [repeat every 4s  for 45] [metadata pod="a"]
+  {app="bar"} "xbar"  @ 2s  [repeat every 2s  for 90] [metadata pod="b"]
+  {app="bar"} "noise" @ 1s  [repeat every 2s  for 90] [metadata pod="b"]
+
+eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
+  {app="foo", pod="a"} 6
+  {app="bar", pod="a"} 15
+eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)
+  {app="foo", pod="a"} 6
+  {app="foo", pod="b"} 12
 
 # bottomk() with special inputs.
 clear


### PR DESCRIPTION
**What this PR does / why we need it**:

Structured metadata was one of the least-covered dimensions in the `logqltest` declarative correctness suite: several parsers, formatters, and aggregation functions were only ever tested against a stream label or a parsed field, never a metadata-origin one. This adds that coverage so a metadata-origin label is verified to behave identically to a stream label or a parsed field wherever the language guarantees that — label filters, `logfmt`/`json`/`regexp`/`pattern`/`unpack`, `line_format`/`label_format`/`drop`/`keep`, `bytes()`/`duration()` conversions, range and vector aggregation grouping, `unwrap`, and binary operation matching/grouping.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

All new/changed scenarios were verified against the real engine (`direct`, query-frontend without sharding, and query-frontend with sharding) before being pinned, per the checklist in `pkg/logql/internal/logqltest/testdata/AGENTS.md`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)