### PR TITLE
feat(dataobj): Write min/max shard buckets to index files

### DIFF
--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -238,8 +238,10 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 					return fmt.Errorf("failed to append to stream: %w", err)
 				}
 				streamIDLookup[stream.ID] = newStreamID
-				streamLabels[stream.ID] = stream.Labels
-				shardBuckets[stream.ID] = streams.ShardBucket(stream.Labels)
+				if _, ok := streamLabels[stream.ID]; !ok {
+					streamLabels[stream.ID] = stream.Labels
+					shardBuckets[stream.ID] = streams.ShardBucket(stream.Labels)
+				}
 				c.uncompressedByTenant[section.Tenant] += uint64(stream.UncompressedSize)
 			}
 			return nil

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -33,6 +33,8 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 			break
 		}
 		streamLbls := calcCtx.streamLabels[log.StreamID]
+		shardBucket := calcCtx.streamShardBuckets[log.StreamID]
+
 		// The uncompressed byte contract is line bytes plus structured metadata
 		// value bytes, matching streams.Stream.UncompressedSize and the stats
 		// calculation so every producer reports the same quantity.
@@ -53,6 +55,7 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 				StreamID:         log.StreamID,
 				Timestamp:        log.Timestamp,
 				UncompressedSize: uncompressedSize,
+				ShardBucket:      shardBucket,
 			})
 		})
 	}

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -32,8 +33,12 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 		if batchErr != nil {
 			break
 		}
-		streamLbls := calcCtx.streamLabels[log.StreamID]
-		shardBucket := calcCtx.streamShardBuckets[log.StreamID]
+		streamLbls, labelsOK := calcCtx.streamLabels[log.StreamID]
+		shardBucket, shardOK := calcCtx.streamShardBuckets[log.StreamID]
+
+		if !labelsOK || !shardOK {
+			return errors.New("unknown stream ID for record")
+		}
 
 		// The uncompressed byte contract is line bytes plus structured metadata
 		// value bytes, matching streams.Stream.UncompressedSize and the stats

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -2,7 +2,7 @@ package index
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -28,16 +28,12 @@ func (c *labelPostingsCalculation) Prepare(_ context.Context, _ *logsCalculation
 }
 
 func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculationContext, batch []logs.Record) error {
-	var batchErr error
 	for _, log := range batch {
-		if batchErr != nil {
-			break
-		}
 		streamLbls, labelsOK := calcCtx.streamLabels[log.StreamID]
 		shardBucket, shardOK := calcCtx.streamShardBuckets[log.StreamID]
 
 		if !labelsOK || !shardOK {
-			return errors.New("unknown stream ID for record")
+			return fmt.Errorf("unknown stream ID %d in log record", log.StreamID)
 		}
 
 		// The uncompressed byte contract is line bytes plus structured metadata
@@ -48,9 +44,6 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 			uncompressedSize += int64(len(md.Value))
 		})
 		streamLbls.Range(func(lbl labels.Label) {
-			if batchErr != nil {
-				return
-			}
 			calcCtx.builder.ObserveLabelPosting(calcCtx.tenantID, postings.LabelObservation{
 				ObjectPath:       calcCtx.objectPath,
 				ShardBuckets:     int64(streams.ShardFactor),
@@ -64,7 +57,7 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 			})
 		})
 	}
