### PR TITLE
refactor(logql): Remove (*parser).Parse and unexport parseExprWithoutValidation

### DIFF
--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -289,16 +289,10 @@ func (g *Gateway) LabelNamesForMetricName(ctx context.Context, req *logproto.Lab
 	// An empty matchers string cannot be parsed,
 	// therefore we check the string representation of the matchers.
 	if req.Matchers != syntax.EmptyMatchers {
-		expr, err := syntax.ParseExprWithoutValidation(req.Matchers)
+		matchers, err = syntax.ParseMatchers(req.Matchers, false)
 		if err != nil {
 			return nil, err
 		}
-
-		matcherExpr, ok := expr.(*syntax.MatchersExpr)
-		if !ok {
-			return nil, fmt.Errorf("invalid label matchers found of type %T", expr)
-		}
-		matchers = matcherExpr.Mts
 	}
 
 	if err := g.queryGate.Start(ctx); err != nil {
@@ -324,16 +318,10 @@ func (g *Gateway) LabelValuesForMetricName(ctx context.Context, req *logproto.La
 	// An empty matchers string cannot be parsed,
 	// therefore we check the string representation of the matchers.
 	if req.Matchers != syntax.EmptyMatchers {
-		expr, err := syntax.ParseExprWithoutValidation(req.Matchers)
+		matchers, err = syntax.ParseMatchers(req.Matchers, false)
 		if err != nil {
 			return nil, err
 		}
-
-		matcherExpr, ok := expr.(*syntax.MatchersExpr)
-		if !ok {
-			return nil, fmt.Errorf("invalid label matchers found of type %T", expr)
-		}
-		matchers = matcherExpr.Mts
 	}
 
 	if err := g.queryGate.Start(ctx); err != nil {

--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -58,21 +58,9 @@ type parser struct {
 	*strings.Reader
 }
 
-func (p *parser) Parse() (Expr, error) {
-	p.errs = p.errs[:0]
-	p.Scanner.Error = func(_ *Scanner, msg string) {
-		p.Error(msg)
-	}
-	e := p.p.Parse(p)
-	if e != 0 || len(p.errs) > 0 {
-		return nil, p.errs[0]
-	}
-	return p.expr, nil
-}
-
 // ParseExpr parses a string and returns an Expr.
 func ParseExpr(input string) (Expr, error) {
-	expr, err := ParseExprWithoutValidation(input)
+	expr, err := parseExprWithoutValidation(input)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +70,13 @@ func ParseExpr(input string) (Expr, error) {
 	return expr, nil
 }
 
-func ParseExprWithoutValidation(input string) (expr Expr, err error) {
+// parseExprWithoutValidation parses a string and returns an Expr, skipping the
+// semantic validation done by ParseExpr.
+//
+// The parse itself is inlined here rather than living on the parser type: parts
+// of LogQL parsing panic deliberately and rely on the recover below, so there
+// must be no way to invoke them without it.
+func parseExprWithoutValidation(input string) (expr Expr, err error) {
 	if len(input) >= maxInputSize {
 		return nil, logqlmodel.NewParseError(fmt.Sprintf("input size too long (%d > %d)", len(input), maxInputSize), 0, 0)
 	}
@@ -104,7 +98,15 @@ func ParseExprWithoutValidation(input string) (expr Expr, err error) {
 
 	p.Reset(input)
 	p.Init(p.Reader)
-	return p.Parse()
+
+	p.errs = p.errs[:0]
+	p.Scanner.Error = func(_ *Scanner, msg string) {
+		p.Error(msg)
+	}
+	if e := p.p.Parse(p); e != 0 || len(p.errs) > 0 {
+		return nil, p.errs[0]
+	}
+	return p.expr, nil
 }
 
 func MustParseExpr(input string) Expr {
@@ -146,7 +148,7 @@ func ParseMatchers(input string, validate bool) ([]*labels.Matcher, error) {
 	if validate {
 		expr, err = ParseExpr(input)
 	} else {
-		expr, err = ParseExprWithoutValidation(input)
+		expr, err = parseExprWithoutValidation(input)
 	}
 
 	if err != nil {
@@ -261,7 +263,7 @@ func validateSortGrouping(grouping *Grouping) error {
 
 // ParseLogSelector parses a log selector expression `{app="foo"} |= "filter"`
 func ParseLogSelector(input string, validate bool) (LogSelectorExpr, error) {
-	expr, err := ParseExprWithoutValidation(input)
+	expr, err := parseExprWithoutValidation(input)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Inlines `(*parser).Parse` into `parseExprWithoutValidation` and unexports it. Parts of LogQL parsing panic on purpose and rely on that function's `recover`. Removing this dangerous but innocuous looking function that's currently unused.

Also drop the exported `syntax.ParseExprWithoutValidation`. Its only external callers were two index-gateway handlers that were open-coding `ParseMatchers`, so they now call that instead.