### PR TITLE
chore: Scan the offset table and symbols without a string per entry

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -73,7 +73,6 @@ func (p *streamPostings) build(ctx context.Context) error {
 				haveLast = false
 			}
 			lastName = string(labelName)
-			p.postings[lastName] = []streamPostingOffset{}
 			valueCount = 0
 		}
 		if valueCount%symbolFactor == 0 {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -58,26 +58,33 @@ func newStreamPostings(ctx context.Context, factory *streamenc.FilePoolDecbufFac
 
 func (p *streamPostings) build(ctx context.Context) error {
 	var (
-		lastName, lastValue string
-		haveLast            bool
-		lastOff             int
-		valueCount          int
+		lastName   string
+		haveName   bool
+		lastValue  []byte // the previous entry's value, in a buffer every entry reuses
+		haveLast   bool
+		lastOff    int
+		valueCount int
 	)
-	err := streamPostingsOffsetTable(ctx, p.factory, p.off, func(labelName, labelValue string, _ uint64, entryOffset int) error {
-		if _, ok := p.postings[labelName]; !ok {
+	err := streamPostingsOffsetTable(ctx, p.factory, p.off, func(labelName, labelValue []byte, _ uint64, entryOffset int) error {
+		if !haveName || lastName != string(labelName) {
 			// New label name
-			p.postings[labelName] = []streamPostingOffset{}
 			if haveLast {
 				// Always include the last value for the previous label name
-				p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: lastValue, offset: lastOff})
+				p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: string(lastValue), offset: lastOff})
+				haveLast = false
 			}
+			lastName, haveName = string(labelName), true
+			p.postings[lastName] = []streamPostingOffset{}
 			valueCount = 0
 		}
 		if valueCount%symbolFactor == 0 {
-			p.postings[labelName] = append(p.postings[labelName], streamPostingOffset{labelValue: labelValue, offset: entryOffset})
+			p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: string(labelValue), offset: entryOffset})
 			haveLast = false
 		} else {
-			lastName, lastValue, lastOff = labelName, labelValue, entryOffset
+			lastOff = entryOffset
+			// This value is kept only if it turns out to be the last of its label name.
+			// Copying it into a reused buffer defers allocating the string until we know it will be kept.
+			lastValue = append(lastValue[:0], labelValue...)
 			haveLast = true
 		}
 		valueCount++
@@ -87,7 +94,7 @@ func (p *streamPostings) build(ctx context.Context) error {
 		return err
 	}
 	if haveLast {
-		p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: lastValue, offset: lastOff})
+		p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: string(lastValue), offset: lastOff})
 	}
 	// Trim any extra space in the slices
 	for k, v := range p.postings {
@@ -99,11 +106,11 @@ func (p *streamPostings) build(ctx context.Context) error {
 }
 
 // isLabelName reports whether the given name is a label name held in the postings offset table.
-func (p *streamPostings) isLabelName(name string) bool {
-	if name == "" { // in postings, this is where the all-postings entry is stored, not a real label name
+func (p *streamPostings) isLabelName(name []byte) bool {
+	if len(name) == 0 { // in postings, this is where the all-postings entry is stored, not a real label name
 		return false
 	}
-	_, ok := p.postings[name]
+	_, ok := p.postings[string(name)]
 	return ok
 }
 
@@ -339,12 +346,19 @@ func (p *pooledBigEndianPostings) release() {
 // streamPostingsOffsetTable iterates the postings-offset table, running
 // perEntryFn against each entry in the table.
 // It is the streaming equivalent of ReadOffsetTable.
+//
+// labelName and labelValue are valid only for the duration of the perEntryFn
+// call they are passed to: they each point into a scratch buffer that is
+// overwritten with each call.
+// A callback that keeps either must copy it, which converting to a string does.
+// Since we only need to keep a small proportion of the names/values, this is
+// a significant saving on allocations.
 func streamPostingsOffsetTable(
 	ctx context.Context,
 	factory *streamenc.FilePoolDecbufFactory,
 	postingsOffsetTableOffset int,
 	perEntryFn func(
-		labelName, labelValue string,
+		labelName, labelValue []byte,
 		postingsOffset uint64, // Absolute file offset
 		entryOffset int, // Relative offset of this entry within the postings offset table
 	) error,
@@ -355,14 +369,17 @@ func streamPostingsOffsetTable(
 		return err
 	}
 
+	var labelName []byte
+	var labelValue []byte
+
 	size := decbuf.Be32()
 	for i := uint32(0); decbuf.Err() == nil && i < size; i++ {
 		entryOffset := decbuf.Offset()
 		if keyCount := decbuf.Uvarint(); keyCount != 2 {
 			return fmt.Errorf("unexpected number of keys for postings offset table %d", keyCount)
 		}
-		labelName := decbuf.UvarintStr()
-		labelValue := decbuf.UvarintStr()
+		labelName = append(labelName[:0], decbuf.UnsafeUvarintBytes()...)
+		labelValue = append(labelValue[:0], decbuf.UnsafeUvarintBytes()...)
 		postingsOffset := decbuf.Uvarint64()
 		if err := decbuf.Err(); err != nil {
 			return err

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -59,21 +59,20 @@ func newStreamPostings(ctx context.Context, factory *streamenc.FilePoolDecbufFac
 func (p *streamPostings) build(ctx context.Context) error {
 	var (
 		lastName   string
-		haveName   bool
 		lastValue  []byte // the previous entry's value, in a buffer every entry reuses
 		haveLast   bool
 		lastOff    int
 		valueCount int
 	)
 	err := streamPostingsOffsetTable(ctx, p.factory, p.off, func(labelName, labelValue []byte, _ uint64, entryOffset int) error {
-		if !haveName || lastName != string(labelName) {
+		if lastName != string(labelName) {
 			// New label name
 			if haveLast {
 				// Always include the last value for the previous label name
 				p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: string(lastValue), offset: lastOff})
 				haveLast = false
 			}
-			lastName, haveName = string(labelName), true
+			lastName = string(labelName)
 			p.postings[lastName] = []streamPostingOffset{}
 			valueCount = 0
 		}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -131,7 +131,7 @@ func writeCrossCheckFixture(t testing.TB, format int) string {
 
 // BenchmarkNewStreamFileReader reproduces the index-open hot path.
 func BenchmarkNewStreamFileReader(b *testing.B) {
-	path := writeCrossCheckFixture(b, FormatV4)
+	path := writeBenchmarkFixture(b, 1_000_000, 3)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
@@ -47,7 +47,7 @@ type streamSymbols struct {
 
 // newStreamSymbols scans the symbol section once, validating its CRC,
 // capturing the sparse offset table, and building labelNameSymbols.
-func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int, isLabelName func(symbol string) bool) (*streamSymbols, error) {
+func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int, isLabelName func(symbol []byte) bool) (*streamSymbols, error) {
 	decbuf := factory.NewDecbufAtChecked(ctx, off, castagnoliTable)
 	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
@@ -70,9 +70,11 @@ func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFact
 		if i%symbolFactor == 0 {
 			s.offsets = append(s.offsets, decbuf.Offset())
 		}
-		symbol := decbuf.UvarintStr()
+		// Read the symbol as bytes rather than as a string because we're going to
+		// throw away most symbols, so allocating a string is unnecessary.
+		symbol := decbuf.UnsafeUvarintBytes()
 		if isLabelName(symbol) {
-			s.labelNameSymbols[uint32(i)] = symbol
+			s.labelNameSymbols[uint32(i)] = string(symbol)
 		}
 	}
 	if err := decbuf.Err(); err != nil {


### PR DESCRIPTION
Opening an index with the streaming reader took much longer than opening an index with the mmap reader. This was due to the streaming reader doing many more allocations, almost all of which came from Decbuf.UvarintStr, which is string(d.UnsafeUvarintBytes()).

Most of these allocations are completely unnecessary as the string is thrown away - we only keep a sparse offset table and label name symbols in memory. This change avoids those allocations.

Benchmark results:
```
                       │ before.txt  │              after.txt              │
                       │   sec/op    │   sec/op     vs base                │
NewStreamFileReader-12   202.7m ± 1%   153.0m ± 1%  -24.49% (p=0.000 n=10)

                       │  before.txt  │              after.txt               │
                       │     B/op     │     B/op      vs base                │
NewStreamFileReader-12   72.61Mi ± 0%   11.24Mi ± 1%  -84.52% (p=0.000 n=10)

                       │  before.txt   │              after.txt              │
                       │   allocs/op   │  allocs/op   vs base                │
NewStreamFileReader-12   6000.15k ± 0%   62.63k ± 0%  -98.96% (p=0.000 n=10)
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
