### PR TITLE
fix(logql): Clear resultCache on BaseLabelsBuilder.Reset

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -201,6 +201,7 @@ func (b *BaseLabelsBuilder) Reset() {
 	b.errDetails = ""
 	b.baseMap = nil
 	b.parserKeyHints.Reset()
+	clear(b.resultCache)
 }
 
 // ParserLabelHints returns a limited list of expected labels to extract for metric queries.

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -50,6 +50,21 @@ func TestLabelsBuilder_Get(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestBaseLabelsBuilder_ResetClearsResultCache(t *testing.T) {
+	lbs := labels.FromStrings("app", "x")
+	base := NewBaseLabelsBuilder()
+	b := base.ForLabels(lbs, labels.StableHash(lbs))
+	require.NotEmpty(t, base.resultCache)
+
+	b.Reset()
+	b.Add(StructuredMetadataLabel, labels.FromStrings("trace_id", "aaa"))
+	_ = b.LabelsResult()
+	require.NotEmpty(t, base.resultCache)
+
+	b.Reset()
+	require.Empty(t, base.resultCache)
+}
+
 func TestLabelsBuilder_LabelsError(t *testing.T) {
 	lbs := labels.FromStrings("already", "in")
 	b := NewBaseLabelsBuilder().ForLabels(lbs, labels.StableHash(lbs))


### PR DESCRIPTION
**What this PR does / why we need it**:

`pipeline.Reset()` is supposed to drop the label cache so a long-lived ingester tailer does not grow without bound. `BaseLabelsBuilder.Reset()` already cleared add/del state, but left `resultCache` intact.

With structured metadata (OTLP default) each distinct label set becomes another cache entry. Tailing then leaks until the process is killed.

This restores the invariant from #6152 that #9949 intended: after `Reset()`, the cache is empty.

**Which issue(s) this PR fixes**:
Fixes #24031

**Special notes for your reviewer**:

`streamPipeline.Process` also calls `Reset()` per line, so the cache no longer survives across lines. That matches the tailer requirement. A line with unchanged labels still uses `currentResult` and does not touch the cache.

**Tests run**

- `go test -count=1 ./pkg/logql/log/` (RED on unfixed `Reset()`, then GREEN)

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.