### PR TITLE
fix: Propagate response encoding flags to queriers when frontend.encoding is protobuf

### DIFF
--- a/pkg/querier/queryrange/marshal.go
+++ b/pkg/querier/queryrange/marshal.go
@@ -358,6 +358,11 @@ func (Codec) QueryRequestUnwrap(ctx context.Context, req *QueryRequest) (queryra
 		ctx = httpreq.InjectHeader(ctx, httpreq.LokiDisablePipelineWrappersHeader, disableWrappers)
 	}
 
+	// Add response encoding flags
+	if encodingFlags, ok := req.Metadata[httpreq.LokiEncodingFlagsHeader]; ok {
+		ctx = httpreq.InjectHeader(ctx, httpreq.LokiEncodingFlagsHeader, encodingFlags)
+	}
+
 	// Add limits
 	if encodedLimits, ok := req.Metadata[querylimits.HTTPHeaderQueryLimitsKey]; ok {
 		limits, err := querylimits.UnmarshalQueryLimits([]byte(encodedLimits))
@@ -482,6 +487,12 @@ func (Codec) QueryRequestWrap(ctx context.Context, r queryrangebase.Request) (*Q
 	disableWrappers := httpreq.ExtractHeader(ctx, httpreq.LokiDisablePipelineWrappersHeader)
 	if disableWrappers != "" {
 		result.Metadata[httpreq.LokiDisablePipelineWrappersHeader] = disableWrappers
+	}
+
+	// Keep response encoding flags
+	encodingFlags := httpreq.ExtractHeader(ctx, httpreq.LokiEncodingFlagsHeader)
+	if encodingFlags != "" {
+		result.Metadata[httpreq.LokiEncodingFlagsHeader] = encodingFlags
 	}
 
 	// Add limits

--- a/pkg/querier/queryrange/marshal_test.go
+++ b/pkg/querier/queryrange/marshal_test.go
@@ -1,8 +1,10 @@
 package queryrange
 
 import (
+	"context"
 	"testing"
 
+	"github.com/grafana/dskit/user"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
 
 func TestResultToResponse(t *testing.T) {
@@ -80,6 +83,44 @@ func TestResponseWrap(t *testing.T) {
 			require.IsType(t, tt.expected, actual.Response)
 		})
 	}
+}
+
+// TestQueryRequestWrapUnwrap_EncodingFlags pins the propagation of the
+// X-Loki-Response-Encoding-Flags header across the protobuf hop between the
+// query-frontend and the querier. Without it, `categorize-labels` never reaches
+// the querier's engine and the flag is a silent no-op on the default
+// (frontend.encoding: protobuf) path.
+func TestQueryRequestWrapUnwrap_EncodingFlags(t *testing.T) {
+	codec := Codec{}
+	req := &LokiRequest{Query: `{app="a"}`}
+	// QueryRequestWrap requires an org ID on the context.
+	baseCtx := user.InjectOrgID(context.Background(), "fake")
+
+	t.Run("propagates flags set on the frontend ctx", func(t *testing.T) {
+		ctx := httpreq.AddEncodingFlagsToContext(baseCtx,
+			httpreq.NewEncodingFlags(httpreq.FlagCategorizeLabels))
+
+		wrapped, err := codec.QueryRequestWrap(ctx, req)
+		require.NoError(t, err)
+		require.Equal(t, string(httpreq.FlagCategorizeLabels), wrapped.Metadata[httpreq.LokiEncodingFlagsHeader])
+
+		_, unwrappedCtx, err := codec.QueryRequestUnwrap(context.Background(), wrapped)
+		require.NoError(t, err)
+
+		flags := httpreq.ExtractEncodingFlagsFromCtx(unwrappedCtx)
+		require.True(t, flags.Has(httpreq.FlagCategorizeLabels),
+			"categorize-labels must reach the querier ctx, otherwise the engine never categorizes")
+	})
+
+	t.Run("no flags means no metadata entry", func(t *testing.T) {
+		wrapped, err := codec.QueryRequestWrap(baseCtx, req)
+		require.NoError(t, err)
+		require.NotContains(t, wrapped.Metadata, httpreq.LokiEncodingFlagsHeader)
+
+		_, unwrappedCtx, err := codec.QueryRequestUnwrap(context.Background(), wrapped)
+		require.NoError(t, err)
+		require.Nil(t, httpreq.ExtractEncodingFlagsFromCtx(unwrappedCtx))
+	})
 }
 
 // Benchmark_UnwrapSeries is the sibling Benchmark_CodecDecodeSeries.


### PR DESCRIPTION
`QueryRequestWrap`/`QueryRequestUnwrap` never copied `X-Loki-Response-Encoding-Flags` into `QueryRequest.Metadata`, so `categorize-labels` didn't reach the querier on the protobuf path. The httpgrpc path already propagated it in `DecodeHTTPGrpcRequest`.

Since `frontend.encoding` defaults to `protobuf`, this changes the response shape on a default config. Clients sending `categorize-labels` will start getting stream labels without structured metadata or parsed labels, and differently grouped streams. Grafana's Loki data source sends this header on every query; it switches parsers on the `encodingFlags` field we already echo in the response body, so it has been running its categorized parser against uncategorized data.