-	return batchErr
+	return nil
 }
 
 func (c *labelPostingsCalculation) Flush(_ context.Context, _ *logsCalculationContext) error {

--- a/pkg/dataobj/index/label_postings_calculation_test.go
+++ b/pkg/dataobj/index/label_postings_calculation_test.go
@@ -320,6 +320,69 @@ func TestLabelPostingsCalculation_TimestampsAndSizes(t *testing.T) {
 	require.Equal(t, expectedSize, row["uncompressed_size.int64"])
 }
 
+func TestLabelPostingsCalculation_ShardBucketsHandling(t *testing.T) {
+	builder := newTestIndexBuilder(t)
+	calcCtx := makeTestCalcContext(builder)
+	calc := &labelPostingsCalculation{}
+
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
+
+	ts1 := time.Unix(10, 0).UTC()
+
+	batch := []logs.Record{
+		{StreamID: 1, Timestamp: ts1, Line: []byte("")}, // shard: 30 (svcA, prod)
+		{StreamID: 2, Timestamp: ts1, Line: []byte("")}, // shard: 25 (svcB, dev)
+		{StreamID: 3, Timestamp: ts1, Line: []byte("")}, // shard: 5  (staging)
+		{StreamID: 4, Timestamp: ts1, Line: []byte("")}, // shard: 15 (dev)
+	}
+	require.NoError(t, calc.ProcessBatch(context.Background(), calcCtx, batch))
+	require.NoError(t, calc.Flush(context.Background(), calcCtx))
+
+	tbl := flushAndReadAllPostingsTable(t, builder)
+	// 2 postings: service_name=svcA, env=prod (both from stream 1).
+	require.Len(t, tbl.rows, 5)
+
+	// Shard factor should be constant on all rows
+	for _, row := range tbl.rows {
+		require.Equal(t, int64(streams.ShardFactor), row["shard_buckets.int64"])
+	}
+
+	// Check min & max shard buckets are calculated correctly
+	// Dev is derived from two records in the same object. Prod & staging have one record.
+	type expectation struct {
+		env      string
+		minShard int64
+		maxShard int64
+	}
+	expect := []expectation{
+		{
+			env:      "prod",
+			minShard: 30,
+			maxShard: 30,
+		},
+		{
+			env:      "staging",
+			minShard: 5,
+			maxShard: 5,
+		},
+		{
+			env:      "dev",
+			minShard: 15,
+			maxShard: 25,
+		},
+	}
+	for _, exp := range expect {
+		i := findRow(tbl.rows, map[string]any{
+			"column_name.utf8": "env",
+			"label_value.utf8": exp.env,
+		})
+		require.NotEqual(t, -1, i)
+		row := tbl.rows[i]
+		require.Equal(t, exp.minShard, row["min_shard_bucket.int64"])
+		require.Equal(t, exp.maxShard, row["max_shard_bucket.int64"])
+	}
+}
+
 func TestLabelPostingsCalculation_EmptyBatch(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	calcCtx := makeTestCalcContext(builder)

--- a/pkg/dataobj/index/label_postings_calculation_test.go
+++ b/pkg/dataobj/index/label_postings_calculation_test.go
@@ -383,6 +383,91 @@ func TestLabelPostingsCalculation_ShardBucketsHandling(t *testing.T) {
 	}
 }
 
+func TestLabelPostingsCalculation_SharedLabelAggregation(t *testing.T) {
+	builder := newTestIndexBuilder(t)
+	calcCtx := makeTestCalcContext(builder)
+	calc := &labelPostingsCalculation{}
+
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
+
+	ts1 := time.Unix(10, 0).UTC()
+	ts2 := time.Unix(20, 0).UTC()
+	line2 := []byte("from-two")  // stream 2: service_name=svcB, env=dev
+	line4 := []byte("from-four") // stream 4: env=dev
+	line1 := []byte("from-one")  // stream 1: service_name=svcA, env=prod (must not mix into env=dev)
+
+	batch := []logs.Record{
+		{StreamID: 2, Timestamp: ts1, Line: line2},
+		{StreamID: 4, Timestamp: ts2, Line: line4},
+		{StreamID: 1, Timestamp: ts1, Line: line1},
+	}
+	require.NoError(t, calc.ProcessBatch(context.Background(), calcCtx, batch))
+	require.NoError(t, calc.Flush(context.Background(), calcCtx))
+
+	tbl := flushAndReadAllPostingsTable(t, builder)
+	// service_name=svcA, service_name=svcB, env=prod, env=dev
+	require.Len(t, tbl.rows, 4)
+
+	i := findRow(tbl.rows, map[string]any{
+		"column_name.utf8": "env",
+		"label_value.utf8": "dev",
+	})
+	require.NotEqual(t, -1, i, "expected env=dev posting aggregated across streams 2 and 4")
+	row := tbl.rows[i]
+	require.Equal(t, int64(len(line2)+len(line4)), row["uncompressed_size.int64"])
+	require.Equal(t, ts1.UTC(), row["min_timestamp.timestamp"])
+	require.Equal(t, ts2.UTC(), row["max_timestamp.timestamp"])
+
+	bitmap := tbl.opaque["stream_id_bitmap.binary"][i]
+	require.True(t, isBitSet(bitmap, 2), "env=dev bitmap should have stream 2 set")
+	require.True(t, isBitSet(bitmap, 4), "env=dev bitmap should have stream 4 set")
+	require.False(t, isBitSet(bitmap, 1), "env=dev bitmap should not include stream 1 (env=prod)")
+}
+
+func TestLabelPostingsCalculation_UnknownStreamID(t *testing.T) {
+	tt := []struct {
+		name     string
+		streamID int64
+		mutate   func(*logsCalculationContext)
+	}{
+		{
+			name:     "stream not in labels or shards",
+			streamID: 99,
+		},
+		{
+			name:     "missing shard bucket",
+			streamID: 1,
+			mutate: func(ctx *logsCalculationContext) {
+				delete(ctx.streamShardBuckets, 1)
+			},
+		},
+		{
+			name:     "missing stream labels",
+			streamID: 1,
+			mutate: func(ctx *logsCalculationContext) {
+				delete(ctx.streamLabels, 1)
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := newTestIndexBuilder(t)
+			calcCtx := makeTestCalcContext(builder)
+			if tc.mutate != nil {
+				tc.mutate(calcCtx)
+			}
+			calc := &labelPostingsCalculation{}
+
+			require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
+			err := calc.ProcessBatch(context.Background(), calcCtx, []logs.Record{
+				{StreamID: tc.streamID, Timestamp: time.Unix(10, 0).UTC(), Line: []byte("x")},
+			})
+			require.ErrorContains(t, err, "unknown stream ID for record")
+		})
+	}
+}
+
 func TestLabelPostingsCalculation_EmptyBatch(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	calcCtx := makeTestCalcContext(builder)

--- a/pkg/dataobj/index/label_postings_calculation_test.go
+++ b/pkg/dataobj/index/label_postings_calculation_test.go
@@ -339,7 +339,7 @@ func TestLabelPostingsCalculation_ShardBucketsHandling(t *testing.T) {
 	require.NoError(t, calc.Flush(context.Background(), calcCtx))
 
 	tbl := flushAndReadAllPostingsTable(t, builder)
-	// 2 postings: service_name=svcA, env=prod (both from stream 1).
+	// 5 postings: service_name={svcA, svcB}, env={dev, staging, prod}
 	require.Len(t, tbl.rows, 5)
 
 	// Shard factor should be constant on all rows
@@ -463,7 +463,7 @@ func TestLabelPostingsCalculation_UnknownStreamID(t *testing.T) {
 			err := calc.ProcessBatch(context.Background(), calcCtx, []logs.Record{
 				{StreamID: tc.streamID, Timestamp: time.Unix(10, 0).UTC(), Line: []byte("x")},
 			})
-			require.ErrorContains(t, err, "unknown stream ID for record")
+			require.ErrorContains(t, err, "unknown stream ID")
 		})
 	}
 }
