### PR TITLE
fix(deletion): Validate delete request queries like read path queries

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1642,7 +1642,7 @@ Log entry deletion is supported when the TSDB index is configured for the index 
 
 Query parameters:
 
-- `query=<series_selector>`: query argument that identifies the streams from which to delete with optional line filters.
+- `query=<series_selector>`: query argument that identifies the streams from which to delete with optional line filters. As with queries on the read path, the stream selector must contain at least one matcher that does not match an empty value, so `{foo=~".*"}` is rejected but `{foo=~".+"}` is accepted.
 - `start=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the start of the time window within which entries will be deleted. This parameter is required.
 - `end=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the end of the time window within which entries will be deleted. If not specified, defaults to the current time.
 - `max_interval=<duration>`: The maximum time period the delete request can span. If the request is larger than this value, it is split into several requests of <= `max_interval`. Valid time units are `s`, `m`, and `h`.

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1642,7 +1642,7 @@ Log entry deletion is supported when the TSDB index is configured for the index 
 
 Query parameters:
 
-- `query=<series_selector>`: query argument that identifies the streams from which to delete with optional line filters. As with queries on the read path, the stream selector must contain at least one matcher that does not match an empty value, so `{foo=~".*"}` is rejected but `{foo=~".+"}` is accepted.
+- `query=<series_selector>`: query argument that identifies the streams from which to delete with optional line filters.
 - `start=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the start of the time window within which entries will be deleted. This parameter is required.
 - `end=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the end of the time window within which entries will be deleted. If not specified, defaults to the current time.
 - `max_interval=<duration>`: The maximum time period the delete request can span. If the request is larger than this value, it is split into several requests of <= `max_interval`. Valid time units are `s`, `m`, and `h`.

--- a/pkg/compactor/deletion/request_handler_test.go
+++ b/pkg/compactor/deletion/request_handler_test.go
@@ -142,12 +142,17 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 	t.Run("Validation", func(t *testing.T) {
 		h := NewDeleteRequestHandler(&mockDeleteRequestsStore{}, time.Minute, 0, nil)
 
+		// error is the message the response body is expected to contain
 		for _, tc := range []struct {
 			orgID, query, startTime, endTime, interval, error string
 		}{
 			{"", `{foo="bar"}`, "0000000000", "0000000001", "", "no org id\n"},
 			{"org-id", "", "0000000000", "0000000001", "", "query not set\n"},
-			{"org-id", `not a query`, "0000000000", "0000000001", "", "invalid query expression\n"},
+			{"org-id", `not a query`, "0000000000", "0000000001", "", "invalid query expression: parse error"},
+			{"org-id", `{foo=~".*"}`, "0000000000", "0000000001", "", "invalid query expression: parse error : queries require at least one regexp or equality matcher that does not have an empty-compatible value"},
+			{"org-id", `{foo!="bar"}`, "0000000000", "0000000001", "", "invalid query expression: parse error : queries require at least one regexp or equality matcher that does not have an empty-compatible value"},
+			{"org-id", `{foo="bar"} |~ "["`, "0000000000", "0000000001", "", `invalid query expression: parse error : stage '|~ "["' : error parsing regexp: missing closing ]`},
+			{"org-id", `{foo="bar"} | addr=ip("not-an-ip")`, "0000000000", "0000000001", "", `invalid query expression: parse error : stage '| addr=ip("not-an-ip")' : ip: invalid pattern: "not-an-ip"`},
 			{"org-id", `{foo="bar"}`, "", "0000000001", "", "start time not set\n"},
 			{"org-id", `{foo="bar"}`, "0000000000000", "0000000001", "", "invalid start time: require unix seconds or RFC3339 format\n"},
 			{"org-id", `{foo="bar"}`, "0000000000", "0000000000001", "", "invalid end time: require unix seconds or RFC3339 format\n"},
@@ -170,7 +175,7 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 				h.AddDeleteRequestHandler(w, req)
 
 				require.Equal(t, w.Code, http.StatusBadRequest)
-				require.Equal(t, w.Body.String(), tc.error)
+				require.Contains(t, w.Body.String(), tc.error)
 			})
 		}
 	})

