### PR TITLE
feat(kafka): Kafka decoders support both formats

### DIFF
--- a/pkg/ingester/kafka_consumer_test.go
+++ b/pkg/ingester/kafka_consumer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/kafka/partition"
@@ -79,6 +80,44 @@ func (nc *noopCommitter) EnqueueOffset(_ int64) {}
 func (noopCommitter) Commit(_ context.Context, _ int64) error { return nil }
 
 func TestConsumer(t *testing.T) {
+	require.Equal(t, []*logproto.PushRequest{
+		{
+			Streams: []logproto.Stream{streamBar},
+		},
+		{
+			Streams: []logproto.Stream{streamFoo},
+		},
+	}, consume(t, encodeFlat, streamBar, streamFoo))
+}
+
+// TestConsumerReadsEitherEncoding is the equivalence property at the boundary that matters:
+// what the consumer pushes must not depend on the encoding the producer chose.
+func TestConsumerReadsEitherEncoding(t *testing.T) {
+	flat := consume(t, encodeFlat, streamBar, streamFoo)
+	nested := consume(t, encodeNested, streamBar, streamFoo)
+
+	require.Equal(t, flat, nested)
+}
+
+// TestConsumerReadsMixedEncodings covers the rollout window, when records in both encodings
+// sit within retention on the same topic.
+func TestConsumerReadsMixedEncodings(t *testing.T) {
+	mixed := consume(t, func(t *testing.T, stream logproto.Stream) []*kgo.Record {
+		t.Helper()
+		if stream.Labels == streamBar.Labels {
+			return encodeFlat(t, stream)
+		}
+		return encodeNested(t, stream)
+	}, streamBar, streamFoo)
+
+	require.Equal(t, consume(t, encodeFlat, streamBar, streamFoo), mixed)
+}
+
+// consume runs the records of each stream through a consumer and returns what reached the
+// pusher. encode chooses the encoding the records are written in.
+func consume(t *testing.T, encode func(*testing.T, logproto.Stream) []*kgo.Record, streams ...logproto.Stream) []*logproto.PushRequest {
+	t.Helper()
+
 	var (
 		toPush     []partition.Record
 		offset     = int64(0)
@@ -90,28 +129,16 @@ func TestConsumer(t *testing.T) {
 	consumer, err := NewKafkaConsumerFactory(pusher, prometheus.NewRegistry(), numWorkers)(&noopCommitter{}, log.NewLogfmtLogger(os.Stdout))
 	require.NoError(t, err)
 
-	records, err := kafka.Encode(0, tenantID, streamBar, 10000)
-	require.NoError(t, err)
-
-	for _, record := range records {
-		toPush = append(toPush, partition.Record{
-			Ctx:      context.Background(),
-			TenantID: tenantID,
-			Content:  record.Value,
-			Offset:   offset,
-		})
-		offset++
-	}
-	records, err = kafka.Encode(0, tenantID, streamFoo, 10000)
-	require.NoError(t, err)
-	for _, record := range records {
-		toPush = append(toPush, partition.Record{
-			Ctx:      context.Background(),
-			TenantID: tenantID,
-			Content:  record.Value,
-			Offset:   offset,
-		})
-		offset++
+	for _, stream := range streams {
+		for _, record := range encode(t, stream) {
+			toPush = append(toPush, partition.Record{
+				Ctx:      context.Background(),
+				TenantID: tenantID,
+				Content:  record.Value,
+				Offset:   offset,
+			})
+			offset++
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -124,12 +151,20 @@ func TestConsumer(t *testing.T) {
 	cancel()
 	wait()
 
-	require.Equal(t, []*logproto.PushRequest{
-		{
-			Streams: []logproto.Stream{streamBar},
-		},
-		{
-			Streams: []logproto.Stream{streamFoo},
-		},
-	}, pusher.pushes)
+	return pusher.pushes
+}
+
+func encodeFlat(t *testing.T, stream logproto.Stream) []*kgo.Record {
+	t.Helper()
+	records, err := kafka.Encode(0, tenantID, stream, 10000)
+	require.NoError(t, err)
+	return records
+}
+
+func encodeNested(t *testing.T, stream logproto.Stream) []*kgo.Record {
+	t.Helper()
+	nested := logproto.FromStream(stream)
+	data, err := nested.Marshal()
+	require.NoError(t, err)
+	return []*kgo.Record{{Key: []byte(tenantID), Value: data}}
 }

--- a/pkg/ingester/kafka_consumer_test.go
+++ b/pkg/ingester/kafka_consumer_test.go
@@ -80,37 +80,26 @@ func (nc *noopCommitter) EnqueueOffset(_ int64) {}
 func (noopCommitter) Commit(_ context.Context, _ int64) error { return nil }
 
 func TestConsumer(t *testing.T) {
-	require.Equal(t, []*logproto.PushRequest{
+	want := []*logproto.PushRequest{
 		{
 			Streams: []logproto.Stream{streamBar},
 		},
 		{
 			Streams: []logproto.Stream{streamFoo},
 		},
-	}, consume(t, encodeFlat, streamBar, streamFoo))
-}
+	}
 
-// TestConsumerReadsEitherEncoding is the equivalence property at the boundary that matters:
-// what the consumer pushes must not depend on the encoding the producer chose.
-func TestConsumerReadsEitherEncoding(t *testing.T) {
-	flat := consume(t, encodeFlat, streamBar, streamFoo)
-	nested := consume(t, encodeNested, streamBar, streamFoo)
+	encoders := map[string]func(*testing.T, logproto.Stream) []*kgo.Record{
+		"can consume flattened data": encodeFlat,
+		"can consume nested data":    encodeNested,
+	}
 
-	require.Equal(t, flat, nested)
-}
-
-// TestConsumerReadsMixedEncodings covers the rollout window, when records in both encodings
-// sit within retention on the same topic.
-func TestConsumerReadsMixedEncodings(t *testing.T) {
-	mixed := consume(t, func(t *testing.T, stream logproto.Stream) []*kgo.Record {
-		t.Helper()
-		if stream.Labels == streamBar.Labels {
-			return encodeFlat(t, stream)
-		}
-		return encodeNested(t, stream)
-	}, streamBar, streamFoo)
-
-	require.Equal(t, consume(t, encodeFlat, streamBar, streamFoo), mixed)
+	for name, encoder := range encoders {
+		t.Run(name, func(t *testing.T) {
+			got := consume(t, encoder, streamBar, streamFoo)
+			require.Equal(t, want, got)
+		})
+	}
 }
 
 // consume runs the records of each stream through a consumer and returns what reached the

--- a/pkg/kafka/decoding_equivalence_test.go
+++ b/pkg/kafka/decoding_equivalence_test.go
@@ -1,0 +1,405 @@
+package kafka
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// TestNoDifferenceBetweenEncodingsForConsumers having sent a stream over the wire, a consumer cannot tell which of the two
+// encodings the producer chose.
+//
+// The two streams are compared after decoding rather than against the input, so that the
+// timestamp normalisation a protobuf round trip performs applies equally to both.
+func TestNoDifferenceBetweenEncodingsForConsumers(t *testing.T) {
+	const nestedEntriesPerRecord = 7
+
+	tests := []struct {
+		name       string
+		stream     logproto.Stream
+		maxSize    int
+		flatSplits bool
+	}{
+		{
+			name:    "no entries",
+			stream:  logproto.Stream{Labels: `{app="test"}`},
+			maxSize: 10 << 20,
+		},
+		{
+			name:    "no entries with a hash",
+			stream:  logproto.Stream{Labels: `{app="test"}`, Hash: 1234},
+			maxSize: 10 << 20,
+		},
+		{
+			name: "one entry",
+			stream: logproto.Stream{Labels: `{app="test"}`, Hash: 1234, Entries: []push.Entry{
+				{Timestamp: time.Unix(0, 1), Line: "only"},
+			}},
+			maxSize: 10 << 20,
+		},
+		{
+			name: "entries with structured metadata",
+			stream: logproto.Stream{Labels: `{app="test"}`, Hash: 1234, Entries: []push.Entry{
+				{Timestamp: time.Unix(0, 1), Line: "a", StructuredMetadata: push.LabelsAdapter{{Name: "trace_id", Value: "1"}}},
+				{Timestamp: time.Unix(0, 2), Line: "b", StructuredMetadata: push.LabelsAdapter{{Name: "trace_id", Value: "2"}}},
+			}},
+			maxSize: 10 << 20,
+		},
+		{
+			name:    "many entries with the flat side in one record",
+			stream:  generateStream(200, 100),
+			maxSize: 10 << 20,
+		},
+		{
+			// The flat side splits here too, at boundaries unrelated to the nested side's.
+			name:       "many entries with both sides split",
+			stream:     generateStream(200, 100),
+			maxSize:    4096,
+			flatSplits: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoder, err := NewDecoder()
+			require.NoError(t, err)
+			nestedRecs := nestedRecords(t, tt.stream, nestedEntriesPerRecord)
+			flatRecs, err := Encode(0, "test-tenant", tt.stream, tt.maxSize)
+			require.NoError(t, err)
+
+			// Asserted so that a case meant to exercise concatenation cannot quietly
+			// collapse into a single record on either side.
+			if tt.flatSplits {
+				require.Greater(t, len(flatRecs), 1)
+			} else {
+				require.Len(t, flatRecs, 1)
+			}
+			if len(tt.stream.Entries) > nestedEntriesPerRecord {
+				require.Greater(t, len(nestedRecs), 1)
+			} else {
+				require.Len(t, nestedRecs, 1)
+			}
+
+			flat := readStream(t, decoder, flatRecs)
+			nested := readStream(t, decoder, nestedRecs)
+
+			require.Equal(t, flat, nested)
+			require.Len(t, flat.Entries, len(tt.stream.Entries))
+		})
+	}
+}
+
+func TestDecodeNestedRecordYieldsFlatStream(t *testing.T) {
+	nested := logproto.InternalStreamAdapter{
+		Labels: `{app="test"}`,
+		Hash:   1234,
+		ResourceLogs: []logproto.ResourceLogs{{
+			Attrs: []push.LabelAdapter{{Name: "host", Value: "host-1"}},
+			ScopeLogs: []logproto.ScopeLogs{{
+				Attrs: []push.LabelAdapter{{Name: "scope", Value: "lib"}},
+				Entries: []push.Entry{
+					{Timestamp: time.Unix(0, 1), Line: "a", StructuredMetadata: push.LabelsAdapter{{Name: "trace_id", Value: "1"}}},
+					{Timestamp: time.Unix(0, 2), Line: "b"},
+				},
+			}},
+		}},
+	}
+
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	got, ls, err := decoder.Decode(nestedRecord(t, nested).Value)
+	require.NoError(t, err)
+
+	require.Equal(t, `{app="test"}`, ls.String())
+	require.Equal(t, uint64(1234), got.Hash)
+	require.Len(t, got.Entries, 2)
+
+	require.Equal(t, "a", got.Entries[0].Line)
+	require.Equal(t, push.LabelsAdapter{
+		{Name: "trace_id", Value: "1"},
+		{Name: "host", Value: "host-1"},
+		{Name: "scope", Value: "lib"},
+	}, got.Entries[0].StructuredMetadata)
+
+	require.Equal(t, "b", got.Entries[1].Line)
+	require.Equal(t, push.LabelsAdapter{
+		{Name: "host", Value: "host-1"},
+		{Name: "scope", Value: "lib"},
+	}, got.Entries[1].StructuredMetadata)
+}
+
+// TestDecodeInterleavedEncodings guards the reuse the Decoder does between calls: nothing
+// from a record may survive into the next one, in either direction.
+func TestDecodeInterleavedEncodings(t *testing.T) {
+	flatStream := logproto.Stream{Labels: `{app="flat"}`, Hash: 999, Entries: []push.Entry{
+		{Timestamp: time.Unix(0, 1), Line: "flat line"},
+	}}
+	nestedStream := logproto.InternalStreamAdapter{
+		Labels: `{app="nested"}`,
+		ResourceLogs: []logproto.ResourceLogs{{
+			Attrs: []push.LabelAdapter{{Name: "host", Value: "host-1"}},
+			ScopeLogs: []logproto.ScopeLogs{{
+				Entries: []push.Entry{{Timestamp: time.Unix(0, 2), Line: "nested line"}},
+			}},
+		}},
+	}
+
+	flatRecords, err := Encode(0, "test-tenant", flatStream, 10<<20)
+	require.NoError(t, err)
+	nestedValue := nestedRecord(t, nestedStream).Value
+
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	// Twice through, so that each encoding is decoded both first and after the other.
+	for range 2 {
+		got, ls, err := decoder.Decode(flatRecords[0].Value)
+		require.NoError(t, err)
+		require.Equal(t, `{app="flat"}`, ls.String())
+		require.Equal(t, uint64(999), got.Hash)
+		require.Len(t, got.Entries, 1)
+		require.Equal(t, "flat line", got.Entries[0].Line)
+		require.Empty(t, got.Entries[0].StructuredMetadata)
+
+		got, ls, err = decoder.Decode(nestedValue)
+		require.NoError(t, err)
+		require.Equal(t, `{app="nested"}`, ls.String())
+		require.Zero(t, got.Hash, "hash of the previous record leaked into this one")
+		require.Len(t, got.Entries, 1)
+		require.Equal(t, "nested line", got.Entries[0].Line)
+		require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-1"}}, got.Entries[0].StructuredMetadata)
+	}
+}
+
+func TestDecodeRejectsDataInNeitherEncoding(t *testing.T) {
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	_, err = decoder.DecodeWithoutLabels([]byte("invalid data"))
+	require.ErrorContains(t, err, "nested:")
+	require.ErrorContains(t, err, "flat:")
+
+	_, _, err = decoder.Decode([]byte("invalid data"))
+	require.Error(t, err)
+}
+
+// TestDecodeReportsBothFailuresForATruncatedNestedRecord covers the case the combined error
+// exists for: the record was written in the nested encoding, so the flat failure alone would
+// describe a wire format it was never in.
+func TestDecodeReportsBothFailuresForATruncatedNestedRecord(t *testing.T) {
+	nested := logproto.InternalStreamAdapter{
+		Labels: `{app="test"}`,
+		ResourceLogs: []logproto.ResourceLogs{{
+			Attrs: []push.LabelAdapter{{Name: "host", Value: "host-1"}},
+			ScopeLogs: []logproto.ScopeLogs{{
+				Entries: []push.Entry{{Timestamp: time.Unix(0, 1), Line: "a line long enough to cut"}},
+			}},
+		}},
+	}
+
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	value := nestedRecord(t, nested).Value
+	truncated := value[:len(value)-8]
+	_, err = decoder.DecodeWithoutLabels(truncated)
+	require.ErrorContains(t, err, "unexpected EOF", "the nested failure is the one that explains the record")
+}
+
+// decodeFlatOnly is DecodeWithoutLabels as it stood before this change: unmarshal as a flat
+// stream, with no second encoding to fall back to.
+//
+// It exists only so BenchmarkDecode can price the fallback against what it replaced. A record
+// in the nested encoding fails here, which is the rollout invariant asserted by
+// TestEncodingsAreMutuallyUndecodable.
+func decodeFlatOnly(data []byte) (logproto.Stream, error) {
+	stream := logproto.Stream{}
+	if err := stream.Unmarshal(data); err != nil {
+		return logproto.Stream{}, fmt.Errorf("failed to unmarshal stream: %w", err)
+	}
+	return stream, nil
+}
+
+// BenchmarkDecode prices the change: what a record in the old flat encoding cost to decode
+// before the fallback existed, what the same record costs now that the nested message is
+// attempted first, and what a record in the new nested encoding costs.
+//
+// Both record shapes are measured because the failed attempt is a cost per record, not per
+// entry: it is plain on a record holding one entry and invisible on one holding a thousand.
+func BenchmarkDecode(b *testing.B) {
+	shapes := []struct {
+		name    string
+		entries int
+	}{
+		{"1 entry per record", 1},
+		{"1000 entries per record", 1000},
+	}
+
+	for _, shape := range shapes {
+		stream := generateStream(shape.entries, 200)
+
+		flatRecords, err := Encode(0, "test-tenant", stream, 10<<20)
+		require.NoError(b, err)
+		require.Len(b, flatRecords, 1)
+
+		// The shape the new encoding takes for traffic that arrived over the native push API:
+		// nested, but with nothing lifted out of the entries.
+		nested := logproto.FromStream(stream)
+
+		// The shape it takes for OTLP traffic, where lifting the attributes out is the point.
+		// Expanding them back is the work the new encoding adds to a decode.
+		shared := logproto.FromStream(stream)
+		shared.ResourceLogs[0].Attrs = []push.LabelAdapter{
+			{Name: "host", Value: "host-1"},
+			{Name: "cluster", Value: "prod-eu-west-2"},
+			{Name: "namespace", Value: "loki-prod-029"},
+		}
+
+		// The same OTLP data as shared, in the encoding it uses today: every entry carrying
+		// its own copy of the three attributes. This is the comparator that says what the
+		// nesting buys, which the wire_bytes of shared alone does not show.
+		expandedRecords, err := Encode(0, "test-tenant", shared.ToStream(), 10<<20)
+		require.NoError(b, err)
+		require.Len(b, expandedRecords, 1)
+
+		// Two groups of three, one per kind of traffic. Within a group the first pair
+		// isolates the code change with the format held fixed, and the second pair the
+		// format change with the code held fixed. The fourth combination, a nested record
+		// read by the prior code, is absent because it does not decode at all: that is the
+		// rollout invariant, and it belongs in a test rather than a benchmark.
+		cases := []struct {
+			name      string
+			data      []byte
+			priorCode bool
+		}{
+			{name: "old format + old code", data: flatRecords[0].Value, priorCode: true},
+			{name: "old format + new code", data: flatRecords[0].Value},
+			{name: "new format + new code", data: nestedRecord(b, nested).Value},
+
+			{name: "old format with attrs expanded + old code", data: expandedRecords[0].Value, priorCode: true},
+			{name: "old format with attrs expanded + new code", data: expandedRecords[0].Value},
+			{name: "new format with attrs shared + new code", data: nestedRecord(b, shared).Value},
+		}
+
+		for _, tc := range cases {
+			b.Run(shape.name+"/"+tc.name, func(b *testing.B) {
+				decoder, err := NewDecoder()
+				require.NoError(b, err)
+
+				for b.Loop() {
+					var err error
+					if tc.priorCode {
+						_, err = decodeFlatOnly(tc.data)
+					} else {
+						_, err = decoder.DecodeWithoutLabels(tc.data)
+					}
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				// Reported after the loop: b.Loop clears custom metrics on its first
+				// iteration, so a value reported before it never reaches the output.
+				b.ReportMetric(float64(len(tc.data)), "wire_bytes")
+			})
+		}
+	}
+}
+
+// TestDecodeWithoutLabelsIsSafeForConcurrentUse pins the property the ingester's consumer
+// relies on: it decodes records from several goroutines sharing one Decoder.
+func TestDecodeWithoutLabelsIsSafeForConcurrentUse(t *testing.T) {
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	var values [][]byte
+	for i := range 8 {
+		stream := logproto.Stream{
+			Labels:  fmt.Sprintf(`{app="test-%d"}`, i),
+			Hash:    uint64(i),
+			Entries: []push.Entry{{Timestamp: time.Unix(0, int64(i+1)), Line: fmt.Sprintf("line-%d", i)}},
+		}
+
+		flat, err := Encode(0, "test-tenant", stream, 10<<20)
+		require.NoError(t, err)
+		values = append(values, flat[0].Value, nestedRecord(t, logproto.FromStream(stream)).Value)
+	}
+
+	done := make(chan struct{})
+	for _, value := range values {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for range 50 {
+				if _, err := decoder.DecodeWithoutLabels(value); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	for range values {
+		<-done
+	}
+}
+
+// nestedRecord marshals a stream in the nested encoding into one record.
+//
+// The tests put nested records on the wire themselves rather than through a producer: the
+// decoder is what is under test, and deciding record boundaries from a size limit is the
+// producer's concern.
+func nestedRecord(t testing.TB, stream logproto.InternalStreamAdapter) *kgo.Record {
+	t.Helper()
+	data, err := stream.Marshal()
+	require.NoError(t, err)
+	return &kgo.Record{Key: []byte("test-tenant"), Value: data}
+}
+
+// nestedRecords writes stream in the nested encoding, starting a new record every
+// entriesPerRecord entries. A stream with no entries still yields one record, as the flat
+// encoder produces for the same input.
+func nestedRecords(t testing.TB, stream logproto.Stream, entriesPerRecord int) []*kgo.Record {
+	t.Helper()
+
+	var records []*kgo.Record
+	for start := 0; ; start += entriesPerRecord {
+		end := min(start+entriesPerRecord, len(stream.Entries))
+		records = append(records, nestedRecord(t, logproto.FromStream(logproto.Stream{
+			Labels:  stream.Labels,
+			Hash:    stream.Hash,
+			Entries: stream.Entries[start:end],
+		})))
+		if end >= len(stream.Entries) {
+			return records
+		}
+	}
+}
+
+// readStream is what a consumer sees: every record of a stream decoded and its entries
+// concatenated. Record boundaries are deliberately not part of the result, because the two
+// encoders split at different points and a consumer does not care where.
+func readStream(t *testing.T, decoder *Decoder, records []*kgo.Record) logproto.Stream {
+	t.Helper()
+	require.NotEmpty(t, records)
+
+	var out logproto.Stream
+	for i, rec := range records {
+		got, err := decoder.DecodeWithoutLabels(rec.Value)
+		require.NoError(t, err)
+
+		if i == 0 {
+			out.Labels, out.Hash = got.Labels, got.Hash
+		} else {
+			require.Equal(t, out.Labels, got.Labels, "every record of a stream must carry the same labels")
+			require.Equal(t, out.Hash, got.Hash, "every record of a stream must carry the same hash")
+		}
+		out.Entries = append(out.Entries, got.Entries...)
+	}
+	return out
+}

--- a/pkg/kafka/decoding_equivalence_test.go
+++ b/pkg/kafka/decoding_equivalence_test.go
@@ -179,6 +179,37 @@ func TestDecodeInterleavedEncodings(t *testing.T) {
 	}
 }
 
+// TestDecodeEmptiesEntriesOfAReusedStream covers the shape TestDecodeInterleavedEncodings
+// cannot: both of its records hold one entry, so entries surviving from the previous record
+// would not show. A record with no entries after one with several is where they would.
+func TestDecodeEmptiesEntriesOfAReusedStream(t *testing.T) {
+	full, err := Encode(0, "test-tenant", logproto.Stream{Labels: `{app="full"}`, Entries: []push.Entry{
+		{Timestamp: time.Unix(0, 1), Line: "a"},
+		{Timestamp: time.Unix(0, 2), Line: "b"},
+		{Timestamp: time.Unix(0, 3), Line: "c"},
+	}}, 10<<20)
+	require.NoError(t, err)
+
+	// A group carrying no entries, rather than labels alone, so the record is unambiguously
+	// in the nested encoding.
+	empty := nestedRecord(t, logproto.InternalStreamAdapter{
+		Labels:       `{app="empty"}`,
+		ResourceLogs: []logproto.ResourceLogs{{ScopeLogs: []logproto.ScopeLogs{{}}}},
+	}).Value
+
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	got, _, err := decoder.Decode(full[0].Value)
+	require.NoError(t, err)
+	require.Len(t, got.Entries, 3)
+
+	got, _, err = decoder.Decode(empty)
+	require.NoError(t, err)
+	require.Equal(t, `{app="empty"}`, got.Labels)
+	require.Empty(t, got.Entries, "entries of the previous record leaked into this one")
+}
+
 func TestDecodeRejectsDataInNeitherEncoding(t *testing.T) {
 	decoder, err := NewDecoder()
 	require.NoError(t, err)
@@ -266,7 +297,9 @@ func BenchmarkDecode(b *testing.B) {
 		// The same OTLP data as shared, in the encoding it uses today: every entry carrying
 		// its own copy of the three attributes. This is the comparator that says what the
 		// nesting buys, which the wire_bytes of shared alone does not show.
-		expandedRecords, err := Encode(0, "test-tenant", shared.ToStream(), 10<<20)
+		var expanded logproto.Stream
+		shared.ToStream(&expanded)
+		expandedRecords, err := Encode(0, "test-tenant", expanded, 10<<20)
 		require.NoError(b, err)
 		require.Len(b, expandedRecords, 1)
 
@@ -293,6 +326,10 @@ func BenchmarkDecode(b *testing.B) {
 			b.Run(shape.name+"/"+tc.name, func(b *testing.B) {
 				decoder, err := NewDecoder()
 				require.NoError(b, err)
+
+				// The fallback's cost is an allocation count per record, so report it without
+				// waiting for -benchmem.
+				b.ReportAllocs()
 
 				for b.Loop() {
 					var err error

--- a/pkg/kafka/decoding_equivalence_test.go
+++ b/pkg/kafka/decoding_equivalence_test.go
@@ -96,6 +96,9 @@ func TestNoDifferenceBetweenEncodingsForConsumers(t *testing.T) {
 	}
 }
 
+// TestDecodeNestedRecordYieldsFlatStream is the end to end shape of a nested record read by a
+// consumer. The resource and scope attributes are here so that resolving them runs as part of a
+// decode; what they resolve to is TestToStream's business.
 func TestDecodeNestedRecordYieldsFlatStream(t *testing.T) {
 	nested := logproto.InternalStreamAdapter{
 		Labels: `{app="test"}`,
@@ -121,28 +124,27 @@ func TestDecodeNestedRecordYieldsFlatStream(t *testing.T) {
 	require.Equal(t, `{app="test"}`, ls.String())
 	require.Equal(t, uint64(1234), got.Hash)
 	require.Len(t, got.Entries, 2)
-
 	require.Equal(t, "a", got.Entries[0].Line)
-	require.Equal(t, push.LabelsAdapter{
-		{Name: "trace_id", Value: "1"},
-		{Name: "host", Value: "host-1"},
-		{Name: "scope", Value: "lib"},
-	}, got.Entries[0].StructuredMetadata)
-
 	require.Equal(t, "b", got.Entries[1].Line)
-	require.Equal(t, push.LabelsAdapter{
-		{Name: "host", Value: "host-1"},
-		{Name: "scope", Value: "lib"},
-	}, got.Entries[1].StructuredMetadata)
 }
 
-// TestDecodeInterleavedEncodings guards the reuse the Decoder does between calls: nothing
-// from a record may survive into the next one, in either direction.
+// TestDecodeInterleavedEncodings guards the reuse the Decoder does between calls: nothing from a
+// record may survive into the next one, in either direction. The records differ in entry count as
+// well as in encoding, because entries left over from a longer record only show on a shorter one.
 func TestDecodeInterleavedEncodings(t *testing.T) {
-	flatStream := logproto.Stream{Labels: `{app="flat"}`, Hash: 999, Entries: []push.Entry{
+	oneFlat, err := Encode(0, "test-tenant", logproto.Stream{Labels: `{app="flat"}`, Hash: 999, Entries: []push.Entry{
 		{Timestamp: time.Unix(0, 1), Line: "flat line"},
-	}}
-	nestedStream := logproto.InternalStreamAdapter{
+	}}, 10<<20)
+	require.NoError(t, err)
+
+	threeFlat, err := Encode(0, "test-tenant", logproto.Stream{Labels: `{app="three"}`, Entries: []push.Entry{
+		{Timestamp: time.Unix(0, 1), Line: "a"},
+		{Timestamp: time.Unix(0, 2), Line: "b"},
+		{Timestamp: time.Unix(0, 3), Line: "c"},
+	}}, 10<<20)
+	require.NoError(t, err)
+
+	oneNested := nestedRecord(t, logproto.InternalStreamAdapter{
 		Labels: `{app="nested"}`,
 		ResourceLogs: []logproto.ResourceLogs{{
 			Attrs: []push.LabelAdapter{{Name: "host", Value: "host-1"}},
@@ -150,49 +152,11 @@ func TestDecodeInterleavedEncodings(t *testing.T) {
 				Entries: []push.Entry{{Timestamp: time.Unix(0, 2), Line: "nested line"}},
 			}},
 		}},
-	}
+	}).Value
 
-	flatRecords, err := Encode(0, "test-tenant", flatStream, 10<<20)
-	require.NoError(t, err)
-	nestedValue := nestedRecord(t, nestedStream).Value
-
-	decoder, err := NewDecoder()
-	require.NoError(t, err)
-
-	// Twice through, so that each encoding is decoded both first and after the other.
-	for range 2 {
-		got, ls, err := decoder.Decode(flatRecords[0].Value)
-		require.NoError(t, err)
-		require.Equal(t, `{app="flat"}`, ls.String())
-		require.Equal(t, uint64(999), got.Hash)
-		require.Len(t, got.Entries, 1)
-		require.Equal(t, "flat line", got.Entries[0].Line)
-		require.Empty(t, got.Entries[0].StructuredMetadata)
-
-		got, ls, err = decoder.Decode(nestedValue)
-		require.NoError(t, err)
-		require.Equal(t, `{app="nested"}`, ls.String())
-		require.Zero(t, got.Hash, "hash of the previous record leaked into this one")
-		require.Len(t, got.Entries, 1)
-		require.Equal(t, "nested line", got.Entries[0].Line)
-		require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-1"}}, got.Entries[0].StructuredMetadata)
-	}
-}
-
-// TestDecodeEmptiesEntriesOfAReusedStream covers the shape TestDecodeInterleavedEncodings
-// cannot: both of its records hold one entry, so entries surviving from the previous record
-// would not show. A record with no entries after one with several is where they would.
-func TestDecodeEmptiesEntriesOfAReusedStream(t *testing.T) {
-	full, err := Encode(0, "test-tenant", logproto.Stream{Labels: `{app="full"}`, Entries: []push.Entry{
-		{Timestamp: time.Unix(0, 1), Line: "a"},
-		{Timestamp: time.Unix(0, 2), Line: "b"},
-		{Timestamp: time.Unix(0, 3), Line: "c"},
-	}}, 10<<20)
-	require.NoError(t, err)
-
-	// A group carrying no entries, rather than labels alone, so the record is unambiguously
-	// in the nested encoding.
-	empty := nestedRecord(t, logproto.InternalStreamAdapter{
+	// A group carrying no entries, rather than labels alone, so the record is unambiguously in
+	// the nested encoding.
+	emptyNested := nestedRecord(t, logproto.InternalStreamAdapter{
 		Labels:       `{app="empty"}`,
 		ResourceLogs: []logproto.ResourceLogs{{ScopeLogs: []logproto.ScopeLogs{{}}}},
 	}).Value
@@ -200,14 +164,34 @@ func TestDecodeEmptiesEntriesOfAReusedStream(t *testing.T) {
 	decoder, err := NewDecoder()
 	require.NoError(t, err)
 
-	got, _, err := decoder.Decode(full[0].Value)
-	require.NoError(t, err)
-	require.Len(t, got.Entries, 3)
+	// Twice through, so every record is decoded both first and after each of the others.
+	for range 2 {
+		got, ls, err := decoder.Decode(oneFlat[0].Value)
+		require.NoError(t, err)
+		require.Equal(t, `{app="flat"}`, ls.String())
+		require.Equal(t, uint64(999), got.Hash)
+		require.Len(t, got.Entries, 1)
+		require.Equal(t, "flat line", got.Entries[0].Line)
+		require.Empty(t, got.Entries[0].StructuredMetadata)
 
-	got, _, err = decoder.Decode(empty)
-	require.NoError(t, err)
-	require.Equal(t, `{app="empty"}`, got.Labels)
-	require.Empty(t, got.Entries, "entries of the previous record leaked into this one")
+		got, ls, err = decoder.Decode(oneNested)
+		require.NoError(t, err)
+		require.Equal(t, `{app="nested"}`, ls.String())
+		require.Zero(t, got.Hash, "hash of the previous record leaked into this one")
+		require.Len(t, got.Entries, 1)
+		require.Equal(t, "nested line", got.Entries[0].Line)
+		require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-1"}}, got.Entries[0].StructuredMetadata)
+
+		got, ls, err = decoder.Decode(threeFlat[0].Value)
+		require.NoError(t, err)
+		require.Equal(t, `{app="three"}`, ls.String())
+		require.Len(t, got.Entries, 3)
+
+		got, ls, err = decoder.Decode(emptyNested)
+		require.NoError(t, err)
+		require.Equal(t, `{app="empty"}`, ls.String())
+		require.Empty(t, got.Entries, "entries of the previous record leaked into this one")
+	}
 }
 
 func TestDecodeRejectsDataInNeitherEncoding(t *testing.T) {
@@ -217,32 +201,6 @@ func TestDecodeRejectsDataInNeitherEncoding(t *testing.T) {
 	_, err = decoder.DecodeWithoutLabels([]byte("invalid data"))
 	require.ErrorContains(t, err, "nested:")
 	require.ErrorContains(t, err, "flat:")
-
-	_, _, err = decoder.Decode([]byte("invalid data"))
-	require.Error(t, err)
-}
-
-// TestDecodeReportsBothFailuresForATruncatedNestedRecord covers the case the combined error
-// exists for: the record was written in the nested encoding, so the flat failure alone would
-// describe a wire format it was never in.
-func TestDecodeReportsBothFailuresForATruncatedNestedRecord(t *testing.T) {
-	nested := logproto.InternalStreamAdapter{
-		Labels: `{app="test"}`,
-		ResourceLogs: []logproto.ResourceLogs{{
-			Attrs: []push.LabelAdapter{{Name: "host", Value: "host-1"}},
-			ScopeLogs: []logproto.ScopeLogs{{
-				Entries: []push.Entry{{Timestamp: time.Unix(0, 1), Line: "a line long enough to cut"}},
-			}},
-		}},
-	}
-
-	decoder, err := NewDecoder()
-	require.NoError(t, err)
-
-	value := nestedRecord(t, nested).Value
-	truncated := value[:len(value)-8]
-	_, err = decoder.DecodeWithoutLabels(truncated)
-	require.ErrorContains(t, err, "unexpected EOF", "the nested failure is the one that explains the record")
 }
 
 // decodeFlatOnly is DecodeWithoutLabels as it stood before this change: unmarshal as a flat

--- a/pkg/kafka/encoding.go
+++ b/pkg/kafka/encoding.go
@@ -150,16 +150,12 @@ func NewDecoder() (*Decoder, error) {
 
 // Decode converts a Kafka record's byte data back into a logproto.Stream and labels.Labels.
 // The decoding process works as follows:
-// 1. Unmarshal the data into a logproto.Stream.
+// 1. Unmarshal the data into a logproto.Stream, in either encoding the record may carry.
 // 2. Parse and cache the labels for efficiency in future decodes.
 //
 // Returns the decoded logproto.Stream, parsed labels, and any error encountered.
 func (d *Decoder) Decode(data []byte) (logproto.Stream, labels.Labels, error) {
-	d.stream.Labels = ""
-	d.stream.Hash = 0
-	d.stream.Entries = d.stream.Entries[:0]
-
-	if err := d.stream.Unmarshal(data); err != nil {
+	if err := decodeStream(data, d.stream); err != nil {
 		return logproto.Stream{}, labels.EmptyLabels(), fmt.Errorf("failed to unmarshal stream: %w", err)
 	}
 
@@ -185,11 +181,33 @@ func (d *Decoder) DecodeWithoutLabels(data []byte) (logproto.Stream, error) {
 	}
 
 	stream := logproto.Stream{}
-	if err := stream.Unmarshal(data); err != nil {
+	if err := decodeStream(data, &stream); err != nil {
 		return logproto.Stream{}, fmt.Errorf("failed to unmarshal stream: %w", err)
 	}
 
 	return stream, nil
+}
+
+func decodeStream(data []byte, into *logproto.Stream) error {
+	var nested logproto.InternalStreamAdapter
+	nestedErr := nested.Unmarshal(data)
+	if nestedErr == nil {
+		// no need to zero [*into] because ToStream overrides all the values
+		*into = nested.ToStream()
+		return nil
+	}
+
+	// - unmarshaling doesn't zero the values
+	// - [into] could be reused between the calls
+	// => zero the values, keep the into.Entries capacity though
+	into.Labels = ""
+	into.Hash = 0
+	into.Entries = into.Entries[:0]
+
+	if flatErr := into.Unmarshal(data); flatErr != nil {
+		return fmt.Errorf("not a valid record in either encoding: nested: %w; flat: %w", nestedErr, flatErr)
+	}
+	return nil
 }
 
 // sovPush calculates the size of varint-encoded uint64.

--- a/pkg/kafka/encoding.go
+++ b/pkg/kafka/encoding.go
@@ -156,7 +156,7 @@ func NewDecoder() (*Decoder, error) {
 // Returns the decoded logproto.Stream, parsed labels, and any error encountered.
 func (d *Decoder) Decode(data []byte) (logproto.Stream, labels.Labels, error) {
 	if err := decodeStream(data, d.stream); err != nil {
-		return logproto.Stream{}, labels.EmptyLabels(), fmt.Errorf("failed to unmarshal stream: %w", err)
+		return logproto.Stream{}, labels.EmptyLabels(), err
 	}
 
 	var ls labels.Labels
@@ -182,30 +182,30 @@ func (d *Decoder) DecodeWithoutLabels(data []byte) (logproto.Stream, error) {
 
 	stream := logproto.Stream{}
 	if err := decodeStream(data, &stream); err != nil {
-		return logproto.Stream{}, fmt.Errorf("failed to unmarshal stream: %w", err)
+		return logproto.Stream{}, err
 	}
 
 	return stream, nil
 }
 
+// decodeStream unmarshals a record into `into`, in whichever of the two encodings it carries.
 func decodeStream(data []byte, into *logproto.Stream) error {
 	var nested logproto.InternalStreamAdapter
 	nestedErr := nested.Unmarshal(data)
 	if nestedErr == nil {
-		// no need to zero [*into] because ToStream overrides all the values
-		*into = nested.ToStream()
+		nested.ToStream(into)
 		return nil
 	}
 
-	// - unmarshaling doesn't zero the values
-	// - [into] could be reused between the calls
-	// => zero the values, keep the into.Entries capacity though
+	// Unmarshal leaves fields absent from the wire untouched and `into` may be reused between
+	// calls, so reset it here rather than leaving either path to overwrite everything. The
+	// Entries capacity is kept.
 	into.Labels = ""
 	into.Hash = 0
 	into.Entries = into.Entries[:0]
 
 	if flatErr := into.Unmarshal(data); flatErr != nil {
-		return fmt.Errorf("not a valid record in either encoding: nested: %w; flat: %w", nestedErr, flatErr)
+		return fmt.Errorf("failed to unmarshal stream in either encoding: nested: %w; flat: %w", nestedErr, flatErr)
 	}
 	return nil
 }

--- a/pkg/kafka/encoding_test.go
+++ b/pkg/kafka/encoding_test.go
@@ -163,7 +163,7 @@ func generateStream(entries, lineLength int) logproto.Stream {
 		Entries: make([]logproto.Entry, entries),
 	}
 
-	for i := 0; i < entries; i++ {
+	for i := range entries {
 		stream.Entries[i] = logproto.Entry{
 			Timestamp: time.Now(),
 			Line:      generateRandomString(lineLength),

--- a/pkg/logproto/internal_push.go
+++ b/pkg/logproto/internal_push.go
@@ -1,0 +1,92 @@
+package logproto
+
+import (
+	"github.com/grafana/loki/pkg/push"
+)
+
+// This file holds the hand-written companions to the generated internal push types: the rules
+// that must not be restated at each call site, because restating them is how a site comes to
+// forget that a resource or a scope attribute applies to an entry.
+
+// EntryCount is the number of entries the stream holds, across every group and scope.
+func (s *InternalStreamAdapter) EntryCount() int {
+	n := 0
+	for i := range s.ResourceLogs {
+		for j := range s.ResourceLogs[i].ScopeLogs {
+			n += len(s.ResourceLogs[i].ScopeLogs[j].Entries)
+		}
+	}
+	return n
+}
+
+// AppendEffectiveMetadata appends everything that applies to an entry — its own pairs, then
+// its resource's, then its scope's — to dst and returns the result.
+//
+// Reading only an entry's own StructuredMetadata silently misses attributes that arrived on
+// the resource or the scope, which is the mistake this exists to prevent.
+//
+// The order, and the duplicate a repeated name leaves behind, are exactly what the OTLP parse
+// site produces when it expands attributes onto entries itself. Reproducing it is what makes
+// a nested record and its flat equivalent store identical bytes.
+func AppendEffectiveMetadata(dst, resAttrs, scopeAttrs []push.LabelAdapter, e *push.Entry) []push.LabelAdapter {
+	dst = append(dst, e.StructuredMetadata...)
+	dst = append(dst, resAttrs...)
+	return append(dst, scopeAttrs...)
+}
+
+// FromStream wraps a flat stream as an internal one, in a single group and scope with no
+// shared attributes.
+//
+// This is the native push path: a logproto.Stream carries every attribute on every entry
+// already, so there is nothing to lift out. It costs one group and one scope header per
+// stream and no per-entry work, because the entries slice is taken as it is.
+func FromStream(s Stream) InternalStreamAdapter {
+	return InternalStreamAdapter{
+		Labels: s.Labels,
+		Hash:   s.Hash,
+		ResourceLogs: []ResourceLogs{{
+			ScopeLogs: []ScopeLogs{{Entries: s.Entries}},
+		}},
+	}
+}
+
+// ToStream flattens the internal stream back into the wire format Loki has always used,
+// resolving each entry's effective metadata onto it.
+//
+// It is the expensive direction: every entry beneath a resource or scope that carries
+// attributes gets a fresh metadata slice.
+func (s *InternalStreamAdapter) ToStream() Stream {
+	out := Stream{
+		Labels: s.Labels,
+		Hash:   s.Hash,
+	}
+
+	count := s.EntryCount()
+	if count == 0 {
+		// Left nil rather than an empty slice, because the flat form unmarshals to nil when
+		// it carries no entries and the two must be indistinguishable.
+		return out
+	}
+	out.Entries = make([]push.Entry, 0, count)
+
+	for i := range s.ResourceLogs {
+		res := &s.ResourceLogs[i]
+		for j := range res.ScopeLogs {
+			scope := &res.ScopeLogs[j]
+
+			nothingLifted := len(res.Attrs) == 0 && len(scope.Attrs) == 0
+			if nothingLifted {
+				out.Entries = append(out.Entries, scope.Entries...)
+				continue
+			}
+
+			for k := range scope.Entries {
+				e := scope.Entries[k]
+				md := make([]push.LabelAdapter, 0, len(e.StructuredMetadata)+len(res.Attrs)+len(scope.Attrs))
+				e.StructuredMetadata = AppendEffectiveMetadata(md, res.Attrs, scope.Attrs, &scope.Entries[k])
+				out.Entries = append(out.Entries, e)
+			}
+		}
+	}
+	return out
+}

--- a/pkg/logproto/internal_push.go
+++ b/pkg/logproto/internal_push.go
@@ -1,6 +1,8 @@
 package logproto
 
 import (
+	"slices"
+
 	"github.com/grafana/loki/pkg/push"
 )
 
@@ -8,8 +10,8 @@ import (
 // that must not be restated at each call site, because restating them is how a site comes to
 // forget that a resource or a scope attribute applies to an entry.
 
-// EntryCount is the number of entries the stream holds, across every group and scope.
-func (s *InternalStreamAdapter) EntryCount() int {
+// entryCount is the number of entries the stream holds, across every group and scope.
+func (s *InternalStreamAdapter) entryCount() int {
 	n := 0
 	for i := range s.ResourceLogs {
 		for j := range s.ResourceLogs[i].ScopeLogs {
@@ -17,21 +19,6 @@ func (s *InternalStreamAdapter) EntryCount() int {
 		}
 	}
 	return n
-}
-
-// AppendEffectiveMetadata appends everything that applies to an entry — its own pairs, then
-// its resource's, then its scope's — to dst and returns the result.
-//
-// Reading only an entry's own StructuredMetadata silently misses attributes that arrived on
-// the resource or the scope, which is the mistake this exists to prevent.
-//
-// The order, and the duplicate a repeated name leaves behind, are exactly what the OTLP parse
-// site produces when it expands attributes onto entries itself. Reproducing it is what makes
-// a nested record and its flat equivalent store identical bytes.
-func AppendEffectiveMetadata(dst, resAttrs, scopeAttrs []push.LabelAdapter, e *push.Entry) []push.LabelAdapter {
-	dst = append(dst, e.StructuredMetadata...)
-	dst = append(dst, resAttrs...)
-	return append(dst, scopeAttrs...)
 }
 
 // FromStream wraps a flat stream as an internal one, in a single group and scope with no
@@ -50,24 +37,20 @@ func FromStream(s Stream) InternalStreamAdapter {
 	}
 }
 
-// ToStream flattens the internal stream back into the wire format Loki has always used,
+// ToStream flattens the internal stream into out, in the wire format Loki has always used,
 // resolving each entry's effective metadata onto it.
 //
 // It is the expensive direction: every entry beneath a resource or scope that carries
 // attributes gets a fresh metadata slice.
-func (s *InternalStreamAdapter) ToStream() Stream {
-	out := Stream{
-		Labels: s.Labels,
-		Hash:   s.Hash,
-	}
-
-	count := s.EntryCount()
+func (s *InternalStreamAdapter) ToStream(out *Stream) {
+	out.Labels = s.Labels
+	out.Hash = s.Hash
+	out.Entries = out.Entries[:0]
+	count := s.entryCount()
 	if count == 0 {
-		// Left nil rather than an empty slice, because the flat form unmarshals to nil when
-		// it carries no entries and the two must be indistinguishable.
-		return out
+		return
 	}
-	out.Entries = make([]push.Entry, 0, count)
+	out.Entries = slices.Grow(out.Entries, count)
 
 	for i := range s.ResourceLogs {
 		res := &s.ResourceLogs[i]
@@ -82,11 +65,15 @@ func (s *InternalStreamAdapter) ToStream() Stream {
 
 			for k := range scope.Entries {
 				e := scope.Entries[k]
+
 				md := make([]push.LabelAdapter, 0, len(e.StructuredMetadata)+len(res.Attrs)+len(scope.Attrs))
-				e.StructuredMetadata = AppendEffectiveMetadata(md, res.Attrs, scope.Attrs, &scope.Entries[k])
+				md = append(md, e.StructuredMetadata...)
+				md = append(md, res.Attrs...)
+				md = append(md, scope.Attrs...)
+
+				e.StructuredMetadata = md
 				out.Entries = append(out.Entries, e)
 			}
 		}
 	}
-	return out
 }

--- a/pkg/logproto/internal_push.go
+++ b/pkg/logproto/internal_push.go
@@ -37,11 +37,14 @@ func FromStream(s Stream) InternalStreamAdapter {
 	}
 }
 
-// ToStream flattens the internal stream into out, in the wire format Loki has always used,
-// resolving each entry's effective metadata onto it.
+// ToStream expands nested OTLP-like InternalStreamAdapter structure to logproto.Stream.
+// It copies structured metadata from the top levels to each logproto.Entry. If an attribute
+// is duplicated (e.g., exists in resource, scope, and entry) then the precedence is
+// entry >> scope >> resource.
 //
-// It is the expensive direction: every entry beneath a resource or scope that carries
-// attributes gets a fresh metadata slice.
+// out is reused: its entries slice is truncated and refilled, so an older result is not a
+// snapshot. Copy it if you need to keep one. Entries with no attributes to resolve are copied as
+// they are, so their structured metadata is shared with s and must not be written to.
 func (s *InternalStreamAdapter) ToStream(out *Stream) {
 	out.Labels = s.Labels
 	out.Hash = s.Hash
@@ -52,28 +55,51 @@ func (s *InternalStreamAdapter) ToStream(out *Stream) {
 	}
 	out.Entries = slices.Grow(out.Entries, count)
 
-	for i := range s.ResourceLogs {
-		res := &s.ResourceLogs[i]
-		for j := range res.ScopeLogs {
-			scope := &res.ScopeLogs[j]
+	var sharedAttrs []push.LabelAdapter
 
-			nothingLifted := len(res.Attrs) == 0 && len(scope.Attrs) == 0
-			if nothingLifted {
+	for i := range s.ResourceLogs {
+		res := s.ResourceLogs[i]
+		for j := range res.ScopeLogs {
+			scope := res.ScopeLogs[j]
+
+			hasSharedAttrs := len(res.Attrs) > 0 || len(scope.Attrs) > 0
+			if !hasSharedAttrs {
 				out.Entries = append(out.Entries, scope.Entries...)
 				continue
+			}
+
+			sharedAttrs = append(sharedAttrs[:0], scope.Attrs...)
+			// only add resource attributes if they are not overridden by scope attrs already
+			for _, resAttr := range res.Attrs {
+				if !hasName(sharedAttrs, resAttr.Name) {
+					sharedAttrs = append(sharedAttrs, resAttr)
+				}
 			}
 
 			for k := range scope.Entries {
 				e := scope.Entries[k]
 
-				md := make([]push.LabelAdapter, 0, len(e.StructuredMetadata)+len(res.Attrs)+len(scope.Attrs))
+				md := make([]push.LabelAdapter, 0, len(e.StructuredMetadata)+len(sharedAttrs))
 				md = append(md, e.StructuredMetadata...)
-				md = append(md, res.Attrs...)
-				md = append(md, scope.Attrs...)
+
+				for _, sharedAttr := range sharedAttrs {
+					if !hasName(md, sharedAttr.Name) {
+						md = append(md, sharedAttr)
+					}
+				}
 
 				e.StructuredMetadata = md
 				out.Entries = append(out.Entries, e)
 			}
 		}
 	}
+}
+
+func hasName(attrs []push.LabelAdapter, name string) bool {
+	for i := range attrs {
+		if attrs[i].Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/logproto/internal_push_test.go
+++ b/pkg/logproto/internal_push_test.go
@@ -1,0 +1,254 @@
+package logproto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+func entry(ns int64, line string, md ...push.LabelAdapter) push.Entry {
+	return push.Entry{
+		Timestamp:          time.Unix(0, ns),
+		Line:               line,
+		StructuredMetadata: md,
+	}
+}
+
+// TestEncodingsAreMutuallyUndecodable pins the property the field numbering of
+// InternalStreamAdapter exists to provide: a record written in either encoding fails to
+// decode as the other, so a consumer can attempt one and fall back on error rather than
+// decoding to a stream with no entries and silently dropping every line.
+//
+// Giving Stream a varint field 2, or InternalStreamAdapter a length delimited one, would
+// quietly remove the property, which is why it is asserted here rather than assumed.
+func TestEncodingsAreMutuallyUndecodable(t *testing.T) {
+	oneEntry := []push.Entry{entry(1, "x")}
+	oneGroup := []ResourceLogs{{ScopeLogs: []ScopeLogs{{Entries: oneEntry}}}}
+
+	marshalFlat := func(t *testing.T, s Stream) []byte {
+		t.Helper()
+		data, err := s.Marshal()
+		require.NoError(t, err)
+		return data
+	}
+	marshalNested := func(t *testing.T, s InternalStreamAdapter) []byte {
+		t.Helper()
+		data, err := s.Marshal()
+		require.NoError(t, err)
+		return data
+	}
+
+	tests := []struct {
+		name          string
+		data          func(*testing.T) []byte
+		decodesFlat   bool
+		decodesNested bool
+	}{
+		{
+			name: "flat with entries and a hash",
+			data: func(t *testing.T) []byte {
+				return marshalFlat(t, Stream{Labels: `{a="b"}`, Hash: 7, Entries: oneEntry})
+			},
+			decodesFlat: true,
+		},
+		{
+			name:        "flat with entries and a zero hash",
+			data:        func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`, Entries: oneEntry}) },
+			decodesFlat: true,
+		},
+		{
+			name:        "flat with a hash and no entries",
+			data:        func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`, Hash: 7}) },
+			decodesFlat: true,
+		},
+		{
+			name:        "flat with a single zero valued entry",
+			data:        func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`, Entries: []push.Entry{{}}}) },
+			decodesFlat: true,
+		},
+		{
+			name: "nested with groups and a hash",
+			data: func(t *testing.T) []byte {
+				return marshalNested(t, InternalStreamAdapter{Labels: `{a="b"}`, Hash: 7, ResourceLogs: oneGroup})
+			},
+			decodesNested: true,
+		},
+		{
+			name: "nested with groups and a zero hash",
+			data: func(t *testing.T) []byte {
+				return marshalNested(t, InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: oneGroup})
+			},
+			decodesNested: true,
+		},
+		{
+			name: "nested with a single empty group",
+			data: func(t *testing.T) []byte {
+				return marshalNested(t, InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{}}})
+			},
+			decodesNested: true,
+		},
+		{
+			// The only shape both accept, because neither carries a field the other
+			// disagrees about. Asserted to decode the same either way below.
+			name:          "labels alone",
+			data:          func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`}) },
+			decodesFlat:   true,
+			decodesNested: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := tt.data(t)
+
+			var flat Stream
+			flatErr := flat.Unmarshal(data)
+			var nested InternalStreamAdapter
+			nestedErr := nested.Unmarshal(data)
+
+			require.Equal(t, tt.decodesFlat, flatErr == nil, "flat decode: %v", flatErr)
+			require.Equal(t, tt.decodesNested, nestedErr == nil, "nested decode: %v", nestedErr)
+			require.True(t, tt.decodesFlat || tt.decodesNested, "a record must decode as one of the two")
+
+			if tt.decodesFlat && tt.decodesNested {
+				require.Equal(t, flat, nested.ToStream(),
+					"a record both encodings accept must mean the same thing either way")
+			}
+		})
+	}
+}
+
+func TestFromStreamRoundTripsThroughToStream(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+	}{
+		{"no entries", Stream{Labels: `{a="b"}`}},
+		{"no entries with a hash", Stream{Labels: `{a="b"}`, Hash: 7}},
+		{"one entry", Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{entry(1, "x")}}},
+		{
+			name: "entries with structured metadata",
+			stream: Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{
+				entry(1, "x", push.LabelAdapter{Name: "trace_id", Value: "1"}),
+				entry(2, "y", push.LabelAdapter{Name: "trace_id", Value: "2"}),
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nested := FromStream(tt.stream)
+			require.Equal(t, len(tt.stream.Entries), nested.EntryCount())
+			require.Equal(t, tt.stream, nested.ToStream())
+		})
+	}
+}
+
+// TestToStreamLeavesEntriesNilWhenEmpty keeps a decoded record indistinguishable from the
+// flat form, which unmarshals to a nil slice rather than an empty one when it carries no
+// entries.
+func TestToStreamLeavesEntriesNilWhenEmpty(t *testing.T) {
+	for _, s := range []InternalStreamAdapter{
+		{Labels: `{a="b"}`},
+		{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{}}},
+		{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{ScopeLogs: []ScopeLogs{{}}}}},
+	} {
+		require.Nil(t, s.ToStream().Entries)
+	}
+}
+
+// TestToStreamResolvesEffectiveMetadata pins the expansion against what the OTLP parse site
+// produces when it flattens attributes onto entries itself: the entry's own pairs, then the
+// resource's, then the scope's, neither sorted nor deduplicated. Anything else and a nested
+// record would store different bytes than its flat equivalent.
+func TestToStreamResolvesEffectiveMetadata(t *testing.T) {
+	nested := InternalStreamAdapter{
+		Labels: `{a="b"}`,
+		Hash:   7,
+		ResourceLogs: []ResourceLogs{{
+			Attrs: []push.LabelAdapter{{Name: "host", Value: "host-1"}, {Name: "shared", Value: "resource"}},
+			ScopeLogs: []ScopeLogs{{
+				Attrs: []push.LabelAdapter{{Name: "scope", Value: "lib"}, {Name: "shared", Value: "scope"}},
+				Entries: []push.Entry{
+					entry(1, "x", push.LabelAdapter{Name: "shared", Value: "entry"}),
+					entry(2, "y"),
+				},
+			}},
+		}},
+	}
+
+	got := nested.ToStream()
+
+	require.Equal(t, `{a="b"}`, got.Labels)
+	require.Equal(t, uint64(7), got.Hash)
+	require.Len(t, got.Entries, 2)
+
+	require.Equal(t, push.LabelsAdapter{
+		{Name: "shared", Value: "entry"},
+		{Name: "host", Value: "host-1"},
+		{Name: "shared", Value: "resource"},
+		{Name: "scope", Value: "lib"},
+		{Name: "shared", Value: "scope"},
+	}, got.Entries[0].StructuredMetadata)
+
+	require.Equal(t, push.LabelsAdapter{
+		{Name: "host", Value: "host-1"},
+		{Name: "shared", Value: "resource"},
+		{Name: "scope", Value: "lib"},
+		{Name: "shared", Value: "scope"},
+	}, got.Entries[1].StructuredMetadata)
+}
+
+// TestToStreamKeepsEntriesUnderTheirOwnGroup guards the association that containment
+// carries: an entry must not inherit the attributes of a resource it does not sit under.
+func TestToStreamKeepsEntriesUnderTheirOwnGroup(t *testing.T) {
+	nested := InternalStreamAdapter{
+		Labels: `{a="b"}`,
+		ResourceLogs: []ResourceLogs{
+			{
+				Attrs:     []push.LabelAdapter{{Name: "host", Value: "host-1"}},
+				ScopeLogs: []ScopeLogs{{Entries: []push.Entry{entry(1, "one")}}},
+			},
+			{
+				Attrs:     []push.LabelAdapter{{Name: "host", Value: "host-2"}},
+				ScopeLogs: []ScopeLogs{{Entries: []push.Entry{entry(2, "two")}}},
+			},
+		},
+	}
+
+	got := nested.ToStream()
+
+	require.Len(t, got.Entries, 2)
+	require.Equal(t, "one", got.Entries[0].Line)
+	require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-1"}}, got.Entries[0].StructuredMetadata)
+	require.Equal(t, "two", got.Entries[1].Line)
+	require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-2"}}, got.Entries[1].StructuredMetadata)
+}
+
+// TestToStreamDoesNotWriteThroughSharedAttrs guards against expanding into a shared slice. The
+// signature of AppendEffectiveMetadata invites passing resAttrs as dst to save an allocation,
+// but a resource's attributes belong to every entry beneath it, so appending one entry's
+// metadata onto them would corrupt its siblings.
+func TestToStreamDoesNotWriteThroughSharedAttrs(t *testing.T) {
+	resAttrs := make([]push.LabelAdapter, 1, 8) // spare capacity is what makes a stray append silent
+	resAttrs[0] = push.LabelAdapter{Name: "host", Value: "host-1"}
+
+	nested := InternalStreamAdapter{
+		Labels: `{a="b"}`,
+		ResourceLogs: []ResourceLogs{{
+			Attrs: resAttrs,
+			ScopeLogs: []ScopeLogs{{
+				Attrs:   []push.LabelAdapter{{Name: "scope", Value: "lib"}},
+				Entries: []push.Entry{entry(1, "x"), entry(2, "y")},
+			}},
+		}},
+	}
+
+	nested.ToStream()
+
+	require.Equal(t, []push.LabelAdapter{{Name: "host", Value: "host-1"}}, nested.ResourceLogs[0].Attrs)
+	require.Equal(t, []push.LabelAdapter{{Name: "scope", Value: "lib"}}, nested.ResourceLogs[0].ScopeLogs[0].Attrs)
+}

--- a/pkg/logproto/internal_push_test.go
+++ b/pkg/logproto/internal_push_test.go
@@ -114,7 +114,9 @@ func TestEncodingsAreMutuallyUndecodable(t *testing.T) {
 			require.True(t, tt.decodesFlat || tt.decodesNested, "a record must decode as one of the two")
 
 			if tt.decodesFlat && tt.decodesNested {
-				require.Equal(t, flat, nested.ToStream(),
+				var fromNested Stream
+				nested.ToStream(&fromNested)
+				require.Equal(t, flat, fromNested,
 					"a record both encodings accept must mean the same thing either way")
 			}
 		})
@@ -141,8 +143,11 @@ func TestFromStreamRoundTripsThroughToStream(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nested := FromStream(tt.stream)
-			require.Equal(t, len(tt.stream.Entries), nested.EntryCount())
-			require.Equal(t, tt.stream, nested.ToStream())
+			require.Equal(t, len(tt.stream.Entries), nested.entryCount())
+
+			var got Stream
+			nested.ToStream(&got)
+			require.Equal(t, tt.stream, got)
 		})
 	}
 }
@@ -156,8 +161,24 @@ func TestToStreamLeavesEntriesNilWhenEmpty(t *testing.T) {
 		{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{}}},
 		{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{ScopeLogs: []ScopeLogs{{}}}}},
 	} {
-		require.Nil(t, s.ToStream().Entries)
+		var got Stream
+		s.ToStream(&got)
+		require.Nil(t, got.Entries)
 	}
+}
+
+// TestToStreamOverwritesAReusedStream covers the reuse the decoder does between records:
+// nothing of the stream out held before may survive, least of all entries, which an
+// entry-less record would otherwise inherit whole.
+func TestToStreamOverwritesAReusedStream(t *testing.T) {
+	out := Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{entry(1, "x"), entry(2, "y")}}
+
+	empty := InternalStreamAdapter{Labels: `{c="d"}`, ResourceLogs: []ResourceLogs{{ScopeLogs: []ScopeLogs{{}}}}}
+	empty.ToStream(&out)
+
+	require.Equal(t, `{c="d"}`, out.Labels)
+	require.Zero(t, out.Hash)
+	require.Empty(t, out.Entries)
 }
 
 // TestToStreamResolvesEffectiveMetadata pins the expansion against what the OTLP parse site
@@ -180,7 +201,8 @@ func TestToStreamResolvesEffectiveMetadata(t *testing.T) {
 		}},
 	}
 
-	got := nested.ToStream()
+	var got Stream
+	nested.ToStream(&got)
 
 	require.Equal(t, `{a="b"}`, got.Labels)
 	require.Equal(t, uint64(7), got.Hash)
@@ -219,7 +241,8 @@ func TestToStreamKeepsEntriesUnderTheirOwnGroup(t *testing.T) {
 		},
 	}
 
-	got := nested.ToStream()
+	var got Stream
+	nested.ToStream(&got)
 
 	require.Len(t, got.Entries, 2)
 	require.Equal(t, "one", got.Entries[0].Line)
@@ -228,10 +251,10 @@ func TestToStreamKeepsEntriesUnderTheirOwnGroup(t *testing.T) {
 	require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-2"}}, got.Entries[1].StructuredMetadata)
 }
 
-// TestToStreamDoesNotWriteThroughSharedAttrs guards against expanding into a shared slice. The
-// signature of AppendEffectiveMetadata invites passing resAttrs as dst to save an allocation,
-// but a resource's attributes belong to every entry beneath it, so appending one entry's
-// metadata onto them would corrupt its siblings.
+// TestToStreamDoesNotWriteThroughSharedAttrs guards against expanding into a shared slice.
+// Appending an entry's own metadata onto res.Attrs saves an allocation and is the obvious
+// shortcut, but a resource's attributes belong to every entry beneath it, so taking it would
+// corrupt the entry's siblings.
 func TestToStreamDoesNotWriteThroughSharedAttrs(t *testing.T) {
 	resAttrs := make([]push.LabelAdapter, 1, 8) // spare capacity is what makes a stray append silent
 	resAttrs[0] = push.LabelAdapter{Name: "host", Value: "host-1"}
@@ -247,7 +270,8 @@ func TestToStreamDoesNotWriteThroughSharedAttrs(t *testing.T) {
 		}},
 	}
 
-	nested.ToStream()
+	var got Stream
+	nested.ToStream(&got)
 
 	require.Equal(t, []push.LabelAdapter{{Name: "host", Value: "host-1"}}, nested.ResourceLogs[0].Attrs)
 	require.Equal(t, []push.LabelAdapter{{Name: "scope", Value: "lib"}}, nested.ResourceLogs[0].ScopeLogs[0].Attrs)

--- a/pkg/logproto/internal_push_test.go
+++ b/pkg/logproto/internal_push_test.go
@@ -1,6 +1,9 @@
 package logproto
 
 import (
+	"fmt"
+	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
@@ -9,92 +12,55 @@ import (
 	"github.com/grafana/loki/pkg/push"
 )
 
-func entry(ns int64, line string, md ...push.LabelAdapter) push.Entry {
-	return push.Entry{
-		Timestamp:          time.Unix(0, ns),
-		Line:               line,
-		StructuredMetadata: md,
-	}
-}
-
-// TestEncodingsAreMutuallyUndecodable pins the property the field numbering of
-// InternalStreamAdapter exists to provide: a record written in either encoding fails to
-// decode as the other, so a consumer can attempt one and fall back on error rather than
-// decoding to a stream with no entries and silently dropping every line.
-//
-// Giving Stream a varint field 2, or InternalStreamAdapter a length delimited one, would
-// quietly remove the property, which is why it is asserted here rather than assumed.
 func TestEncodingsAreMutuallyUndecodable(t *testing.T) {
 	oneEntry := []push.Entry{entry(1, "x")}
 	oneGroup := []ResourceLogs{{ScopeLogs: []ScopeLogs{{Entries: oneEntry}}}}
 
-	marshalFlat := func(t *testing.T, s Stream) []byte {
-		t.Helper()
-		data, err := s.Marshal()
-		require.NoError(t, err)
-		return data
-	}
-	marshalNested := func(t *testing.T, s InternalStreamAdapter) []byte {
-		t.Helper()
-		data, err := s.Marshal()
-		require.NoError(t, err)
-		return data
-	}
-
 	tests := []struct {
 		name          string
-		data          func(*testing.T) []byte
+		record        interface{ Marshal() ([]byte, error) }
 		decodesFlat   bool
 		decodesNested bool
 	}{
 		{
-			name: "flat with entries and a hash",
-			data: func(t *testing.T) []byte {
-				return marshalFlat(t, Stream{Labels: `{a="b"}`, Hash: 7, Entries: oneEntry})
-			},
+			name:        "flat with entries and a hash",
+			record:      &Stream{Labels: `{a="b"}`, Hash: 7, Entries: oneEntry},
 			decodesFlat: true,
 		},
 		{
 			name:        "flat with entries and a zero hash",
-			data:        func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`, Entries: oneEntry}) },
+			record:      &Stream{Labels: `{a="b"}`, Entries: oneEntry},
 			decodesFlat: true,
 		},
 		{
 			name:        "flat with a hash and no entries",
-			data:        func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`, Hash: 7}) },
+			record:      &Stream{Labels: `{a="b"}`, Hash: 7},
 			decodesFlat: true,
 		},
 		{
 			name:        "flat with a single zero valued entry",
-			data:        func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`, Entries: []push.Entry{{}}}) },
+			record:      &Stream{Labels: `{a="b"}`, Entries: []push.Entry{{}}},
 			decodesFlat: true,
 		},
 		{
-			name: "nested with groups and a hash",
-			data: func(t *testing.T) []byte {
-				return marshalNested(t, InternalStreamAdapter{Labels: `{a="b"}`, Hash: 7, ResourceLogs: oneGroup})
-			},
+			name:          "nested with groups and a hash",
+			record:        &InternalStreamAdapter{Labels: `{a="b"}`, Hash: 7, ResourceLogs: oneGroup},
 			decodesNested: true,
 		},
 		{
-			name: "nested with groups and a zero hash",
-			data: func(t *testing.T) []byte {
-				return marshalNested(t, InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: oneGroup})
-			},
+			name:          "nested with groups and a zero hash",
+			record:        &InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: oneGroup},
 			decodesNested: true,
 		},
 		{
-			name: "nested with a single empty group",
-			data: func(t *testing.T) []byte {
-				return marshalNested(t, InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{}}})
-			},
+			name:          "nested with a single empty group",
+			record:        &InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{}}},
 			decodesNested: true,
 		},
 		{
-			// The only shape both accept, because neither carries a field the other
-			// disagrees about. Asserted to decode the same either way below.
+			// The only shape both accept: it carries no field they disagree about.
 			name:          "labels alone",
-			data:          func(t *testing.T) []byte { return marshalFlat(t, Stream{Labels: `{a="b"}`}) },
+			record:        &Stream{Labels: `{a="b"}`},
 			decodesFlat:   true,
 			decodesNested: true,
 		},
@@ -102,7 +68,8 @@ func TestEncodingsAreMutuallyUndecodable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := tt.data(t)
+			data, err := tt.record.Marshal()
+			require.NoError(t, err)
 
 			var flat Stream
 			flatErr := flat.Unmarshal(data)
@@ -123,156 +90,371 @@ func TestEncodingsAreMutuallyUndecodable(t *testing.T) {
 	}
 }
 
-func TestFromStreamRoundTripsThroughToStream(t *testing.T) {
+func TestToStream(t *testing.T) {
 	tests := []struct {
 		name   string
-		stream Stream
+		nested InternalStreamAdapter
+		want   Stream
 	}{
-		{"no entries", Stream{Labels: `{a="b"}`}},
-		{"no entries with a hash", Stream{Labels: `{a="b"}`, Hash: 7}},
-		{"one entry", Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{entry(1, "x")}}},
 		{
-			name: "entries with structured metadata",
-			stream: Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{
-				entry(1, "x", push.LabelAdapter{Name: "trace_id", Value: "1"}),
-				entry(2, "y", push.LabelAdapter{Name: "trace_id", Value: "2"}),
+			name:   "labels alone",
+			nested: InternalStreamAdapter{Labels: `{a="b"}`},
+			want:   Stream{Labels: `{a="b"}`},
+		},
+		{
+			name:   "an empty group",
+			nested: InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{}}},
+			want:   Stream{Labels: `{a="b"}`},
+		},
+		{
+			name:   "an empty scope",
+			nested: InternalStreamAdapter{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{ScopeLogs: []ScopeLogs{{}}}}},
+			want:   Stream{Labels: `{a="b"}`},
+		},
+		{
+			name: "entries with nothing lifted off them",
+			nested: InternalStreamAdapter{
+				Labels: `{a="b"}`,
+				Hash:   7,
+				ResourceLogs: []ResourceLogs{
+					resource(
+						attrs(),
+						scope(
+							attrs(),
+							entry(1, "x", attrs("trace_id", "1")...),
+							entry(2, "y"),
+						),
+					),
+				},
+			},
+			want: Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{
+				entry(1, "x", attrs("trace_id", "1")...),
+				entry(2, "y"),
+			}},
+		},
+		{
+			name: "resource and scope attributes resolved onto each entry",
+			nested: InternalStreamAdapter{
+				Labels: `{a="b"}`,
+				Hash:   7,
+				ResourceLogs: []ResourceLogs{
+					resource(
+						attrs("host", "host-1", "shared", "resource"),
+						scope(
+							attrs("scope", "lib", "shared", "scope"),
+							entry(1, "x", attrs("shared", "entry")...),
+							entry(2, "y"),
+						),
+					),
+				},
+			},
+			want: Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{
+				entry(1, "x", attrs("shared", "entry", "scope", "lib", "host", "host-1")...),
+				entry(2, "y", attrs("scope", "lib", "shared", "scope", "host", "host-1")...),
+			}},
+		},
+		{
+			name: "entries under separate groups",
+			nested: InternalStreamAdapter{
+				Labels: `{a="b"}`,
+				ResourceLogs: []ResourceLogs{
+					resource(attrs("host", "host-1"), scope(attrs(), entry(1, "one"))),
+					resource(attrs("host", "host-2"), scope(attrs(), entry(2, "two"))),
+				},
+			},
+			want: Stream{Labels: `{a="b"}`, Entries: []push.Entry{
+				entry(1, "one", attrs("host", "host-1")...),
+				entry(2, "two", attrs("host", "host-2")...),
+			}},
+		},
+		{
+			name: "attributes priority",
+			nested: InternalStreamAdapter{
+				Labels: `{a="b"}`,
+				ResourceLogs: []ResourceLogs{
+					resource(
+						attrs("host", "resource-1"),
+						scope(
+							attrs("host", "scope-11"),
+							entry(111, "e111", attrs("host", "entry-111")...),
+							entry(112, "e112"),
+						),
+						scope(
+							attrs(),
+							entry(121, "e121", attrs("host", "entry-121")...),
+							entry(122, "e122"),
+						),
+					),
+					resource(
+						attrs(),
+						scope(
+							attrs("host", "scope-21"),
+							entry(211, "e211", attrs("host", "entry-211")...),
+							entry(212, "e212"),
+						),
+						scope(
+							attrs(),
+							entry(221, "e221", attrs("host", "entry-221")...),
+							entry(222, "e222"),
+						),
+					),
+					resource(
+						attrs(),
+						scope(
+							attrs(),
+							entry(311, "e311", attrs("host", "entry-311")...),
+							entry(312, "e312"),
+						),
+					),
+				},
+			},
+			want: Stream{Labels: `{a="b"}`, Entries: []push.Entry{
+				// resource 1
+				// -> scope 11
+				entry(111, "e111", attrs("host", "entry-111")...),
+				entry(112, "e112", attrs("host", "scope-11")...),
+				// -> scope 12
+				entry(121, "e121", attrs("host", "entry-121")...),
+				entry(122, "e122", attrs("host", "resource-1")...),
+
+				// resource 2
+				// -> scope 21
+				entry(211, "e211", attrs("host", "entry-211")...),
+				entry(212, "e212", attrs("host", "scope-21")...),
+				// -> scope 22
+				entry(221, "e221", attrs("host", "entry-221")...),
+				entry(222, "e222"),
+
+				// resource 3
+				entry(311, "e311", attrs("host", "entry-311")...),
+				entry(312, "e312"),
 			}},
 		},
 	}
 
+	// Shared by all cases, so every call gets the previous result's leftovers.
+	// The decoder reuses the stream the same way.
+	var reused Stream
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nested := FromStream(tt.stream)
-			require.Equal(t, len(tt.stream.Entries), nested.entryCount())
+			before, err := tt.nested.Marshal()
+			require.NoError(t, err)
 
-			var got Stream
-			nested.ToStream(&got)
-			require.Equal(t, tt.stream, got)
+			var fresh Stream
+			tt.nested.ToStream(&fresh)
+			require.Equal(t, tt.want, fresh)
+
+			tt.nested.ToStream(&reused)
+			requireSameStream(t, tt.want, reused)
+
+			after, err := tt.nested.Marshal()
+			require.NoError(t, err)
+			require.Equal(t, before, after, "flattening a record must not modify it")
 		})
 	}
 }
 
-// TestToStreamLeavesEntriesNilWhenEmpty keeps a decoded record indistinguishable from the
-// flat form, which unmarshals to a nil slice rather than an empty one when it carries no
-// entries.
-func TestToStreamLeavesEntriesNilWhenEmpty(t *testing.T) {
-	for _, s := range []InternalStreamAdapter{
-		{Labels: `{a="b"}`},
-		{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{}}},
-		{Labels: `{a="b"}`, ResourceLogs: []ResourceLogs{{ScopeLogs: []ScopeLogs{{}}}}},
-	} {
-		var got Stream
-		s.ToStream(&got)
-		require.Nil(t, got.Entries)
+// TestToStreamIntoAReusedStream checks that a reused output gives the same result as a fresh
+// one. Random shapes are needed here: a leak only shows when one record follows a different one.
+func TestToStreamIntoAReusedStream(t *testing.T) {
+	// Fixed seed, so a failure always repeats. To try other shapes:
+	// go test -fuzz FuzzToStreamIntoAReusedStream ./pkg/logproto
+	requireReuseIsInvisible(t, 1, 1000)
+}
+
+func FuzzToStreamIntoAReusedStream(f *testing.F) {
+	f.Add(int64(1))
+	f.Add(int64(-1))
+	f.Fuzz(func(t *testing.T, seed int64) {
+		requireReuseIsInvisible(t, seed, 50)
+	})
+}
+
+func requireReuseIsInvisible(t *testing.T, seed int64, records int) {
+	t.Helper()
+
+	r := rand.New(rand.NewSource(seed))
+	var reused Stream
+
+	for i := range records {
+		nested := randomStreamAdapter(r)
+		where := fmt.Sprintf("record %d of seed %d", i, seed)
+
+		before, err := nested.Marshal()
+		require.NoError(t, err, where)
+
+		var fresh Stream
+		nested.ToStream(&fresh)
+
+		nested.ToStream(&reused)
+		requireSameStream(t, fresh, reused, where)
+
+		// More entries than any random record has, so a leftover entry always shows up,
+		// not only after a longer record.
+		primed := Stream{Labels: "stale", Hash: 1 << 20, Entries: make([]push.Entry, 64)}
+		nested.ToStream(&primed)
+		requireSameStream(t, fresh, primed, where)
+
+		want := flattenReference(nested)
+		require.Equal(t, want.Labels, reused.Labels, where)
+		require.Equal(t, want.Hash, reused.Hash, where)
+		requireSameEntries(t, want.Entries, reused.Entries, where)
+
+		after, err := nested.Marshal()
+		require.NoError(t, err, where)
+		require.Equal(t, before, after, "flattening a record must not modify it: %s", where)
 	}
 }
 
-// TestToStreamOverwritesAReusedStream covers the reuse the decoder does between records:
-// nothing of the stream out held before may survive, least of all entries, which an
-// entry-less record would otherwise inherit whole.
-func TestToStreamOverwritesAReusedStream(t *testing.T) {
-	out := Stream{Labels: `{a="b"}`, Hash: 7, Entries: []push.Entry{entry(1, "x"), entry(2, "y")}}
+// requireSameStream compares streams field by field, not as whole structs. ToStream truncates
+// the entries slice instead of replacing it, so a record with no entries leaves Entries empty on
+// a reused stream but nil on a fresh one. Both mean "no entries", and the flat format does the
+// same, so that difference is not worth asserting.
+func requireSameStream(t *testing.T, want, got Stream, msgAndArgs ...any) {
+	t.Helper()
 
-	empty := InternalStreamAdapter{Labels: `{c="d"}`, ResourceLogs: []ResourceLogs{{ScopeLogs: []ScopeLogs{{}}}}}
-	empty.ToStream(&out)
-
-	require.Equal(t, `{c="d"}`, out.Labels)
-	require.Zero(t, out.Hash)
-	require.Empty(t, out.Entries)
+	require.Equal(t, want.Labels, got.Labels, msgAndArgs...)
+	require.Equal(t, want.Hash, got.Hash, msgAndArgs...)
+	if len(want.Entries) == 0 {
+		require.Empty(t, got.Entries, msgAndArgs...)
+		return
+	}
+	require.Equal(t, want.Entries, got.Entries, msgAndArgs...)
 }
 
-// TestToStreamResolvesEffectiveMetadata pins the expansion against what the OTLP parse site
-// produces when it flattens attributes onto entries itself: the entry's own pairs, then the
-// resource's, then the scope's, neither sorted nor deduplicated. Anything else and a nested
-// record would store different bytes than its flat equivalent.
-func TestToStreamResolvesEffectiveMetadata(t *testing.T) {
+// requireSameEntries compares entries in full and treats nil and empty metadata as equal.
+// ToStream leaves metadata alone when there is nothing to resolve and builds a new slice when
+// there is, so two correct results can differ in nil-ness alone.
+func requireSameEntries(t *testing.T, want, got []push.Entry, msgAndArgs ...any) {
+	t.Helper()
+
+	require.Len(t, got, len(want), msgAndArgs...)
+	for i := range want {
+		require.Equal(t, want[i].Timestamp, got[i].Timestamp, msgAndArgs...)
+		require.Equal(t, want[i].Line, got[i].Line, msgAndArgs...)
+		require.Equal(t, want[i].Parsed, got[i].Parsed, msgAndArgs...)
+
+		if len(want[i].StructuredMetadata) == 0 {
+			require.Empty(t, got[i].StructuredMetadata, msgAndArgs...)
+			continue
+		}
+		require.Equal(t, want[i].StructuredMetadata, got[i].StructuredMetadata, msgAndArgs...)
+	}
+}
+
+// flattenReference is a slow and obvious ToStream. It allocates everything and keeps no buffers,
+// so its output can never carry anything from an earlier entry, scope or record.
+//
+// The test needs it because comparing two ToStream calls only catches leaks between calls. A
+// buffer shared inside one record would look the same in both.
+func flattenReference(nested InternalStreamAdapter) Stream {
+	out := Stream{Labels: nested.Labels, Hash: nested.Hash}
+
+	for _, res := range nested.ResourceLogs {
+		for _, sc := range res.ScopeLogs {
+			for _, e := range sc.Entries {
+				// Entry wins over scope, scope wins over resource. Duplicates inside the
+				// entry's own metadata stay as they are.
+				md := slices.Clone(e.StructuredMetadata)
+				taken := make(map[string]bool, len(md))
+				for _, attr := range md {
+					taken[attr.Name] = true
+				}
+				for _, attr := range slices.Concat(sc.Attrs, res.Attrs) {
+					if taken[attr.Name] {
+						continue
+					}
+					taken[attr.Name] = true
+					md = append(md, attr)
+				}
+
+				out.Entries = append(out.Entries, push.Entry{
+					Timestamp:          e.Timestamp,
+					Line:               e.Line,
+					StructuredMetadata: md,
+					Parsed:             e.Parsed,
+				})
+			}
+		}
+	}
+
+	return out
+}
+
+// randomStreamAdapter builds a record of a random shape. Any level can be empty, so some records
+// come out with no entries at all.
+func randomStreamAdapter(r *rand.Rand) InternalStreamAdapter {
 	nested := InternalStreamAdapter{
-		Labels: `{a="b"}`,
-		Hash:   7,
-		ResourceLogs: []ResourceLogs{{
-			Attrs: []push.LabelAdapter{{Name: "host", Value: "host-1"}, {Name: "shared", Value: "resource"}},
-			ScopeLogs: []ScopeLogs{{
-				Attrs: []push.LabelAdapter{{Name: "scope", Value: "lib"}, {Name: "shared", Value: "scope"}},
-				Entries: []push.Entry{
-					entry(1, "x", push.LabelAdapter{Name: "shared", Value: "entry"}),
-					entry(2, "y"),
-				},
-			}},
-		}},
+		Labels: fmt.Sprintf(`{app="a-%d"}`, r.Intn(4)),
+		Hash:   uint64(r.Intn(8)),
 	}
 
-	var got Stream
-	nested.ToStream(&got)
+	for range r.Intn(4) {
+		res := resource(randomAttrs(r))
+		for range r.Intn(4) {
+			sc := scope(randomAttrs(r))
+			for range r.Intn(5) {
+				sc.Entries = append(sc.Entries, entry(
+					int64(r.Intn(1000)+1),
+					fmt.Sprintf("line-%d", r.Intn(1000)),
+					randomAttrs(r)...,
+				))
+			}
+			res.ScopeLogs = append(res.ScopeLogs, sc)
+		}
+		nested.ResourceLogs = append(nested.ResourceLogs, res)
+	}
 
-	require.Equal(t, `{a="b"}`, got.Labels)
-	require.Equal(t, uint64(7), got.Hash)
-	require.Len(t, got.Entries, 2)
-
-	require.Equal(t, push.LabelsAdapter{
-		{Name: "shared", Value: "entry"},
-		{Name: "host", Value: "host-1"},
-		{Name: "shared", Value: "resource"},
-		{Name: "scope", Value: "lib"},
-		{Name: "shared", Value: "scope"},
-	}, got.Entries[0].StructuredMetadata)
-
-	require.Equal(t, push.LabelsAdapter{
-		{Name: "host", Value: "host-1"},
-		{Name: "shared", Value: "resource"},
-		{Name: "scope", Value: "lib"},
-		{Name: "shared", Value: "scope"},
-	}, got.Entries[1].StructuredMetadata)
+	return nested
 }
 
-// TestToStreamKeepsEntriesUnderTheirOwnGroup guards the association that containment
-// carries: an entry must not inherit the attributes of a resource it does not sit under.
-func TestToStreamKeepsEntriesUnderTheirOwnGroup(t *testing.T) {
-	nested := InternalStreamAdapter{
-		Labels: `{a="b"}`,
-		ResourceLogs: []ResourceLogs{
-			{
-				Attrs:     []push.LabelAdapter{{Name: "host", Value: "host-1"}},
-				ScopeLogs: []ScopeLogs{{Entries: []push.Entry{entry(1, "one")}}},
-			},
-			{
-				Attrs:     []push.LabelAdapter{{Name: "host", Value: "host-2"}},
-				ScopeLogs: []ScopeLogs{{Entries: []push.Entry{entry(2, "two")}}},
-			},
-		},
+// randomAttrs picks up to 3 attributes from a pool of 3 names, so names collide inside one set
+// and across resource, scope and entry. It can also pick none, which is the case where ToStream
+// copies entries as they are.
+func randomAttrs(r *rand.Rand) []push.LabelAdapter {
+	names := []string{"host", "scope", "shared"}
+
+	var res []push.LabelAdapter
+	for range r.Intn(4) {
+		name := names[r.Intn(len(names))]
+		res = append(res, push.LabelAdapter{Name: name, Value: fmt.Sprintf("%s-%d", name, r.Intn(3))})
 	}
-
-	var got Stream
-	nested.ToStream(&got)
-
-	require.Len(t, got.Entries, 2)
-	require.Equal(t, "one", got.Entries[0].Line)
-	require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-1"}}, got.Entries[0].StructuredMetadata)
-	require.Equal(t, "two", got.Entries[1].Line)
-	require.Equal(t, push.LabelsAdapter{{Name: "host", Value: "host-2"}}, got.Entries[1].StructuredMetadata)
+	return res
 }
 
-// TestToStreamDoesNotWriteThroughSharedAttrs guards against expanding into a shared slice.
-// Appending an entry's own metadata onto res.Attrs saves an allocation and is the obvious
-// shortcut, but a resource's attributes belong to every entry beneath it, so taking it would
-// corrupt the entry's siblings.
-func TestToStreamDoesNotWriteThroughSharedAttrs(t *testing.T) {
-	resAttrs := make([]push.LabelAdapter, 1, 8) // spare capacity is what makes a stray append silent
-	resAttrs[0] = push.LabelAdapter{Name: "host", Value: "host-1"}
+func entry(ns int64, line string, md ...push.LabelAdapter) push.Entry {
+	return push.Entry{
+		Timestamp:          time.Unix(0, ns),
+		Line:               line,
+		StructuredMetadata: md,
+	}
+}
 
-	nested := InternalStreamAdapter{
-		Labels: `{a="b"}`,
-		ResourceLogs: []ResourceLogs{{
-			Attrs: resAttrs,
-			ScopeLogs: []ScopeLogs{{
-				Attrs:   []push.LabelAdapter{{Name: "scope", Value: "lib"}},
-				Entries: []push.Entry{entry(1, "x"), entry(2, "y")},
-			}},
-		}},
+func resource(attrs []push.LabelAdapter, scopes ...ScopeLogs) ResourceLogs {
+	return ResourceLogs{
+		Attrs:     attrs,
+		ScopeLogs: scopes,
+	}
+}
+
+func attrs(keyValues ...string) []push.LabelAdapter {
+	if len(keyValues)%2 != 0 {
+		panic("odd number of keyValues")
 	}
 
-	var got Stream
-	nested.ToStream(&got)
+	res := make([]push.LabelAdapter, 0, len(keyValues)/2)
 
-	require.Equal(t, []push.LabelAdapter{{Name: "host", Value: "host-1"}}, nested.ResourceLogs[0].Attrs)
-	require.Equal(t, []push.LabelAdapter{{Name: "scope", Value: "lib"}}, nested.ResourceLogs[0].ScopeLogs[0].Attrs)
+	for i := 0; i < len(keyValues); i += 2 {
+		res = append(res, push.LabelAdapter{Name: keyValues[i], Value: keyValues[i+1]})
+	}
+
+	return res
+}
+
+func scope(attrs []push.LabelAdapter, entries ...push.Entry) ScopeLogs {
+	return ScopeLogs{
+		Attrs:   attrs,
+		Entries: entries,
+	}
 }


### PR DESCRIPTION
**Context**

We added a new [internal_push.proto](https://github.com/grafana/loki/blob/5d773910761d808ae017d58e418166c2e83b51ee/pkg/logproto/internal_push.proto) that has a different representation of incoming streams `InternalStreamAdapter` (list of entries => nested list of entries). We are going to send data over Kafka using this new structure (serialized to bytes via proto).

We want the consumers to be able to gradually migrate from `StreamAdapter` to `InternalStreamAdapter`. The core idea is that when they receive a slice of bytes `[]byte` these bytes might represent either of `StreamAdapter` or `InternalStreamAdapter`. Consumers should support both data formats (at least temporarily).

**Implementation**
kafka decoder now first attempts to deserialize incoming bytes as `InternalStreamAdapter`. If it works without an error it converts `InternalStreamAdapter` to `logproto.Stream` (expanding the attributes). If there's an error deserializing the bytes to `InternalStreamAdapter` decoder fallbacks to the previous `logproto.Stream` serialization.

## Benchmarks

I'm comparing the allocations using 3 different dimensions:
- how many log entries per 1 kafka record? (1 entry, 1000 entries)
- the code + format combination (old code + old format, new code + old format, new code + new format)
- are there shared attributes in the encoded Kafka request?


### No shared attributes - 1 entry / record

The fallback nearly doubles the decode of a single-entry record, because such a decode is almost entirely per-record overhead.

```go
// old format                                                                                                                                                                                                          
  logproto.Stream{                                                                                                                                                                                                       
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                                
      Entries: []push.Entry{                                                                                                                                                                                             
          {Timestamp: t0, Line: "…200 bytes…"},   // no StructuredMetadata                                                                                                                                               
      },                                                                                                                                                                                                                 
  }                                                                                                                                                                                                                      
                                                                                                                                                                                                                         
  // new format                                                                                                                                                                                                          
  logproto.InternalStreamAdapter{                                                                                                                                                                                        
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                                
      ResourceLogs: []logproto.ResourceLogs{{                                                                                                                                                                            
          // Attrs empty on both resource and scope: nothing was lifted out                                                                                                                                              
          ScopeLogs: []logproto.ScopeLogs{{                                                                                                                                                                              
              Entries: []push.Entry{                                                                                                                                                                                     
                  {Timestamp: t0, Line: "…200 bytes…"},                                                                                                                                                                  
              },                                                                                                                                                                                                         
          }},                                                                                                                                                                                                            
      }},                                                                                                                                                                                                                
  }                                                                                                                                                                                                                      
                                                                                                                                                                                                                         
  ┌───────────────────────┬────────────┬──────────┬──────┬───────────┐                                                                                                                                                   
  │                       │ wire bytes │ time/op  │ B/op │ allocs/op │                                                                                                                                                   
  ├───────────────────────┼────────────┼──────────┼──────┼───────────┤                                                                                                                                                   
  │ old format + old code │        246 │  90.0 ns │  328 │         3 │                                                                                                                                                   
  ├───────────────────────┼────────────┼──────────┼──────┼───────────┤                                                                                                                                                   
  │ old format + new code │        246 │ 176.6 ns │  416 │         6 │                                                                                                                                                   
  ├───────────────────────┼────────────┼──────────┼──────┼───────────┤                                                                                                                                                   
  │ new format + new code │        252 │ 182.8 ns │  520 │         6 │                                                                                                                                                   
  └───────────────────────┴────────────┴──────────┴──────┴───────────┘
```

### No shared attributes - 1000 entries / record

Same +3 allocations as above, now against a 1,013 baseline: +1.0% in time.

```go                                                                                                                                                                                                    
  // old format                                                                                                                                                                                          
  logproto.Stream{                                                                                                                                                                                       
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                
      Entries: []push.Entry{                                                                                                                                                                             
          {Timestamp: t0, Line: "…200 bytes…"},   // no StructuredMetadata                                                                                                                               
          {Timestamp: t1, Line: "…200 bytes…"},                                                                                                                                                          
          …                                        // 1000 entries                                                                                                                                       
      },                                                                                                                                                                                                 
  }                                                                                                                                                                                                      
                                                                                                                                                                                                         
  // new format                                                                                                                                                                                          
  logproto.InternalStreamAdapter{                                                                                                                                                                        
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                
      ResourceLogs: []logproto.ResourceLogs{{                                                                                                                                                            
          // Attrs empty on both resource and scope: nothing was lifted out                                                                                                                              
          ScopeLogs: []logproto.ScopeLogs{{                                                                                                                                                              
              Entries: []push.Entry{                                                                                                                                                                     
                  {Timestamp: t0, Line: "…200 bytes…"},                                                                                                                                                  
                  {Timestamp: t1, Line: "…200 bytes…"},                                                                                                                                                  
                  …                                 // 1000 entries                                                                                                                                      
              },                                                                                                                                                                                         
          }},                                                                                                                                                                                            
      }},                                                                                                                                                                                                
  }                                                                                                                                                                                                      
                                                                                                                                                                                                         
  ┌───────────────────────┬────────────┬─────────┬─────────┬───────────┐                                                                                                                                 
  │                       │ wire bytes │ time/op │  B/op   │ allocs/op │                                                                                                                                 
  ├───────────────────────┼────────────┼─────────┼─────────┼───────────┤                                                                                                                                 
  │ old format + old code │    219,026 │ 67.9 µs │ 510,984 │     1,013 │                                                                                                                                 
  ├───────────────────────┼────────────┼─────────┼─────────┼───────────┤                                                                                                                                 
  │ old format + new code │    219,026 │ 68.6 µs │ 511,304 │     1,016 │                                                                                                                                 
  ├───────────────────────┼────────────┼─────────┼─────────┼───────────┤                                                                                                                                 
  │ new format + new code │    219,034 │ 77.6 µs │ 601,193 │     1,016 │                                                                                                                                 
  └───────────────────────┴────────────┴─────────┴─────────┴───────────┘
```

### Three shared resource attributes — 1 entry / record

An OTLP push whose resource carries host, cluster and namespace. With one entry there is nothing to share yet, so the nesting only adds framing.

```go
// old format — the three pairs copied onto the entry                                                                                                                                                  
  logproto.Stream{                                                                                                                                                                                       
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                
      Entries: []push.Entry{                                                                                                                                                                             
          {Timestamp: t0, Line: "…200 bytes…", StructuredMetadata: push.LabelsAdapter{                                                                                                                   
              {Name: "host", Value: "host-1"},                                                                                                                                                           
              {Name: "cluster", Value: "prod-eu-west-2"},                                                                                                                                                
              {Name: "namespace", Value: "loki-prod-029"},                                                                                                                                               
          }},                                                                                                                                                                                            
      },                                                                                                                                                                                                 
  }                                                                                                                                                                                                      
                                                                                                                                                                                                         
  // new format — the three pairs stored once, on the resource                                                                                                                                           
  logproto.InternalStreamAdapter{                                                                                                                                                                        
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                
      ResourceLogs: []logproto.ResourceLogs{{                                                                                                                                                            
          Attrs: []push.LabelAdapter{                                                                                                                                                                    
              {Name: "host", Value: "host-1"},                                                                                                                                                           
              {Name: "cluster", Value: "prod-eu-west-2"},                                                                                                                                                
              {Name: "namespace", Value: "loki-prod-029"},                                                                                                                                               
          },                                                                                                                                                                                             
          ScopeLogs: []logproto.ScopeLogs{{                                                                                                                                                              
              Entries: []push.Entry{                                                                                                                                                                     
                  {Timestamp: t0, Line: "…200 bytes…"},   // no metadata of its own                                                                                                                      
              },                                                                                                                                                                                         
          }},                                                                                                                                                                                            
      }},                                                                                                                                                                                                
  }                                                                                                                                                                                                      
                                                                                                                                                                                                         
  ┌───────────────────────┬────────────┬──────────┬──────┬───────────┐                                                                                                                                   
  │                       │ wire bytes │ time/op  │ B/op │ allocs/op │                                                                                                                                   
  ├───────────────────────┼────────────┼──────────┼──────┼───────────┤                                                                                                                                   
  │ old format + old code │        317 │ 250.9 ns │  616 │        12 │                                                                                                                                   
  ├───────────────────────┼────────────┼──────────┼──────┼───────────┤                                                                                                                                   
  │ old format + new code │        317 │ 338.0 ns │  704 │        15 │                                                                                                                                   
  ├───────────────────────┼────────────┼──────────┼──────┼───────────┤                                                                                                                                   
  │ new format + new code │        323 │ 375.2 ns │  904 │        16 │                                                                                                                                   
  └───────────────────────┴────────────┴──────────┴──────┴───────────
```

### Three shared resource attributes — 1000 entries / record

The same OTLP push, 1000 log records under that one resource. This is the case the nesting exists for.

```go
// old format — the three pairs repeated on all 1000 entries                                                                                                                                           
  logproto.Stream{                                                                                                                                                                                       
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                
      Entries: []push.Entry{                                                                                                                                                                             
          {Timestamp: t0, Line: "…200 bytes…", StructuredMetadata: push.LabelsAdapter{                                                                                                                   
              {Name: "host", Value: "host-1"},                                                                                                                                                           
              {Name: "cluster", Value: "prod-eu-west-2"},                                                                                                                                                
              {Name: "namespace", Value: "loki-prod-029"},                                                                                                                                               
          }},                                                                                                                                                                                            
          {Timestamp: t1, Line: "…200 bytes…", StructuredMetadata: push.LabelsAdapter{                                                                                                                   
              {Name: "host", Value: "host-1"},              // the same three pairs                                                                                                                      
              {Name: "cluster", Value: "prod-eu-west-2"},   // again, and again,                                                                                                                         
              {Name: "namespace", Value: "loki-prod-029"},  // 1000 times over                                                                                                                           
          }},                                                                                                                                                                                            
          …                                                                                                                                                                                              
      },                                                                                                                                                                                                 
  }                                                                                                                                                                                                      
                                                                                                                                                                                                         
  // new format — the three pairs stored once, on the resource                                                                                                                                           
  logproto.InternalStreamAdapter{                                                                                                                                                                        
      Labels: `{app="test", env="prod"}`,                                                                                                                                                                
      ResourceLogs: []logproto.ResourceLogs{{                                                                                                                                                            
          Attrs: []push.LabelAdapter{                       // once, not 1000 times                                                                                                                      
              {Name: "host", Value: "host-1"},                                                                                                                                                           
              {Name: "cluster", Value: "prod-eu-west-2"},                                                                                                                                                
              {Name: "namespace", Value: "loki-prod-029"},                                                                                                                                               
          },                                                                                                                                                                                             
          ScopeLogs: []logproto.ScopeLogs{{                                                                                                                                                              
              Entries: []push.Entry{                                                                                                                                                                     
                  {Timestamp: t0, Line: "…200 bytes…"},     // no metadata of their own                                                                                                                  
                  {Timestamp: t1, Line: "…200 bytes…"},                                                                                                                                                  
                  …                                          // 1000 entries                                                                                                                             
              },                                                                                                                                                                                         
          }},                                                                                                                                                                                            
      }},                                                                                                                                                                                                
  }                                                                                                                                                                                                      
                                                                                                                                                                                                         
  ┌───────────────────────┬────────────┬──────────┬─────────┬───────────┐                                                                                                                                
  │                       │ wire bytes │ time/op  │  B/op   │ allocs/op │                                                                                                                                
  ├───────────────────────┼────────────┼──────────┼─────────┼───────────┤                                                                                                                                
  │ old format + old code │    290,026 │ 215.9 µs │ 798,988 │    10,013 │                                                                                                                                
  ├───────────────────────┼────────────┼──────────┼─────────┼───────────┤                                                                                                                                
  │ old format + new code │    290,026 │ 217.6 µs │ 799,480 │    10,017 │                                                                                                                                
  ├───────────────────────┼────────────┼──────────┼─────────┼───────────┤                                                                                                                                
  │ new format + new code │    219,105 │ 110.6 µs │ 697,481 │     2,025 │                                                                                                                                
  └───────────────────────┴────────────┴──────────┴─────────┴───────────┘
```