@@ -551,6 +551,7 @@ func BenchmarkLabelPostingsCalculation_ProcessBatch(b *testing.B) {
 					"namespace", fmt.Sprintf("ns-%d", i%10),
 				)
 			}
+			shardBuckets := makeTestShardBuckets(streamLabels)
 
 			// Pre-build the batch: records are distributed round-robin across streams.
 			batch := make([]logs.Record, bc.records)
@@ -571,11 +572,12 @@ func BenchmarkLabelPostingsCalculation_ProcessBatch(b *testing.B) {
 					b.Fatal(err)
 				}
 				calcCtx := &logsCalculationContext{
-					tenantID:     "bench-tenant",
-					objectPath:   "bench/path",
-					sectionIdx:   0,
-					streamLabels: streamLabels,
-					builder:      builder,
+					tenantID:           "bench-tenant",
+					objectPath:         "bench/path",
+					sectionIdx:         0,
+					streamLabels:       streamLabels,
+					streamShardBuckets: shardBuckets,
+					builder:            builder,
 				}
 				calc := &labelPostingsCalculation{}
 

--- a/pkg/dataobj/index/stats_calculation_test.go
+++ b/pkg/dataobj/index/stats_calculation_test.go
@@ -38,6 +38,7 @@ func makeTestStreamLabels() map[int64]labels.Labels {
 		1: labels.FromStrings("service_name", "svcA", "env", "prod"),
 		2: labels.FromStrings("service_name", "svcB", "env", "dev"),
 		3: labels.FromStrings("env", "staging"),
+		4: labels.FromStrings("env", "dev"),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Wires up the dataobj index-builder to calculate min/max shard buckets present in a posting. 
These can be used to prune which log objects get read when looking up sections for a specific shard.
* Note: On their own, these aren't that helpful, but after compaction each log object will have at most 2 shards so this becomes much more useful for pruning.