--- a/pkg/compactor/deletion/request_handler_test.go
+++ b/pkg/compactor/deletion/request_handler_test.go
@@ -142,9 +142,8 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 	t.Run("Validation", func(t *testing.T) {
 		h := NewDeleteRequestHandler(&mockDeleteRequestsStore{}, time.Minute, 0, nil)
 
-		// error is the message the response body is expected to contain
 		for _, tc := range []struct {
-			orgID, query, startTime, endTime, interval, error string
+			orgID, query, startTime, endTime, interval, expectedErrorSubstring string
 		}{
 			{"", `{foo="bar"}`, "0000000000", "0000000001", "", "no org id\n"},
 			{"org-id", "", "0000000000", "0000000001", "", "query not set\n"},
@@ -164,7 +163,7 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 			{"org-id", `{foo="bar"} |= "foo"`, "0000000000", "0000000001", "30s", "max_interval can't be greater than the interval to be deleted (1s)\n"},
 			{"org-id", `{foo="bar"} |= "foo"`, "0000000000", "0000000000", "", "start time can't be greater than or equal to end time\n"},
 		} {
-			t.Run(strings.TrimSpace(tc.error), func(t *testing.T) {
+			t.Run(strings.TrimSpace(tc.expectedErrorSubstring), func(t *testing.T) {
 				req := buildRequest(tc.orgID, tc.query, tc.startTime, tc.endTime, false)
 
 				params := req.URL.Query()
@@ -175,7 +174,7 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 				h.AddDeleteRequestHandler(w, req)
 
 				require.Equal(t, w.Code, http.StatusBadRequest)
-				require.Contains(t, w.Body.String(), tc.error)
+				require.Contains(t, w.Body.String(), tc.expectedErrorSubstring)
 			})
 		}
 	})

--- a/pkg/compactor/deletion/util.go
+++ b/pkg/compactor/deletion/util.go
@@ -2,6 +2,7 @@ package deletion
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -11,11 +12,20 @@ var (
 	errInvalidQuery = errors.New("invalid query expression")
 )
 
-// parseDeletionQuery checks if the given logQL is valid for deletions
+// parseDeletionQuery checks if the given logQL is valid for deletions. It applies the
+// same validation we apply to queries on the read path, e.g. requiring at least one
+// matcher that does not match everything.
 func parseDeletionQuery(query string) (syntax.LogSelectorExpr, error) {
-	logSelectorExpr, err := syntax.ParseLogSelector(query, false)
+	logSelectorExpr, err := syntax.ParseLogSelector(query, true)
 	if err != nil {
-		return nil, errInvalidQuery
+		return nil, fmt.Errorf("%w: %s", errInvalidQuery, err)
+	}
+
+	// Some stages are only checked when the pipeline gets built, for instance line
+	// filter regexes and ip() patterns. Build it here and throw it away so we reject
+	// the request now, instead of failing every time we try to process it later.
+	if _, err := logSelectorExpr.Pipeline(); err != nil {
+		return nil, fmt.Errorf("%w: %s", errInvalidQuery, err)
 	}
 
 	return logSelectorExpr, nil

--- a/pkg/compactor/deletion/util.go
+++ b/pkg/compactor/deletion/util.go
@@ -12,9 +12,7 @@ var (
 	errInvalidQuery = errors.New("invalid query expression")
 )
 
-// parseDeletionQuery checks if the given logQL is valid for deletions. It applies the
-// same validation we apply to queries on the read path, e.g. requiring at least one
-// matcher that does not match everything.
+// parseDeletionQuery checks if the given logQL is valid for deletions.
 func parseDeletionQuery(query string) (syntax.LogSelectorExpr, error) {
 	logSelectorExpr, err := syntax.ParseLogSelector(query, true)
 	if err != nil {

--- a/pkg/compactor/deletion/util_test.go
+++ b/pkg/compactor/deletion/util_test.go
@@ -6,34 +6,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// substring of the parse error logql returns for selectors that match everything
+const errAtleastOneMatcherRequired = "queries require at least one regexp or equality matcher"
+
 func TestParseLogQLExpressionForDeletion(t *testing.T) {
-	t.Run("invalid logql", func(t *testing.T) {
-		logSelectorExpr, err := parseDeletionQuery("gjgjg ggj")
-		require.Nil(t, logSelectorExpr)
-		require.ErrorIs(t, err, errInvalidQuery)
-	})
+	for _, tc := range []struct {
+		name        string
+		query       string
+		errContains string
+	}{
+		{"invalid logql", "gjgjg ggj", "syntax error"},
+		{"pipeline expression with invalid line filter", `{env="dev", secret="true"} |= social sec number`, "syntax error"},
+		{"matcher matching everything", `{env=~".*"}`, errAtleastOneMatcherRequired},
+		{"only empty-compatible matchers", `{env!="dev"}`, errAtleastOneMatcherRequired},
+		{"unclosed character class in line filter", `{env="dev"} |~ "["`, "error parsing regexp: missing closing ]"},
+		{"unclosed character class in negated line filter", `{env="dev"} !~ "["`, "error parsing regexp: missing closing ]"},
+		{"invalid repetition in label filter regex", `{env="dev"} | addr=~"*"`, "error parsing regexp: missing argument to repetition operator"},
+		{"invalid ip pattern in label filter", `{env="dev"} | addr=ip("not-an-ip")`, `ip: invalid pattern: "not-an-ip"`},
+		{"out of range ip in label filter", `{env="dev"} | addr=ip("192.168.0.500")`, `ip: invalid pattern: "192.168.0.500"`},
+		{"truncated ip after parser stage", `{env="dev"} | json | addr=ip("1.2.3")`, `ip: invalid pattern: "1.2.3"`},
+		{"invalid ip pattern in line filter", `{env="dev"} |= ip("garbage")`, `ip: invalid pattern: "garbage"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logSelectorExpr, err := parseDeletionQuery(tc.query)
+			require.Nil(t, logSelectorExpr)
+			require.ErrorIs(t, err, errInvalidQuery)
+			// the reason has to reach the caller, "invalid query expression" alone is not actionable
+			require.ErrorContains(t, err, tc.errContains)
+		})
+	}
 
-	t.Run("matcher expression", func(t *testing.T) {
-		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"}`)
-		require.NotNil(t, logSelectorExpr)
-		require.NoError(t, err)
-	})
-
-	t.Run("pipeline expression with line filter", func(t *testing.T) {
-		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} |= "social sec number"`)
-		require.NotNil(t, logSelectorExpr)
-		require.NoError(t, err)
-	})
-
-	t.Run("pipeline expression with multiple line filters", func(t *testing.T) {
-		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} |= "social sec number" |~ "[abd]*" `)
-		require.NotNil(t, logSelectorExpr)
-		require.NoError(t, err)
-	})
-
-	t.Run("pipeline expression with invalid line filter", func(t *testing.T) {
-		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} |= social sec number`)
-		require.Nil(t, logSelectorExpr)
-		require.ErrorIs(t, err, errInvalidQuery)
-	})
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{"matcher expression", `{env="dev", secret="true"}`},
+		{"regex matcher requiring a value", `{env=~".+"}`},
+		{"pipeline expression with line filter", `{env="dev", secret="true"} |= "social sec number"`},
+		{"pipeline expression with multiple line filters", `{env="dev", secret="true"} |= "social sec number" |~ "[abd]*" `},
+		{"valid regex line filter", `{env="dev"} |~ "[abc]+"`},
+		{"valid ip in label filter", `{env="dev"} | addr=ip("192.168.0.1")`},
+		{"valid ip range in line filter", `{env="dev"} |= ip("192.168.4.5-192.168.4.20")`},
+		{"valid ip cidr in line filter", `{env="dev"} |= ip("192.168.4.0/24")`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logSelectorExpr, err := parseDeletionQuery(tc.query)
+			require.NotNil(t, logSelectorExpr)
+			require.NoError(t, err)
+		})
+	}
 }

--- a/pkg/compactor/deletion/util_test.go
+++ b/pkg/compactor/deletion/util_test.go
@@ -6,9 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// substring of the parse error logql returns for selectors that match everything
-const errAtleastOneMatcherRequired = "queries require at least one regexp or equality matcher"
-
 func TestParseLogQLExpressionForDeletion(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
@@ -17,8 +14,8 @@ func TestParseLogQLExpressionForDeletion(t *testing.T) {
 	}{
 		{"invalid logql", "gjgjg ggj", "syntax error"},
 		{"pipeline expression with invalid line filter", `{env="dev", secret="true"} |= social sec number`, "syntax error"},
-		{"matcher matching everything", `{env=~".*"}`, errAtleastOneMatcherRequired},
-		{"only empty-compatible matchers", `{env!="dev"}`, errAtleastOneMatcherRequired},
+		{"matcher matching everything", `{env=~".*"}`, "queries require at least one regexp or equality matcher"},
+		{"only empty-compatible matchers", `{env!="dev"}`, "queries require at least one regexp or equality matcher"},
 		{"unclosed character class in line filter", `{env="dev"} |~ "["`, "error parsing regexp: missing closing ]"},
 		{"unclosed character class in negated line filter", `{env="dev"} !~ "["`, "error parsing regexp: missing closing ]"},
 		{"invalid repetition in label filter regex", `{env="dev"} | addr=~"*"`, "error parsing regexp: missing argument to repetition operator"},


### PR DESCRIPTION
Delete request queries now get the same validation as read path queries: at least one matcher that does not match everything, and a pipeline build to catch bad line filter regexes and `ip()` patterns.

Queries the API accepted before this change and rejects now:

| query | reason |
| --- | --- |
| `{foo=~".*"}` | matches every stream |
| `{foo!="bar"}` | only empty-compatible matchers, so it matches every stream |
| `{foo="bar"} \|~ "["` | invalid regex |
| `{foo="bar"} \| addr=~"*"` | invalid regex in a label filter |
| `{foo="bar"} \| addr=ip("not-an-ip")` | invalid `ip()` pattern |
| `{foo="bar"} \|= ip("garbage")` | invalid `ip()` pattern in a line filter |

The regex and `ip()` ones are why this builds the pipeline: `ParseLogSelector(query, true)` parses them fine and only fails when the stages get compiled.

`parseDeletionQuery` is also what parses stored requests when the compactor loads them, so a request stored before this change that no longer validates will now fail to load, and `loadDeleteRequestsToProcess` returns on the first error. I left that path alone — shout if you'd rather it skip-and-log instead.