### PR TITLE
fix(logql): Point approx_topk shard error at the real flag

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -320,7 +320,7 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 			}, bytesPerShard, nil
 		case syntax.OpTypeApproxTopK:
 			if !m.approxTopkSupport {
-				return nil, 0, fmt.Errorf("approx_topk is not enabled. See -limits.shard_aggregations")
+				return nil, 0, fmt.Errorf("approx_topk is not enabled. See -querier.shard-aggregations or the per-tenant shard_aggregations runtime config")
 			}
 
 			return m.mapApproxTopk(expr, false)

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
+func TestApproxTopkDisabled(t *testing.T) {
+	m := NewShardMapper(NewPowerOfTwoStrategy(ConstantShards(2)), nilShardMetrics, nil)
+	ast, err := syntax.ParseExpr(`approx_topk(3, sum by(ip)(rate({foo="bar"}[5m])))`)
+	require.NoError(t, err)
+	_, _, err = m.Map(ast, nilShardMetrics.downstreamRecorder(), true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "approx_topk is not enabled. See -querier.shard-aggregations")
+}
+
 func TestApproxCountDistinctShardMapping(t *testing.T) {
 	t.Run("disabled is a no-op", func(t *testing.T) {
 		m := NewShardMapper(NewPowerOfTwoStrategy(ConstantShards(2)), nilShardMetrics, nil)


### PR DESCRIPTION
## Summary

- Disabled `approx_topk` queries were telling operators to look at `-limits.shard_aggregations`, which is not a real flag.
- Point the error at `-querier.shard-aggregations` and the per-tenant `shard_aggregations` runtime config, matching the `approx_count_distinct` wording from #24120.

Follow-up to https://github.com/grafana/loki/pull/24120#discussion_r3864058969.

## Test plan

- [x] `go test -v -test.run TestApproxTopkDisabled ./pkg/logql/`
- [x] `go test ./pkg/logql/...`


Made with [Cursor](https://cursor.com)