### PR TITLE
refactor(logql): Group count-distinct types and share sketch matrix stepper

### DIFF
--- a/pkg/logql/approx_count_distinct.go
+++ b/pkg/logql/approx_count_distinct.go
@@ -88,6 +88,48 @@ func (CountDistinctSketchVector) String() string {
 
 func (CountDistinctSketchVector) Type() promql_parser.ValueType { return CountDistinctSketchVectorType }
 
+// ToProto serializes the vector for frontend/querier transport.
+func (v CountDistinctSketchVector) ToProto() (*logproto.CountDistinctSketchVector, error) {
+	samples := make([]*logproto.CountDistinctSketchSample, len(v))
+	for i, sample := range v {
+		p, err := sample.ToProto()
+		if err != nil {
+			return nil, err
+		}
+		samples[i] = p
+	}
+	return &logproto.CountDistinctSketchVector{Samples: samples}, nil
+}
+
+// CountDistinctSketchVectorFromProto deserializes a CountDistinctSketchVector.
+func CountDistinctSketchVectorFromProto(proto *logproto.CountDistinctSketchVector) (CountDistinctSketchVector, error) {
+	if proto == nil {
+		return CountDistinctSketchVector{}, nil
+	}
+	out := make(CountDistinctSketchVector, len(proto.Samples))
+	for i, sample := range proto.Samples {
+		s, err := CountDistinctSketchSampleFromProto(sample)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = s
+	}
+	return out, nil
+}
+
+// Estimate converts sketches into a numeric sample vector.
+func (v CountDistinctSketchVector) Estimate() SampleVector {
+	out := make(promql.Vector, 0, len(v))
+	for _, sample := range v {
+		out = append(out, promql.Sample{
+			T:      sample.T,
+			F:      float64(sample.F.Estimate()),
+			Metric: sample.Metric,
+		})
+	}
+	return SampleVector(out)
+}
+
 func (CountDistinctSketchMatrix) String() string {
 	return "CountDistinctSketchMatrix()"
 }
@@ -110,19 +152,6 @@ func (m CountDistinctSketchMatrix) Merge(right CountDistinctSketchMatrix) (Count
 	return m, nil
 }
 
-// ToProto serializes the vector for frontend/querier transport.
-func (v CountDistinctSketchVector) ToProto() (*logproto.CountDistinctSketchVector, error) {
-	samples := make([]*logproto.CountDistinctSketchSample, len(v))
-	for i, sample := range v {
-		p, err := sample.ToProto()
-		if err != nil {
-			return nil, err
-		}
-		samples[i] = p
-	}
-	return &logproto.CountDistinctSketchVector{Samples: samples}, nil
-}
-
 func (m CountDistinctSketchMatrix) ToProto() (*logproto.CountDistinctSketchMatrix, error) {
 	values := make([]*logproto.CountDistinctSketchVector, len(m))
 	for i, vec := range m {
@@ -133,6 +162,22 @@ func (m CountDistinctSketchMatrix) ToProto() (*logproto.CountDistinctSketchMatri
 		values[i] = p
 	}
 	return &logproto.CountDistinctSketchMatrix{Values: values}, nil
+}
+
+// CountDistinctSketchMatrixFromProto deserializes a CountDistinctSketchMatrix.
+func CountDistinctSketchMatrixFromProto(proto *logproto.CountDistinctSketchMatrix) (CountDistinctSketchMatrix, error) {
+	if proto == nil {
+		return CountDistinctSketchMatrix{}, nil
+	}
+	out := make(CountDistinctSketchMatrix, len(proto.Values))
+	for i, vec := range proto.Values {
+		v, err := CountDistinctSketchVectorFromProto(vec)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
 }
 
 // ToProto serializes one sketch sample.
@@ -150,38 +195,6 @@ func (s CountDistinctSketchSample) ToProto() (*logproto.CountDistinctSketchSampl
 		TimestampMs: s.T,
 		Metric:      metric,
 	}, nil
-}
-
-// CountDistinctSketchVectorFromProto deserializes a CountDistinctSketchVector.
-func CountDistinctSketchVectorFromProto(proto *logproto.CountDistinctSketchVector) (CountDistinctSketchVector, error) {
-	if proto == nil {
-		return CountDistinctSketchVector{}, nil
-	}
-	out := make(CountDistinctSketchVector, len(proto.Samples))
-	for i, sample := range proto.Samples {
-		s, err := CountDistinctSketchSampleFromProto(sample)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = s
-	}
-	return out, nil
-}
-
-// CountDistinctSketchMatrixFromProto deserializes a CountDistinctSketchMatrix.
-func CountDistinctSketchMatrixFromProto(proto *logproto.CountDistinctSketchMatrix) (CountDistinctSketchMatrix, error) {
-	if proto == nil {
-		return CountDistinctSketchMatrix{}, nil
-	}
-	out := make(CountDistinctSketchMatrix, len(proto.Values))
-	for i, vec := range proto.Values {
-		v, err := CountDistinctSketchVectorFromProto(vec)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = v
-	}
-	return out, nil
 }
 
 // CountDistinctSketchSampleFromProto deserializes one sketch sample.
@@ -202,19 +215,6 @@ func CountDistinctSketchSampleFromProto(proto *logproto.CountDistinctSketchSampl
 		F:      hll,
 		Metric: builder.Labels(),
 	}, nil
-}
-
-// Estimate converts sketches into a numeric sample vector.
-func (v CountDistinctSketchVector) Estimate() SampleVector {
-	out := make(promql.Vector, 0, len(v))
-	for _, sample := range v {
-		out = append(out, promql.Sample{
-			T:      sample.T,
-			F:      float64(sample.F.Estimate()),
-			Metric: sample.Metric,
-		})
-	}
-	return SampleVector(out)
 }
 
 // JoinCountDistinctSketchVector joins step sketches into a CountDistinctSketchMatrix.

--- a/pkg/logql/approx_count_distinct.go
+++ b/pkg/logql/approx_count_distinct.go
@@ -426,39 +426,10 @@ func (e *CountDistinctSketchEvalExpr) Walk(f syntax.WalkFn) {
 }
 
 // CountDistinctSketchMatrixStepEvaluator steps through a matrix of count-distinct sketches.
-type CountDistinctSketchMatrixStepEvaluator struct {
-	end, ts time.Time
-	step    time.Duration
-	m       CountDistinctSketchMatrix
-}
+type CountDistinctSketchMatrixStepEvaluator = SketchMatrixStepEvaluator[CountDistinctSketchVector]
 
 func NewCountDistinctSketchMatrixStepEvaluator(m CountDistinctSketchMatrix, params Params) *CountDistinctSketchMatrixStepEvaluator {
-	return &CountDistinctSketchMatrixStepEvaluator{
-		end:  params.End(),
-		ts:   params.Start().Add(-params.Step()), // corrected on first Next()
-		step: params.Step(),
-		m:    m,
-	}
-}
-
-func (m *CountDistinctSketchMatrixStepEvaluator) Next() (bool, int64, StepResult) {
-	m.ts = m.ts.Add(m.step)
-	if m.ts.After(m.end) {
-		return false, 0, nil
-	}
-	ts := m.ts.UnixNano() / int64(time.Millisecond)
-	if len(m.m) == 0 {
-		return false, 0, nil
-	}
-	vec := m.m[0]
-	m.m = m.m[1:]
-	return true, ts, vec
-}
-
-func (*CountDistinctSketchMatrixStepEvaluator) Close() error { return nil }
-func (*CountDistinctSketchMatrixStepEvaluator) Error() error { return nil }
-func (m *CountDistinctSketchMatrixStepEvaluator) Explain(parent Node) {
-	parent.Child("CountDistinctSketchMatrix")
+	return newSketchMatrixStepEvaluator(m, params, "CountDistinctSketchMatrix")
 }
 
 // CountDistinctSketchVectorStepEvaluator estimates one sketch vector per step.

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -315,50 +314,10 @@ func JoinQuantileSketchVector(next bool, r StepResult, stepEvaluator StepEvaluat
 
 // QuantileSketchMatrixStepEvaluator steps through a matrix of quantile sketch
 // vectors, ie t-digest or DDSketch structures per time step.
-type QuantileSketchMatrixStepEvaluator struct {
-	end, ts time.Time
-	step    time.Duration
-	m       ProbabilisticQuantileMatrix
-}
+type QuantileSketchMatrixStepEvaluator = SketchMatrixStepEvaluator[ProbabilisticQuantileVector]
 
 func NewQuantileSketchMatrixStepEvaluator(m ProbabilisticQuantileMatrix, params Params) *QuantileSketchMatrixStepEvaluator {
-	var (
-		step = params.Step()
-	)
-	return &QuantileSketchMatrixStepEvaluator{
-		end:  params.End(),
-		ts:   params.Start().Add(-step), // will be corrected on first Next() call
-		step: step,
-		m:    m,
-	}
-}
-
-func (m *QuantileSketchMatrixStepEvaluator) Next() (bool, int64, StepResult) {
-	m.ts = m.ts.Add(m.step)
-	if m.ts.After(m.end) {
-		return false, 0, nil
-	}
-
-	ts := m.ts.UnixNano() / int64(time.Millisecond)
-
-	if len(m.m) == 0 {
-		return false, 0, nil
-	}
-
-	vec := m.m[0]
-
-	// Reset for next step
-	m.m = m.m[1:]
-
-	return true, ts, vec
-}
-
-func (*QuantileSketchMatrixStepEvaluator) Close() error { return nil }
-
-func (*QuantileSketchMatrixStepEvaluator) Error() error { return nil }
-
-func (*QuantileSketchMatrixStepEvaluator) Explain(parent Node) {
-	parent.Child("QuantileSketchMatrix")
+	return newSketchMatrixStepEvaluator(m, params, "QuantileSketchMatrix")
 }
 
 // QuantileSketchVectorStepEvaluator evaluates a quantile sketch into a

--- a/pkg/logql/step_evaluator.go
+++ b/pkg/logql/step_evaluator.go
@@ -1,6 +1,8 @@
 package logql
 
 import (
+	"time"
+
 	"github.com/prometheus/prometheus/promql"
 )
 
@@ -58,4 +60,48 @@ func (EmptyEvaluator[_]) Error() error { return nil }
 // Next implements StepEvaluator.
 func (e EmptyEvaluator[_]) Next() (ok bool, ts int64, r StepResult) {
 	return false, 0, e.value
+}
+
+// SketchMatrixStepEvaluator steps through a matrix of sketch vectors, one
+// evaluation timestamp at a time. Quantile and count-distinct sketches share
+// this stepper and differ only in the vector type stored in the matrix.
+type SketchMatrixStepEvaluator[V StepResult] struct {
+	end, ts time.Time
+	step    time.Duration
+	m       []V
+	name    string
+}
+
+func newSketchMatrixStepEvaluator[V StepResult](m []V, params Params, name string) *SketchMatrixStepEvaluator[V] {
+	return &SketchMatrixStepEvaluator[V]{
+		end:  params.End(),
+		ts:   params.Start().Add(-params.Step()), // corrected on first Next()
+		step: params.Step(),
+		m:    m,
+		name: name,
+	}
+}
+
+func (m *SketchMatrixStepEvaluator[V]) Next() (bool, int64, StepResult) {
+	m.ts = m.ts.Add(m.step)
+	if m.ts.After(m.end) {
+		return false, 0, nil
+	}
+
+	ts := m.ts.UnixNano() / int64(time.Millisecond)
+	if len(m.m) == 0 {
+		return false, 0, nil
+	}
+
+	vec := m.m[0]
+	m.m = m.m[1:]
+	return true, ts, vec
+}
+
+func (*SketchMatrixStepEvaluator[_]) Close() error { return nil }
+
+func (*SketchMatrixStepEvaluator[_]) Error() error { return nil }
+
+func (m *SketchMatrixStepEvaluator[_]) Explain(parent Node) {
+	parent.Child(m.name)
 }

--- a/pkg/logql/step_evaluator_test.go
+++ b/pkg/logql/step_evaluator_test.go
@@ -1,0 +1,157 @@
+package logql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+func TestSketchMatrixStepEvaluator(t *testing.T) {
+	var (
+		start = time.Unix(0, 0)
+		end   = time.Unix(2, 0)
+		step  = time.Second
+	)
+	params := mustSketchMatrixParams(t, start, end, step)
+
+	v0 := countDistinctStepVec("0")
+	v1 := countDistinctStepVec("1")
+	v2 := countDistinctStepVec("2")
+	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{v0, v1, v2}, params)
+
+	for i, want := range []CountDistinctSketchVector{v0, v1, v2} {
+		ok, ts, r := ev.Next()
+		require.True(t, ok)
+		require.Equal(t, start.Add(step*time.Duration(i)).UnixMilli(), ts)
+		require.Equal(t, want, r.CountDistinctSketchVec())
+	}
+
+	ok, _, r := ev.Next()
+	require.False(t, ok)
+	require.Nil(t, r)
+}
+
+func TestSketchMatrixStepEvaluator_EmptyMatrix(t *testing.T) {
+	params := mustSketchMatrixParams(t, time.Unix(0, 0), time.Unix(2, 0), time.Second)
+	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{}, params)
+
+	ok, _, r := ev.Next()
+	require.False(t, ok)
+	require.Nil(t, r)
+}
+
+func TestSketchMatrixStepEvaluator_FewerVectorsThanSteps(t *testing.T) {
+	var (
+		start = time.Unix(0, 0)
+		end   = time.Unix(2, 0)
+		step  = time.Second
+	)
+	params := mustSketchMatrixParams(t, start, end, step)
+	only := countDistinctStepVec("only")
+	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{only}, params)
+
+	ok, ts, r := ev.Next()
+	require.True(t, ok)
+	require.Equal(t, start.UnixMilli(), ts)
+	require.Equal(t, only, r.CountDistinctSketchVec())
+
+	ok, _, r = ev.Next()
+	require.False(t, ok)
+	require.Nil(t, r)
+}
+
+func TestSketchMatrixStepEvaluator_StopsAtEnd(t *testing.T) {
+	start := time.Unix(0, 0)
+	params := mustSketchMatrixParams(t, start, start, time.Second)
+	first := countDistinctStepVec("first")
+	unused := countDistinctStepVec("unused")
+	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{first, unused}, params)
+
+	ok, ts, r := ev.Next()
+	require.True(t, ok)
+	require.Equal(t, start.UnixMilli(), ts)
+	require.Equal(t, first, r.CountDistinctSketchVec())
+
+	ok, _, r = ev.Next()
+	require.False(t, ok)
+	require.Nil(t, r)
+}
+
+func TestSketchMatrixStepEvaluator_QuantileAlias(t *testing.T) {
+	var (
+		start = time.Unix(0, 0)
+		end   = time.Unix(1, 0)
+		step  = time.Second
+	)
+	params := mustSketchMatrixParams(t, start, end, step)
+	v0 := ProbabilisticQuantileVector{{T: 0, Metric: labels.FromStrings("step", "0")}}
+	v1 := ProbabilisticQuantileVector{{T: 1, Metric: labels.FromStrings("step", "1")}}
+	ev := NewQuantileSketchMatrixStepEvaluator(ProbabilisticQuantileMatrix{v0, v1}, params)
+
+	ok, ts, r := ev.Next()
+	require.True(t, ok)
+	require.Equal(t, start.UnixMilli(), ts)
+	require.Equal(t, v0, r.QuantileSketchVec())
+
+	ok, ts, r = ev.Next()
+	require.True(t, ok)
+	require.Equal(t, start.Add(step).UnixMilli(), ts)
+	require.Equal(t, v1, r.QuantileSketchVec())
+
+	ok, _, r = ev.Next()
+	require.False(t, ok)
+	require.Nil(t, r)
+}
+
+func TestSketchMatrixStepEvaluator_CloseErrorExplain(t *testing.T) {
+	params := mustSketchMatrixParams(t, time.Unix(0, 0), time.Unix(0, 0), time.Second)
+
+	t.Run("count-distinct", func(t *testing.T) {
+		ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{}, params)
+		require.NoError(t, ev.Close())
+		require.NoError(t, ev.Error())
+
+		tree := NewTree()
+		ev.Explain(tree)
+		require.Equal(t, "CountDistinctSketchMatrix\n", tree.String())
+	})
+
+	t.Run("quantile", func(t *testing.T) {
+		ev := NewQuantileSketchMatrixStepEvaluator(ProbabilisticQuantileMatrix{}, params)
+		require.NoError(t, ev.Close())
+		require.NoError(t, ev.Error())
+
+		tree := NewTree()
+		ev.Explain(tree)
+		require.Equal(t, "QuantileSketchMatrix\n", tree.String())
+	})
+}
+
+func mustSketchMatrixParams(t *testing.T, start, end time.Time, step time.Duration) LiteralParams {
+	t.Helper()
+	params, err := NewLiteralParams(
+		`count_over_time({app="a"}[1m])`,
+		start,
+		end,
+		step,
+		0,
+		logproto.FORWARD,
+		1000,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	return params
+}
+
+func countDistinctStepVec(step string) CountDistinctSketchVector {
+	return CountDistinctSketchVector{{
+		F:      hyperloglog.New14(),
+		Metric: labels.FromStrings("step", step),
+	}}
+}

--- a/pkg/logql/step_evaluator_test.go
+++ b/pkg/logql/step_evaluator_test.go
@@ -4,12 +4,25 @@ import (
 	"testing"
 	"time"
 
-	"github.com/axiomhq/hyperloglog"
-	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
+
+// testSketchVec is a StepResult used only to drive SketchMatrixStepEvaluator.
+type testSketchVec struct {
+	id string
+}
+
+func (testSketchVec) SampleVector() promql.Vector                    { return nil }
+func (testSketchVec) QuantileSketchVec() ProbabilisticQuantileVector { return nil }
+func (testSketchVec) CountMinSketchVec() CountMinSketchVector        { return CountMinSketchVector{} }
+func (testSketchVec) CountDistinctSketchVec() CountDistinctSketchVector {
+	return nil
+}
+
+var _ StepResult = testSketchVec{}
 
 func TestSketchMatrixStepEvaluator(t *testing.T) {
 	var (
@@ -19,16 +32,16 @@ func TestSketchMatrixStepEvaluator(t *testing.T) {
 	)
 	params := mustSketchMatrixParams(t, start, end, step)
 
-	v0 := countDistinctStepVec("0")
-	v1 := countDistinctStepVec("1")
-	v2 := countDistinctStepVec("2")
-	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{v0, v1, v2}, params)
+	v0 := testSketchVec{id: "0"}
+	v1 := testSketchVec{id: "1"}
+	v2 := testSketchVec{id: "2"}
+	ev := newSketchMatrixStepEvaluator([]testSketchVec{v0, v1, v2}, params, "TestSketch")
 
-	for i, want := range []CountDistinctSketchVector{v0, v1, v2} {
+	for i, want := range []testSketchVec{v0, v1, v2} {
 		ok, ts, r := ev.Next()
 		require.True(t, ok)
 		require.Equal(t, start.Add(step*time.Duration(i)).UnixMilli(), ts)
-		require.Equal(t, want, r.CountDistinctSketchVec())
+		require.Equal(t, want, r)
 	}
 
 	ok, _, r := ev.Next()
@@ -38,7 +51,7 @@ func TestSketchMatrixStepEvaluator(t *testing.T) {
 
 func TestSketchMatrixStepEvaluator_EmptyMatrix(t *testing.T) {
 	params := mustSketchMatrixParams(t, time.Unix(0, 0), time.Unix(2, 0), time.Second)
-	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{}, params)
+	ev := newSketchMatrixStepEvaluator([]testSketchVec{}, params, "TestSketch")
 
 	ok, _, r := ev.Next()
 	require.False(t, ok)
@@ -52,13 +65,13 @@ func TestSketchMatrixStepEvaluator_FewerVectorsThanSteps(t *testing.T) {
 		step  = time.Second
 	)
 	params := mustSketchMatrixParams(t, start, end, step)
-	only := countDistinctStepVec("only")
-	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{only}, params)
+	only := testSketchVec{id: "only"}
+	ev := newSketchMatrixStepEvaluator([]testSketchVec{only}, params, "TestSketch")
 
 	ok, ts, r := ev.Next()
 	require.True(t, ok)
 	require.Equal(t, start.UnixMilli(), ts)
-	require.Equal(t, only, r.CountDistinctSketchVec())
+	require.Equal(t, only, r)
 
 	ok, _, r = ev.Next()
 	require.False(t, ok)
@@ -68,40 +81,14 @@ func TestSketchMatrixStepEvaluator_FewerVectorsThanSteps(t *testing.T) {
 func TestSketchMatrixStepEvaluator_StopsAtEnd(t *testing.T) {
 	start := time.Unix(0, 0)
 	params := mustSketchMatrixParams(t, start, start, time.Second)
-	first := countDistinctStepVec("first")
-	unused := countDistinctStepVec("unused")
-	ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{first, unused}, params)
+	first := testSketchVec{id: "first"}
+	unused := testSketchVec{id: "unused"}
+	ev := newSketchMatrixStepEvaluator([]testSketchVec{first, unused}, params, "TestSketch")
 
 	ok, ts, r := ev.Next()
 	require.True(t, ok)
 	require.Equal(t, start.UnixMilli(), ts)
-	require.Equal(t, first, r.CountDistinctSketchVec())
-
-	ok, _, r = ev.Next()
-	require.False(t, ok)
-	require.Nil(t, r)
-}
-
-func TestSketchMatrixStepEvaluator_QuantileAlias(t *testing.T) {
-	var (
-		start = time.Unix(0, 0)
-		end   = time.Unix(1, 0)
-		step  = time.Second
-	)
-	params := mustSketchMatrixParams(t, start, end, step)
-	v0 := ProbabilisticQuantileVector{{T: 0, Metric: labels.FromStrings("step", "0")}}
-	v1 := ProbabilisticQuantileVector{{T: 1, Metric: labels.FromStrings("step", "1")}}
-	ev := NewQuantileSketchMatrixStepEvaluator(ProbabilisticQuantileMatrix{v0, v1}, params)
-
-	ok, ts, r := ev.Next()
-	require.True(t, ok)
-	require.Equal(t, start.UnixMilli(), ts)
-	require.Equal(t, v0, r.QuantileSketchVec())
-
-	ok, ts, r = ev.Next()
-	require.True(t, ok)
-	require.Equal(t, start.Add(step).UnixMilli(), ts)
-	require.Equal(t, v1, r.QuantileSketchVec())
+	require.Equal(t, first, r)
 
 	ok, _, r = ev.Next()
 	require.False(t, ok)
@@ -110,26 +97,14 @@ func TestSketchMatrixStepEvaluator_QuantileAlias(t *testing.T) {
 
 func TestSketchMatrixStepEvaluator_CloseErrorExplain(t *testing.T) {
 	params := mustSketchMatrixParams(t, time.Unix(0, 0), time.Unix(0, 0), time.Second)
+	ev := newSketchMatrixStepEvaluator([]testSketchVec{}, params, "TestSketch")
 
-	t.Run("count-distinct", func(t *testing.T) {
-		ev := NewCountDistinctSketchMatrixStepEvaluator(CountDistinctSketchMatrix{}, params)
-		require.NoError(t, ev.Close())
-		require.NoError(t, ev.Error())
+	require.NoError(t, ev.Close())
+	require.NoError(t, ev.Error())
 
-		tree := NewTree()
-		ev.Explain(tree)
-		require.Equal(t, "CountDistinctSketchMatrix\n", tree.String())
-	})
-
-	t.Run("quantile", func(t *testing.T) {
-		ev := NewQuantileSketchMatrixStepEvaluator(ProbabilisticQuantileMatrix{}, params)
-		require.NoError(t, ev.Close())
-		require.NoError(t, ev.Error())
-
-		tree := NewTree()
-		ev.Explain(tree)
-		require.Equal(t, "QuantileSketchMatrix\n", tree.String())
-	})
+	tree := NewTree()
+	ev.Explain(tree)
+	require.Equal(t, "TestSketch\n", tree.String())
 }
 
 func mustSketchMatrixParams(t *testing.T, start, end time.Time, step time.Duration) LiteralParams {
@@ -147,11 +122,4 @@ func mustSketchMatrixParams(t *testing.T, start, end time.Time, step time.Durati
 	)
 	require.NoError(t, err)
 	return params
-}
-
-func countDistinctStepVec(step string) CountDistinctSketchVector {
-	return CountDistinctSketchVector{{
-		F:      hyperloglog.New14(),
-		Metric: labels.FromStrings("step", step),
-	}}
 }


### PR DESCRIPTION
## Summary
- Group `CountDistinctSketchVector` methods together, then `CountDistinctSketchMatrix` methods, in `approx_count_distinct.go`.
- Replace the duplicated count-distinct and quantile matrix steppers with a generic `SketchMatrixStepEvaluator`.

Follow-up to review comments on #24120 and #24196. Related: https://github.com/grafana/loki-private/issues/2769

## Test plan
- [x] `go test ./pkg/logql/ -count=1`