### PR TITLE
fix(compactor): Skip completed jobs during timeout retries

### DIFF
--- a/pkg/compactor/jobqueue/queue.go
+++ b/pkg/compactor/jobqueue/queue.go
@@ -151,55 +151,75 @@ func (q *Queue) retryFailedJobs() {
 		case <-q.stop:
 			return
 		case <-ticker.C:
-			var jobsToRetry []string
-
-			q.processingJobsMtx.Lock()
-			now := time.Now()
-			for jobID, pj := range q.processingJobs {
-				if pj.attemptsLeft <= 0 {
-					level.Error(util_log.Logger).Log("msg", "job ran out of attempts, dropping it", "jobID", jobID)
-					q.metrics.jobsDropped.Inc()
-
-					delete(q.processingJobs, jobID)
-					continue
-				}
-				timeout := q.builders[pj.job.Type].jobTimeout
-				if pj.lastAttemptFailed || now.Sub(pj.dequeued) > timeout {
-					jobsToRetry = append(jobsToRetry, jobID)
-				}
-			}
-			q.processingJobsMtx.Unlock()
+			jobsToRetry := q.findJobsToRetry(time.Now())
 
 			for _, jobID := range jobsToRetry {
-				reason := "timeout"
-				q.processingJobsMtx.Lock()
-				pj := q.processingJobs[jobID]
-				if pj.lastAttemptFailed {
-					reason = "failed"
+				job, reason, ok := q.prepareJobForRetry(jobID)
+				if !ok {
+					continue
 				}
-
-				// reset the dequeued time so that the timeout is calculated from the time when the job is sent for processing.
-				q.processingJobs[jobID].dequeued = time.Now()
-				q.processingJobs[jobID].lastAttemptFailed = false
-				q.processingJobs[jobID].attemptsLeft--
-				q.processingJobsMtx.Unlock()
 
 				// Requeue the job
 				select {
 				case <-q.stop:
 					return
-				case q.queue <- pj.job:
+				case q.queue <- job:
 					q.metrics.jobRetries.WithLabelValues(reason).Inc()
 					level.Warn(util_log.Logger).Log(
 						"msg", "requeued job",
 						"job_id", jobID,
-						"job_type", pj.job.Type,
+						"job_type", job.Type,
 						"reason", reason,
 					)
 				}
 			}
 		}
 	}
+}
+
+func (q *Queue) findJobsToRetry(now time.Time) []string {
+	var jobsToRetry []string
+
+	q.processingJobsMtx.Lock()
+	defer q.processingJobsMtx.Unlock()
+
+	for jobID, pj := range q.processingJobs {
+		if pj.attemptsLeft <= 0 {
+			level.Error(util_log.Logger).Log("msg", "job ran out of attempts, dropping it", "jobID", jobID)
+			q.metrics.jobsDropped.Inc()
+
+			delete(q.processingJobs, jobID)
+			continue
+		}
+		timeout := q.builders[pj.job.Type].jobTimeout
+		if pj.lastAttemptFailed || now.Sub(pj.dequeued) > timeout {
+			jobsToRetry = append(jobsToRetry, jobID)
+		}
+	}
+
+	return jobsToRetry
+}
+
+func (q *Queue) prepareJobForRetry(jobID string) (*grpc.Job, string, bool) {
+	q.processingJobsMtx.Lock()
+	defer q.processingJobsMtx.Unlock()
+
+	pj, exists := q.processingJobs[jobID]
+	if !exists {
+		return nil, "", false
+	}
+
+	reason := "timeout"
+	if pj.lastAttemptFailed {
+		reason = "failed"
+	}
+
+	// Reset the dequeued time so that the timeout is calculated from the time when the job is sent for processing.
+	pj.dequeued = time.Now()
+	pj.lastAttemptFailed = false
+	pj.attemptsLeft--
+
+	return pj.job, reason, true
 }
 
 func (q *Queue) Loop(s grpc.JobQueue_LoopServer) error {

--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -291,6 +291,42 @@ func TestQueue_JobTimeout(t *testing.T) {
 	q.processingJobsMtx.RUnlock()
 }
 
+func TestQueue_TimeoutRetrySkipsCompletedJob(t *testing.T) {
+	q := newQueue(time.Hour, nil)
+	defer func() {
+		close(q.stop)
+		q.wg.Wait()
+	}()
+
+	require.NoError(t, q.RegisterBuilder(compactor_grpc.JOB_TYPE_DELETION, &mockBuilder{}, jobTimeout, jobRetries, nil))
+
+	job := &compactor_grpc.Job{
+		Id:   "test-job",
+		Type: compactor_grpc.JOB_TYPE_DELETION,
+	}
+
+	q.processingJobsMtx.Lock()
+	q.processingJobs[job.Id] = &processingJob{
+		job:          job,
+		dequeued:     time.Now().Add(-2 * jobTimeout),
+		attemptsLeft: 2,
+	}
+	q.processingJobsMtx.Unlock()
+
+	// Select the job for retry, then simulate a late successful response before retrying it.
+	jobsToRetry := q.findJobsToRetry(time.Now())
+	require.Equal(t, []string{job.Id}, jobsToRetry)
+	require.NoError(t, q.reportJobResult(&compactor_grpc.JobResult{
+		JobId:   job.Id,
+		JobType: job.Type,
+	}))
+
+	retriedJob, reason, ok := q.prepareJobForRetry(jobsToRetry[0])
+	require.False(t, ok)
+	require.Nil(t, retriedJob)
+	require.Empty(t, reason)
+}
+
 func TestQueue_Close(t *testing.T) {
 	q := NewQueue(nil)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The compactor job queue identifies timed-out jobs while holding `processingJobsMtx`, then releases and reacquires the lock before preparing each retry.

A late successful job result can remove a job from `processingJobs` between these two phases. The retry path previously assumed that the job still existed and dereferenced a nil `processingJob`, causing a panic.

This change rechecks whether the job still exists while preparing the retry.
If a successful result has already removed it, the retry is skipped.

The timeout scan and retry preparation are also split into helpers so the interleaving is covered by a deterministic regression test.

**Which issue(s) this PR fixes**:

N/A. No existing issue was found for this bug.

**Special notes for your reviewer**:

This does not change configuration, APIs, or the retry behavior of jobs that are still being processed.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.