### PR TITLE
test(logql): Assert structured metadata and parsed fields in the logqltest DSL

### DIFF
--- a/pkg/logql/internal/logqltest/README.md
+++ b/pkg/logql/internal/logqltest/README.md
@@ -78,10 +78,14 @@ eval select from <t0> to <t1> <forward|backward> <logql>
 - **Matrix** (range queries): one line per series, `{labels} <p0> <p1> …`, one point per step
   from `<t0>` to `<t1>`. Use `_` for a step with no point.
 - **Streams** (log-selection queries, e.g. `{app="foo"} |= "bar"`): one line per log entry,
-  `{labels} "<line>" @ <ts>` (or `` `<line>` `` for a raw line). Several lines sharing the same
-  `{labels}` belong to one stream and are checked as an exact, ordered sequence — a stream's line
-  order is meaningful (it follows the query direction), unlike the set of series in a
-  vector/matrix. Distinct label sets are compared as a set (order-independent), like series.
+  `{labels} "<line>" @ <ts>  [metadata key1="value1" …]  [parsed key1="value1" …]` (or
+  `` `<line>` `` for a raw line).
+  Several lines sharing the same `{labels}` belong to one stream and are checked as an exact,
+  ordered sequence — a stream's line order is meaningful (it follows the query direction), unlike
+  the set of series in a vector/matrix. Distinct label sets are compared as a set
+  (order-independent), like series.
+  `{labels}` holds the **stream labels alone**; the two optional clauses carry the other label
+  categories — see "Categorized labels" below.
 
 Point syntax (from promqltest):
 
@@ -91,13 +95,71 @@ Point syntax (from promqltest):
 - `<base>[±<step>]x<count>` — expands to `count+1` points: `2+3x2` → `2 5 8`; `1-1x2` → `1 0 -1`;
   `4x3` → `4 4 4 4`
 
-Label sets are compared as sets (order-independent). Note that Loki promotes **structured
-metadata into the result label set**, so a stream loaded with `[metadata detected_level="info"]`
-produces series labelled `{…, detected_level="info"}`.
+Label sets are compared as sets (order-independent). Note that a **metric** query promotes
+**structured metadata into the result label set**, so a stream loaded with
+`[metadata detected_level="info"]` produces series labelled `{…, detected_level="info"}`. A
+log-selection query does not — see "Structured Metadata and Parsed Fields" below.
 
 An **empty-value label is significant**: `{app="a", age=""}` asserts that `age` is present with an
 empty value (e.g. from a `json` expression whose path is missing, or `logfmt --keep-empty`), which is
 distinct from omitting `age` entirely.
+
+### Structured Metadata and Parsed Fields
+
+A LogQL label belongs to one of three categories: a **stream** label from the selector, a
+**structured metadata** label attached at ingest, or a **parsed** label a pipeline stage extracted.
+Log-selection results keep the three apart, so an expected line writes the stream labels in
+`{labels}` and pins the other two with an optional `[metadata …]` / `[parsed …]` clause — the same
+`key="value"` syntax as a `load` line's metadata, again with **literal square brackets**:
+
+```
+load
+  {app="a"} "boom" @ 10s [metadata lvl="error" trace_id="abc"]
+  {app="a"} "fine" @ 20s
+
+eval select from 0 to 30s forward {app="a"}
+  {app="a"} "boom" @ 10s [metadata lvl="error" trace_id="abc"]
+  {app="a"} "fine" @ 20s
+```
+
+- Each clause is the **complete** expected set for its category, compared order-independently. A
+  line written **without** a clause asserts the entry carries nothing in that category — so `"fine"`
+  above has no metadata, and neither line has a parsed label.
+- Both entries share one stream. Metadata stays out of the stream labels, so a high-cardinality
+  value like `trace_id` does not split the result into one stream per line.
+- Writing the categories apart is what catches a label that moves between them. `| label_format`
+  reads a metadata label and writes a **parsed** one:
+
+  ```
+  eval select from 0 to 30s forward {app="a"} | label_format level=lvl
+    {app="a"} "boom" @ 10s [metadata trace_id="abc"] [parsed level="error"]
+  ```
+
+  `lvl` has left the metadata and `level` has appeared in the parsed labels, while `{app="a"}` is
+  unchanged.
+- The clauses are ordered, `[metadata …]` before `[parsed …]`. The other way round is an error, not
+  a silently dropped clause.
+- An empty value is significant here too: `[metadata lvl=""]` asserts `lvl` is present and empty,
+  distinct from an absent `lvl`.
+- Both clauses are for `eval select` only; a metric query has no per-entry labels, and asserts
+  metadata through its result label set instead.
+
+Results only come back in categories because the harness **asks for them that way**. Every
+[execution stack](#execution-stacks) sends the `categorize-labels` response encoding flag
+(`X-Loki-Response-Encoding-Flags: categorize-labels`) on a query, which is what Grafana's Explore
+does — so these scripts assert the shape a Grafana user actually sees, not the plain-API default.
+
+Without the flag Loki merges all three categories into one label set: the example above would return
+`{app="a", lvl="error", trace_id="abc"}` and `{app="a"}` as **two** streams, with nothing on an entry
+to say which category a label came from. The flag is set in two places, since it is read twice:
+
+- The query-frontend stacks put it on the HTTP request *and* its context (`exec_query_frontend.go`).
+  The frontend's response encoder reads the header to write the categories into the JSON; the
+  querier reads the context copy — forwarded through `QueryRequestWrap` — to categorize at all.
+- The direct stack injects it straight into the engine's context (`exec_direct.go`), since it has no
+  frontend in front of it.
+
+The flag applies to log-selection queries only, so metric results are untouched.
 
 Every `eval` must assert exactly one kind of result — series, log streams, a scalar,
 `expect empty`, or `expect fail`; otherwise the harness errors (a forgotten expected block would
@@ -138,7 +200,6 @@ The direction only changes the order lines come back in, never which lines match
 bounds and the pipeline are unaffected. Expected lines within one stream are compared in the order
 they are written, so a `backward` block lists them newest first. Streams themselves are still
 compared as a set, and each is ordered independently.
-
 
 ### Empty results
 
@@ -208,8 +269,8 @@ eval instant at 60s some_query_with_a_nondeterministic_value({app="a"}[1m])
 
 - `<stack>` is the exact stack name, in double quotes.
 - The named stack still runs the query, must not error, and is still checked for series/stream
-  count, sample/line count, and timestamps. Only the float value comparison (or, for a
-  log-selection query, the log line text) is skipped.
+  count, sample/line count, timestamps, and categorized labels. Only the float value comparison
+  (or, for a log-selection query, the log line text) is skipped.
 
 A stack can have `skip values-comparison` or `expect values-toleration`, not both — they're
 contradictory ("don't compare" vs. "compare, loosely").
@@ -242,6 +303,9 @@ eval select from 0 to 60s forward {app="foo"} |= "status=200"
   {app="foo"} "level=info status=200" @ 30s
   {app="foo"} "level=info status=200" @ 40s
   {app="foo"} "level=info status=200" @ 50s
+
+eval select from 0 to 20s forward {app="bar"}
+  {app="bar"} "level=error status=500" @ 10s [metadata detected_level="error"]
 ```
 
 ## Scope

--- a/pkg/logql/internal/logqltest/README.md
+++ b/pkg/logql/internal/logqltest/README.md
@@ -146,8 +146,9 @@ eval select from 0 to 30s forward {app="a"}
 
 Results only come back in categories because the harness **asks for them that way**. Every
 [execution stack](#execution-stacks) sends the `categorize-labels` response encoding flag
-(`X-Loki-Response-Encoding-Flags: categorize-labels`) on a query, which is what Grafana's Explore
-does — so these scripts assert the shape a Grafana user actually sees, not the plain-API default.
+(`X-Loki-Response-Encoding-Flags: categorize-labels`) on a query, as Grafana's Loki datasource does
+on every data query — Explore, dashboards, and alerting alike. So these scripts assert the shape a
+Grafana user actually sees, not the plain-API default.
 
 Without the flag Loki merges all three categories into one label set: the example above would return
 `{app="a", lvl="error", trace_id="abc"}` and `{app="a"}` as **two** streams, with nothing on an entry

--- a/pkg/logql/internal/logqltest/exec_direct.go
+++ b/pkg/logql/internal/logqltest/exec_direct.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
 
 // directExecutionStack runs queries straight through the v1 engine, with no query-frontend in
@@ -58,6 +59,9 @@ func (s *directExecutionStack) eval(cmd evalCmd) (logqlmodel.Result, error) {
 	if err != nil {
 		return logqlmodel.Result{}, err
 	}
+
 	ctx := user.InjectOrgID(context.Background(), tenant)
+	// Add flag to categorize labels. This is mimicking standard behavior of our most important client: Grafana
+	ctx = httpreq.AddEncodingFlagsToContext(ctx, httpreq.NewEncodingFlags(httpreq.FlagCategorizeLabels))
 	return engine.Query(params).Exec(ctx)
 }

--- a/pkg/logql/internal/logqltest/exec_query_frontend.go
+++ b/pkg/logql/internal/logqltest/exec_query_frontend.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/scheduler/schedulerpb"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -249,7 +250,11 @@ func (s *queryFrontendExecutionStack) eval(cmd evalCmd) (logqlmodel.Result, erro
 	if err != nil {
 		return logqlmodel.Result{}, err
 	}
-	httpReq = httpReq.WithContext(userCtx)
+
+	// Add flag to categorize labels. This is mimicking standard behavior of our most important client: Grafana
+	flags := httpreq.NewEncodingFlags(httpreq.FlagCategorizeLabels)
+	httpreq.AddEncodingFlags(httpReq, flags)
+	httpReq = httpReq.WithContext(httpreq.AddEncodingFlagsToContext(userCtx, flags))
 
 	rec := httptest.NewRecorder()
 	s.handler.ServeHTTP(rec, httpReq)

--- a/pkg/logql/internal/logqltest/parser.go
+++ b/pkg/logql/internal/logqltest/parser.go
@@ -32,11 +32,12 @@ var (
 	reRange   = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+step\s+(\S+)\s+(.+)$`)
 	reSelect  = regexp.MustCompile(`^from\s+(\S+)\s+to\s+(\S+)\s+((?i:forward|backward))\s+(.+)$`)
 
-	// reAt, reRepeat and reMetadata are anchored to the head so each load-line directive matches
+	// reAt, reRepeat, reMetadata and reParsed are anchored to the head so each line directive matches
 	// only its own leading segment and can never reach into a later [metadata …] value.
 	reAt       = regexp.MustCompile(`^\s*@\s*(\S+)`)
 	reRepeat   = regexp.MustCompile(`^\s*\[repeat every\s+(\S+)\s+for\s+(\d+)\]`)
 	reMetadata = regexp.MustCompile(`^\s*\[metadata\s+(.*?)\]`)
+	reParsed   = regexp.MustCompile(`^\s*\[parsed\s+(.*?)\]`)
 
 	// reSkip matches a `skip <what> on "<stack>"` directive in an expectation block.
 	reSkip = regexp.MustCompile(`^skip\s+(\S+)\s+on\s+"([^"]+)"$`)
@@ -44,9 +45,9 @@ var (
 	// reValuesToleration matches an `expect values-toleration <epsilon> on "<stack>"` directive.
 	reValuesToleration = regexp.MustCompile(`^expect\s+values-toleration\s+(\S+)\s+on\s+"([^"]+)"$`)
 
-	// reMetadataKeyValue scans the key="value" pairs inside an already-extracted metadata block; it
-	// is intentionally not anchored.
-	reMetadataKeyValue = regexp.MustCompile(`(?:"([^"]*)"|([^\s"=]+))="([^"]*)"`)
+	// reKeyValuePairs scans the key="value" pairs inside an already-extracted [metadata …] or
+	// [parsed …] block; it is intentionally not anchored.
+	reKeyValuePairs = regexp.MustCompile(`(?:"([^"]*)"|([^\s"=]+))="([^"]*)"`)
 )
 
 type streamsParser struct {
@@ -177,31 +178,55 @@ func splitQuoted(s string) (text, rest string, err error) {
 }
 
 // parseMetadata extracts the optional `[metadata key="value" ...]` block, returning the parsed
-// metadata and `rest` with that block removed. A block that is present but malformed (e.g. an
-// unquoted value) is an error rather than silently dropped.
+// metadata and `rest` with that block removed.
 func parseMetadata(rest string) ([]logproto.LabelAdapter, string, error) {
-	m := reMetadata.FindStringSubmatch(rest)
+	metadata, rest, err := parseLabelClause(rest, reMetadata)
+	if err != nil {
+		return nil, rest, fmt.Errorf("[metadata ...]: %w", err)
+	}
+	return metadata, rest, nil
+}
+
+// parseParsed extracts the optional `[parsed key="value" ...]` block, returning the parsed labels
+// and `rest` with that block removed. Unlike metadata, parsed labels are produced by the query
+// pipeline rather than loaded, so this clause is valid only on an expectation line.
+func parseParsed(rest string) ([]logproto.LabelAdapter, string, error) {
+	parsed, rest, err := parseLabelClause(rest, reParsed)
+	if err != nil {
+		return nil, rest, fmt.Errorf("[parsed ...]: %w", err)
+	}
+	return parsed, rest, nil
+}
+
+// parseLabelClause extracts an optional `[<clause> key="value" ...]` block matched by re, returning
+// its labels and `rest` with that block removed. A block that is present but malformed (e.g. an
+// unquoted value) is an error rather than silently dropped.
+//
+// Errors name only what is wrong inside the block; the caller wraps them with the clause it was
+// reading.
+func parseLabelClause(rest string, re *regexp.Regexp) ([]logproto.LabelAdapter, string, error) {
+	m := re.FindStringSubmatch(rest)
 	if m == nil {
 		return nil, rest, nil
 	}
 	inner := strings.TrimSpace(m[1])
 	var out []logproto.LabelAdapter
-	for _, kv := range reMetadataKeyValue.FindAllStringSubmatch(inner, -1) {
+	for _, kv := range reKeyValuePairs.FindAllStringSubmatch(inner, -1) {
 		key := kv[1]
 		if key == "" {
 			key = kv[2]
 		}
 		if key == "" {
-			return nil, rest, fmt.Errorf("empty metadata key in %q", inner)
+			return nil, rest, fmt.Errorf("empty key in %q", inner)
 		}
 		out = append(out, logproto.LabelAdapter{Name: key, Value: kv[3]})
 	}
 	// Every token inside the block must be a key="value" pair; anything left over is malformed.
-	if leftover := strings.TrimSpace(reMetadataKeyValue.ReplaceAllString(inner, "")); leftover != "" {
-		return nil, rest, fmt.Errorf("invalid metadata %q: expected key=\"value\" pairs", inner)
+	if leftover := strings.TrimSpace(reKeyValuePairs.ReplaceAllString(inner, "")); leftover != "" {
+		return nil, rest, fmt.Errorf("invalid %q: expected key=\"value\" pairs", inner)
 	}
 	if len(out) == 0 {
-		return nil, rest, fmt.Errorf("empty [metadata ...] block")
+		return nil, rest, fmt.Errorf("block is empty")
 	}
 	return out, rest[len(m[0]):], nil
 }
@@ -374,10 +399,12 @@ type expectedSeries struct {
 }
 
 // expectedLogEntry is one expected log line within an expectedStream: its timestamp (as a
-// duration offset from the script epoch) and text.
+// duration offset from the script epoch), text, structured metadata, and parsed labels.
 type expectedLogEntry struct {
-	ts   time.Duration
-	line string
+	ts       time.Duration
+	line     string
+	metadata labels.Labels
+	parsed   labels.Labels
 }
 
 // expectedStream is one expected output log stream (for a log-selection query): its label set
@@ -476,11 +503,11 @@ func (p *expectationsParser) parse(line string) error {
 		}
 		p.exp.isValueComparisonSkipped[stack] = true
 	case strings.HasPrefix(line, "{") && isLogLine(line):
-		lbls, ts, text, err := parseLogLine(line)
+		lbls, entry, err := parseLogLine(line)
 		if err != nil {
 			return err
 		}
-		p.addLogEntry(lbls.String(), ts, text)
+		p.addLogEntry(lbls.String(), entry)
 	case strings.HasPrefix(line, "{"):
 		lbls, samples, err := parseSeriesLine(line)
 		if err != nil {
@@ -500,14 +527,14 @@ func (p *expectationsParser) parse(line string) error {
 // addLogEntry appends one expected log line to the stream keyed by labels, creating it on first
 // use. Streams are compared as a set (see compareStreams), so a linear scan to find the matching
 // stream is fine for the handful of expected lines a test script ever has.
-func (p *expectationsParser) addLogEntry(labels string, ts time.Duration, line string) {
+func (p *expectationsParser) addLogEntry(labels string, entry expectedLogEntry) {
 	for i := range p.exp.streams {
 		if p.exp.streams[i].labels == labels {
-			p.exp.streams[i].entries = append(p.exp.streams[i].entries, expectedLogEntry{ts: ts, line: line})
+			p.exp.streams[i].entries = append(p.exp.streams[i].entries, entry)
 			return
 		}
 	}
-	p.exp.streams = append(p.exp.streams, expectedStream{labels: labels, entries: []expectedLogEntry{{ts: ts, line: line}}})
+	p.exp.streams = append(p.exp.streams, expectedStream{labels: labels, entries: []expectedLogEntry{entry}})
 }
 
 // get returns the accumulated expectations.
@@ -556,39 +583,72 @@ func isLogLine(line string) bool {
 	return strings.HasPrefix(rest, `"`) || strings.HasPrefix(rest, "`")
 }
 
-// parseLogLine parses an expected log-stream result line: `{labels} "line" @ <ts>` (or a
-// backtick-delimited raw line). Mirrors the `load` line format (selector, quoted line,
-// timestamp), minus the load-only `[repeat ...]` / `[metadata ...]` clauses.
-func parseLogLine(line string) (labels.Labels, time.Duration, string, error) {
+// parseLogLine parses an expected log-stream result line:
+// `{labels} "line" @ <ts> [metadata key="value" ...] [parsed key="value" ...]` (or a
+// backtick-delimited raw line). Mirrors the `load` line format (selector, quoted line, timestamp,
+// metadata), minus the load-only `[repeat ...]` clause and plus the result-only `[parsed ...]`.
+func parseLogLine(line string) (labels.Labels, expectedLogEntry, error) {
+	var none expectedLogEntry
+
 	line = strings.TrimSpace(line)
 	end := strings.IndexByte(line, '}')
 	if end < 0 {
-		return labels.EmptyLabels(), 0, "", fmt.Errorf("unterminated label set")
+		return labels.EmptyLabels(), none, fmt.Errorf("unterminated label set")
 	}
 	lbls, err := parseSeriesLabels(line[:end+1])
 	if err != nil {
-		return labels.EmptyLabels(), 0, "", err
+		return labels.EmptyLabels(), none, err
 	}
 
 	text, rest, err := splitQuoted(line[end+1:])
 	if err != nil {
-		return labels.EmptyLabels(), 0, "", err
+		return labels.EmptyLabels(), none, err
 	}
 
 	m := reAt.FindStringSubmatch(rest)
 	if m == nil {
-		return labels.EmptyLabels(), 0, "", fmt.Errorf("missing '@ <ts>' timestamp")
+		return labels.EmptyLabels(), none, fmt.Errorf("missing '@ <ts>' timestamp")
 	}
 	ts, err := time.ParseDuration(m[1])
 	if err != nil {
-		return labels.EmptyLabels(), 0, "", fmt.Errorf("invalid timestamp %q: %w", m[1], err)
+		return labels.EmptyLabels(), none, fmt.Errorf("invalid timestamp %q: %w", m[1], err)
 	}
 	rest = rest[len(m[0]):]
 
-	if leftover := strings.TrimSpace(rest); leftover != "" {
-		return labels.EmptyLabels(), 0, "", fmt.Errorf("unexpected content after log line: %q", leftover)
+	// Consume the optional '[metadata key="value" ...]' clause.
+	metadata, rest, err := parseMetadata(rest)
+	if err != nil {
+		return labels.EmptyLabels(), none, err
 	}
-	return lbls, ts, text, nil
+
+	// Consume the optional '[parsed key="value" ...]' clause.
+	parsed, rest, err := parseParsed(rest)
+	if err != nil {
+		return labels.EmptyLabels(), none, err
+	}
+
+	if leftover := strings.TrimSpace(rest); leftover != "" {
+		return labels.EmptyLabels(), none, fmt.Errorf("unexpected content after log line: %q", leftover)
+	}
+	return lbls, expectedLogEntry{
+		ts:       ts,
+		line:     text,
+		metadata: sortedLabels(metadata),
+		parsed:   sortedLabels(parsed),
+	}, nil
+}
+
+// sortedLabels canonicalizes a categorized label set into sorted order, so an expectation and a
+// result compare independently of the order their pairs are written or returned in. Note that when
+// encoded in JSON, the order of labels is not guaranteed, so there is no meaningful output order from
+// the query frontend and sorting before comparing is valid. direct engine output may be assertable
+func sortedLabels(categorized []logproto.LabelAdapter) labels.Labels {
+	b := labels.NewScratchBuilder(len(categorized))
+	for _, l := range categorized {
+		b.Add(l.Name, l.Value)
+	}
+	b.Sort()
+	return b.Labels()
 }
 
 func parseSeriesLabels(s string) (labels.Labels, error) {

--- a/pkg/logql/internal/logqltest/parser_test.go
+++ b/pkg/logql/internal/logqltest/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -117,15 +118,16 @@ func TestParseMetadata(t *testing.T) {
 	}, md)
 	require.Equal(t, ` rest`, rest)
 
-	// Malformed or empty metadata is rejected, not silently dropped.
+	// Malformed or empty metadata is rejected, not silently dropped, and every message names the
+	// clause it was reading.
 	_, _, err = parseMetadata(`[metadata trace_id=abc]`) // unquoted value
-	require.Error(t, err)
+	require.ErrorContains(t, err, `[metadata ...]: invalid "trace_id=abc"`)
 	_, _, err = parseMetadata(`[metadata k="v" junk]`) // stray token
-	require.Error(t, err)
+	require.ErrorContains(t, err, `[metadata ...]: invalid `)
 	_, _, err = parseMetadata(`[metadata ]`) // empty block
-	require.Error(t, err)
+	require.ErrorContains(t, err, `[metadata ...]: block is empty`)
 	_, _, err = parseMetadata(`[metadata ""="v"]`) // empty key
-	require.Error(t, err)
+	require.ErrorContains(t, err, `[metadata ...]: empty key in `)
 }
 
 func TestStreamsParser_RejectsMalformedDirectives(t *testing.T) {
@@ -446,23 +448,76 @@ func TestIsLogLine(t *testing.T) {
 }
 
 func TestParseLogLine(t *testing.T) {
-	lbls, ts, text, err := parseLogLine(`{app="foo", env="prod"} "hello world" @ 90s`)
+	lbls, entry, err := parseLogLine(`{app="foo", env="prod"} "hello world" @ 90s`)
 	require.NoError(t, err)
 	require.Equal(t, `{app="foo", env="prod"}`, lbls.String())
-	require.Equal(t, 90*time.Second, ts)
-	require.Equal(t, "hello world", text)
+	require.Equal(t, 90*time.Second, entry.ts)
+	require.Equal(t, "hello world", entry.line)
+	// Without a `[metadata ...]` clause the line asserts the entry carries no structured metadata.
+	require.Equal(t, "{}", entry.metadata.String())
 
 	// A backtick raw line keeps its double quotes.
 	bt := "`"
-	_, _, text, err = parseLogLine(`{app="foo"} ` + bt + `{"a":"b"}` + bt + ` @ 0s`)
+	_, entry, err = parseLogLine(`{app="foo"} ` + bt + `{"a":"b"}` + bt + ` @ 0s`)
 	require.NoError(t, err)
-	require.Equal(t, `{"a":"b"}`, text)
+	require.Equal(t, `{"a":"b"}`, entry.line)
 
-	_, _, _, err = parseLogLine(`{app="foo"} "line"`) // missing timestamp
+	_, _, err = parseLogLine(`{app="foo"} "line"`) // missing timestamp
 	require.Error(t, err)
 
-	_, _, _, err = parseLogLine(`{app="foo"} "line" @ 0s trailing junk`)
+	_, _, err = parseLogLine(`{app="foo"} "line" @ 0s trailing junk`)
 	require.Error(t, err)
+}
+
+func TestParseLogLine_Metadata(t *testing.T) {
+	// A `[metadata ...]` clause is canonicalized to a sorted label set, so the order the pairs are
+	// written in does not matter.
+	lbls, entry, err := parseLogLine(`{app="foo", lvl="error"} "boom" @ 10s [metadata "svc name"="api" lvl="error"]`)
+	require.NoError(t, err)
+	require.Equal(t, `{app="foo", lvl="error"}`, lbls.String())
+	require.Equal(t, 10*time.Second, entry.ts)
+	require.Equal(t, "boom", entry.line)
+	require.Equal(t, `{lvl="error", "svc name"="api"}`, entry.metadata.String())
+
+	// An empty metadata value is significant: it asserts the key is present and empty.
+	_, entry, err = parseLogLine(`{app="foo", lvl=""} "x" @ 0s [metadata lvl=""]`)
+	require.NoError(t, err)
+	require.Equal(t, `{lvl=""}`, entry.metadata.String())
+
+	// A malformed clause is an error, not silently dropped.
+	_, _, err = parseLogLine(`{app="foo"} "x" @ 0s [metadata lvl=error]`) // unquoted value
+	require.Error(t, err)
+	_, _, err = parseLogLine(`{app="foo"} "x" @ 0s [metadata ]`) // empty block
+	require.Error(t, err)
+
+	// The load-only `[repeat ...]` clause is not accepted on an expectation line.
+	_, _, err = parseLogLine(`{app="foo"} "x" @ 0s [repeat every 10s for 3]`)
+	require.ErrorContains(t, err, "unexpected content after log line")
+}
+
+func TestParseLogLine_Parsed(t *testing.T) {
+	// Both clauses on one line: a categorized result keeps them apart from the stream labels.
+	_, entry, err := parseLogLine(`{app="foo"} "boom" @ 10s [metadata trace_id="abc"] [parsed msg="boom" level="error"]`)
+	require.NoError(t, err)
+	require.Equal(t, `{trace_id="abc"}`, entry.metadata.String())
+	require.Equal(t, `{level="error", msg="boom"}`, entry.parsed.String())
+
+	// `[parsed ...]` stands alone, and without it a line asserts the entry has no parsed labels.
+	_, entry, err = parseLogLine(`{app="foo"} "x" @ 0s [parsed level="error"]`)
+	require.NoError(t, err)
+	require.Equal(t, "{}", entry.metadata.String())
+	require.Equal(t, `{level="error"}`, entry.parsed.String())
+
+	// The clauses are ordered, metadata before parsed; the other way round is rejected rather than
+	// silently dropping one.
+	_, _, err = parseLogLine(`{app="foo"} "x" @ 0s [parsed level="error"] [metadata trace_id="abc"]`)
+	require.ErrorContains(t, err, "unexpected content after log line")
+
+	// A malformed clause is an error, and the message names the clause it was reading.
+	_, _, err = parseLogLine(`{app="foo"} "x" @ 0s [parsed level=error]`) // unquoted value
+	require.ErrorContains(t, err, `[parsed ...]: invalid "level=error"`)
+	_, _, err = parseLogLine(`{app="foo"} "x" @ 0s [parsed ]`)
+	require.ErrorContains(t, err, "[parsed ...]: block is empty")
 }
 
 func TestExpectationsParser_LogStreams(t *testing.T) {
@@ -474,12 +529,31 @@ func TestExpectationsParser_LogStreams(t *testing.T) {
 
 	require.Len(t, exp.streams, 2)
 	require.Equal(t, `{app="foo"}`, exp.streams[0].labels)
-	require.Equal(t, []expectedLogEntry{{ts: 0, line: "1st"}, {ts: 10 * time.Second, line: "2nd"}}, exp.streams[0].entries)
+	require.Equal(t, []expectedLogEntry{
+		{ts: 0, line: "1st", metadata: labels.EmptyLabels()},
+		{ts: 10 * time.Second, line: "2nd", metadata: labels.EmptyLabels()},
+	}, exp.streams[0].entries)
 	require.Equal(t, `{app="bar"}`, exp.streams[1].labels)
-	require.Equal(t, []expectedLogEntry{{ts: 5 * time.Second, line: "x"}}, exp.streams[1].entries)
+	require.Equal(t, []expectedLogEntry{{ts: 5 * time.Second, line: "x", metadata: labels.EmptyLabels()}}, exp.streams[1].entries)
 
 	// A malformed log line (missing timestamp) is surfaced, not silently dropped.
 	require.Error(t, newExpectationsParser().parse(`{app="foo"} "no timestamp"`))
+}
+
+func TestExpectationsParser_LogStreamsWithMetadata(t *testing.T) {
+	// Structured metadata joins the result label set, so an expected line repeats it in `{labels}`
+	// and pins its category with the `[metadata ...]` clause.
+	p := newExpectationsParser()
+	require.NoError(t, p.parse(`{app="foo", lvl="error"} "boom" @ 0s [metadata lvl="error"]`))
+	require.NoError(t, p.parse(`{app="foo", lvl="error"} "bang" @ 10s [metadata lvl="error"]`))
+	exp := p.get()
+
+	require.Len(t, exp.streams, 1)
+	require.Equal(t, `{app="foo", lvl="error"}`, exp.streams[0].labels)
+	require.Len(t, exp.streams[0].entries, 2)
+	for _, e := range exp.streams[0].entries {
+		require.Equal(t, `{lvl="error"}`, e.metadata.String())
+	}
 }
 
 func TestParseSeriesLabels(t *testing.T) {

--- a/pkg/logql/internal/logqltest/runner.go
+++ b/pkg/logql/internal/logqltest/runner.go
@@ -227,9 +227,9 @@ func consumeBlock(lines []string, i int, fn func(content string)) int {
 //
 // Each compare* function below self-guards against every other expectation kind (so it gives a
 // clear "expected X, got Y" error even when called directly, as the tests do). With skipValues
-// true the comparators check result shape only — series count, timestamps, and present/absent
-// samples (or log lines) — and skip value equality. Otherwise, values are compared within epsilon
-// (see floatsEqual).
+// true the comparators check result shape only — series count, timestamps, structured metadata,
+// and present/absent samples (or log lines) — and skip value equality. Otherwise, values are
+// compared within epsilon (see floatsEqual).
 func compareResult(name string, cmd evalCmd, exp expectations, data any, skipValues bool, epsilon float64) error {
 	switch v := data.(type) {
 	case promql.Scalar:
@@ -445,6 +445,10 @@ func compareMatrix(name string, cmd evalCmd, exp expectations, m promql.Matrix, 
 // matched as a set keyed by label string (like vector/matrix series); the log lines within a
 // matched stream are compared as an exact, ordered sequence, since a stream's line order is
 // meaningful (chronological, per the query direction) rather than incidental.
+//
+// Every stack runs a log-selection query with the `categorize-labels` response encoding, so a
+// result stream's labels are its stream labels alone and each line carries its own structured
+// metadata and parsed labels. Both categories are compared per line.
 func compareStreams(name string, exp expectations, got logqlmodel.Streams, skipValues bool) error {
 	if exp.scalar != nil {
 		return fmt.Errorf("%s: expected a scalar, got log streams", name)
@@ -485,6 +489,16 @@ func compareStreams(name string, exp expectations, got logqlmodel.Streams, skipV
 			wantTS := epoch.Add(we.ts).UnixMilli()
 			if gotTS := ge.Timestamp.UnixMilli(); gotTS != wantTS {
 				return fmt.Errorf("%s: stream %s line %d has timestamp %dms, expected %dms", name, lbls, i, gotTS, wantTS)
+			}
+			// A categorized label is part of an entry's identity, not its value, so both categories
+			// are checked even on a stack whose value comparison is skipped.
+			wantMetadata, gotMetadata := we.metadata.String(), sortedLabels(ge.StructuredMetadata).String()
+			if gotMetadata != wantMetadata {
+				return fmt.Errorf("%s: stream %s line %d structured metadata mismatch: want %s, got %s", name, lbls, i, wantMetadata, gotMetadata)
+			}
+			wantParsed, gotParsed := we.parsed.String(), sortedLabels(ge.Parsed).String()
+			if gotParsed != wantParsed {
+				return fmt.Errorf("%s: stream %s line %d parsed labels mismatch: want %s, got %s", name, lbls, i, wantParsed, gotParsed)
 			}
 			if !skipValues && ge.Line != we.line {
 				return fmt.Errorf("%s: stream %s line %d mismatch: want %q, got %q", name, lbls, i, we.line, ge.Line)

--- a/pkg/logql/internal/logqltest/runner_test.go
+++ b/pkg/logql/internal/logqltest/runner_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/loki/pkg/push"
 
+	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
@@ -271,6 +272,51 @@ func TestComparators_DetectMismatches(t *testing.T) {
 			}, false),
 			want: `stream {app="a"} has 1 lines, expected 2`,
 		},
+		"streams unexpected structured metadata": {
+			// A line with no `[metadata ...]` clause asserts the entry carries no metadata.
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("a", clauseAdapters("lvl", "error"), nil)}},
+			}, false),
+			want: `stream {app="a"} line 0 structured metadata mismatch: want {}, got {lvl="error"}`,
+		},
+		"streams missing structured metadata": {
+			err: compareStreams("n", oneStreamWithMetadata("a", "lvl", "error"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("a", nil, nil)}},
+			}, false),
+			want: `stream {app="a"} line 0 structured metadata mismatch: want {lvl="error"}, got {}`,
+		},
+		"streams structured metadata value mismatch": {
+			err: compareStreams("n", oneStreamWithMetadata("a", "lvl", "error"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("a", clauseAdapters("lvl", "info"), nil)}},
+			}, false),
+			want: `structured metadata mismatch: want {lvl="error"}, got {lvl="info"}`,
+		},
+		"streams structured metadata mis-categorized as parsed": {
+			// Both categories carry the same pair, so only comparing them apart tells the two results
+			// apart — this is the mistake `| label_format` can make.
+			err: compareStreams("n", oneStreamWithMetadata("a", "lvl", "error"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("a", nil, clauseAdapters("lvl", "error"))}},
+			}, false),
+			want: `structured metadata mismatch: want {lvl="error"}, got {}`,
+		},
+		"streams unexpected parsed label": {
+			err: compareStreams("n", oneStream("a"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("a", nil, clauseAdapters("lvl", "error"))}},
+			}, false),
+			want: `stream {app="a"} line 0 parsed labels mismatch: want {}, got {lvl="error"}`,
+		},
+		"streams parsed label value mismatch": {
+			err: compareStreams("n", oneStreamWithParsed("a", "lvl", "error"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("a", nil, clauseAdapters("lvl", "info"))}},
+			}, false),
+			want: `parsed labels mismatch: want {lvl="error"}, got {lvl="info"}`,
+		},
+		"streams parsed label mis-categorized as metadata": {
+			err: compareStreams("n", oneStreamWithParsed("a", "lvl", "error"), logqlmodel.Streams{
+				{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("a", clauseAdapters("lvl", "error"), nil)}},
+			}, false),
+			want: `structured metadata mismatch: want {}, got {lvl="error"}`,
+		},
 		"streams duplicate expected stream": {
 			err: compareStreams("n", expectations{streams: []expectedStream{
 				{labels: `{app="a"}`, entries: []expectedLogEntry{{ts: 0, line: "a"}}},
@@ -361,6 +407,16 @@ func TestComparators_AcceptMatches(t *testing.T) {
 			{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "1st"}, {Timestamp: epoch.Add(time.Second), Line: "2nd"}}},
 		}, false))
 	require.NoError(t, compareResult("n", evalCmd{mode: evalInstant, ts: time.Minute}, expectations{empty: true}, logqlmodel.Streams{}, false, defaultEpsilon))
+
+	// A `[metadata ...]` expectation matches whatever order the pairs come back in.
+	require.NoError(t, compareStreams("n",
+		expectations{streams: []expectedStream{{
+			labels:  `{app="a", lvl="error", pod="p1"}`,
+			entries: []expectedLogEntry{{ts: 0, line: "x", metadata: labels.FromStrings("lvl", "error", "pod", "p1")}},
+		}}},
+		logqlmodel.Streams{{Labels: `{app="a", lvl="error", pod="p1"}`, Entries: []push.Entry{
+			gotEntry("x", []logproto.LabelAdapter{{Name: "pod", Value: "p1"}, {Name: "lvl", Value: "error"}}, nil),
+		}}}, false))
 }
 
 func TestComparators_SkipValues(t *testing.T) {
@@ -405,6 +461,13 @@ func TestComparators_SkipValues(t *testing.T) {
 		}}, logqlmodel.Streams{
 			{Labels: `{app="a"}`, Entries: []push.Entry{{Timestamp: epoch, Line: "a"}}},
 		}, true), "has 1 lines, expected 2")
+	})
+
+	t.Run("structured metadata mismatches still error", func(t *testing.T) {
+		// Metadata identifies an entry rather than valuing it, so it is checked even here.
+		require.ErrorContains(t, compareStreams("n", oneStream("a"), logqlmodel.Streams{
+			{Labels: `{app="a"}`, Entries: []push.Entry{gotEntry("wrong line", clauseAdapters("lvl", "error"), nil)}},
+		}, true), `structured metadata mismatch: want {}, got {lvl="error"}`)
 	})
 
 	t.Run("timestamp mismatches still error", func(t *testing.T) {
@@ -458,6 +521,33 @@ func TestEffectiveEpsilon(t *testing.T) {
 	// inheriting a toleration meant for a different stack.
 	require.Equal(t, defaultEpsilon, effectiveEpsilon(exp, queryFrontendShardStackName))
 	require.Equal(t, defaultEpsilon, effectiveEpsilon(expectations{}, directStackName))
+}
+
+// oneStreamWithMetadata builds a single-stream, single-line expectation carrying one structured
+// metadata pair. A categorized result keeps metadata out of the stream labels, so the label set
+// stays the bare `{app="a"}`.
+func oneStreamWithMetadata(line, key, value string) expectations {
+	return expectations{streams: []expectedStream{{
+		labels:  `{app="a"}`,
+		entries: []expectedLogEntry{{ts: 0, line: line, metadata: labels.FromStrings(key, value)}},
+	}}}
+}
+
+// oneStreamWithParsed builds the same shape carrying one parsed label instead.
+func oneStreamWithParsed(line, key, value string) expectations {
+	return expectations{streams: []expectedStream{{
+		labels:  `{app="a"}`,
+		entries: []expectedLogEntry{{ts: 0, line: line, parsed: labels.FromStrings(key, value)}},
+	}}}
+}
+
+// gotEntry builds a result entry at the script epoch with the given categorized labels.
+func gotEntry(line string, structuredMetadata, parsed []logproto.LabelAdapter) push.Entry {
+	return push.Entry{Timestamp: epoch, Line: line, StructuredMetadata: structuredMetadata, Parsed: parsed}
+}
+
+func clauseAdapters(key, value string) []logproto.LabelAdapter {
+	return []logproto.LabelAdapter{{Name: key, Value: value}}
 }
 
 func TestFloatsEqual(t *testing.T) {

--- a/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
+++ b/pkg/logql/internal/logqltest/syntax/logqltest.tmLanguage.json
@@ -145,13 +145,15 @@
     },
 
     "result-expectation": {
-      "comment": "A series line (`{labels} p0 p1 ...`) or a log-stream line (`{labels} \"line\" @ ts`); both start with a label set, so both token kinds are included here.",
+      "comment": "A series line (`{labels} p0 p1 ...`) or a log-stream line (`{labels} \"line\" @ ts [metadata k=\"v\"] [parsed k=\"v\"]`); both start with a label set, so both token kinds are included here.",
       "name": "meta.expectation.result.logqltest",
       "begin": "^[ \\t]*(?=\\{)",
       "end": "$",
       "patterns": [
         { "include": "#label-set" },
         { "include": "#comment" },
+        { "include": "#metadata-clause" },
+        { "include": "#parsed-clause" },
         { "include": "#at-clause" },
         { "include": "#log-line" },
         { "include": "#raw-log-line" },
@@ -236,6 +238,30 @@
           "match": "[^\\s\\]]+",
           "name": "constant.numeric.duration.logqltest"
         }
+      ]
+    },
+
+    "parsed-clause": {
+      "comment": "A `[parsed key=\"value\" ...]` clause on a log-stream expectation line. Result-only: parsed labels come from the query pipeline, so `load` never writes one.",
+      "name": "meta.clause.parsed.logqltest",
+      "begin": "(\\[)[ \\t]*(parsed)\\b",
+      "beginCaptures": {
+        "1": { "name": "punctuation.section.brackets.begin.logqltest" },
+        "2": { "name": "keyword.other.parsed.logqltest" }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": { "name": "punctuation.section.brackets.end.logqltest" }
+      },
+      "patterns": [
+        {
+          "match": "(\"[^\"]*\"|[^\\s\"=\\]]+)[ \\t]*(=)",
+          "captures": {
+            "1": { "name": "entity.other.attribute-name.logqltest" },
+            "2": { "name": "keyword.operator.assignment.logqltest" }
+          }
+        },
+        { "include": "#log-line" }
       ]
     },
 

--- a/pkg/logql/internal/logqltest/testdata/AGENTS.md
+++ b/pkg/logql/internal/logqltest/testdata/AGENTS.md
@@ -159,11 +159,6 @@ eval select from 0 to 30s forward {app="a"} | label_format level=lvl
   {app="a"} "boom" @ 10s [metadata trace_id="abc"] [parsed level="error"]
 ```
 
-Cover the stages that move a label between categories — `label_format`, `drop`, `keep`, and a
-parser that re-extracts a metadata name. Note metadata is *not* in the stream labels here, so
-entries that differ only in a metadata value stay in one stream, unlike the series a metric query
-would produce from them.
-
 ## Files
 
 One feature per file: `range_aggregations`, `vector_aggregations`, `binary_operations`,

--- a/pkg/logql/internal/logqltest/testdata/AGENTS.md
+++ b/pkg/logql/internal/logqltest/testdata/AGENTS.md
@@ -148,6 +148,22 @@ Every `eval select` states a `forward` or `backward` direction, and expected lin
 stream are compared **in that order** — oldest first under `forward`, newest first under
 `backward`.
 
+**A log-selection result keeps the three label categories apart.** `{labels}` is the stream labels
+alone; structured metadata and parsed labels go in the `[metadata …]` and `[parsed …]` clauses.
+Each clause is the complete set for its category, so a line without one asserts the entry carries
+nothing there. Write both whenever the query or the loaded streams produce them:
+
+```
+# lvl was metadata; label_format makes `level` a parsed label, so only trace_id stays metadata.
+eval select from 0 to 30s forward {app="a"} | label_format level=lvl
+  {app="a"} "boom" @ 10s [metadata trace_id="abc"] [parsed level="error"]
+```
+
+Cover the stages that move a label between categories — `label_format`, `drop`, `keep`, and a
+parser that re-extracts a metadata name. Note metadata is *not* in the stream labels here, so
+entries that differ only in a metadata value stay in one stream, unlike the series a metric query
+would produce from them.
+
 ## Files
 
 One feature per file: `range_aggregations`, `vector_aggregations`, `binary_operations`,

--- a/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/log_selection.logqltest
@@ -85,3 +85,46 @@ eval select from 0 to 40s backward {app="foo"} |~ "1st|3rd"
 # A selector matching nothing returns no streams, whichever direction it is read in.
 eval select from 0 to 40s backward {app="missing"}
   expect empty
+
+#
+# Structured metadata and parsed fields smoke test
+#
+clear
+load
+  {app="foo"} "with metadata" @ 10s [metadata lvl="error" trace_id="abc"]
+  {app="foo"} "no metadata"   @ 20s
+
+# Both entries belong to one stream: the metadata stays out of the stream labels.
+eval select from 0 to 30s forward {app="foo"}
+  {app="foo"} "with metadata" @ 10s [metadata lvl="error" trace_id="abc"]
+  {app="foo"} "no metadata"   @ 20s
+
+# A metadata label filter drops the entries that don't match, and keeps the metadata on the rest.
+eval select from 0 to 30s forward {app="foo"} | lvl="error"
+  {app="foo"} "with metadata" @ 10s [metadata lvl="error" trace_id="abc"]
+
+# `drop` removes a metadata label from the entry.
+eval select from 0 to 30s forward {app="foo"} | drop lvl
+  {app="foo"} "with metadata" @ 10s [metadata trace_id="abc"]
+  {app="foo"} "no metadata"   @ 20s
+
+# `label_format` re-categorizes: `level` is a parsed label, so `lvl` leaves the metadata.
+eval select from 0 to 30s forward {app="foo"} | label_format level=lvl
+  {app="foo"} "with metadata" @ 10s [metadata trace_id="abc"] [parsed level="error"]
+  {app="foo"} "no metadata"   @ 20s
+
+# A parser puts each field it extracts in the parsed category, beside the untouched metadata.
+clear
+load
+  {app="foo"} "lvl=error msg=boom" @ 10s [metadata trace_id="abc"]
+
+eval select from 0 to 30s forward {app="foo"} | logfmt
+  {app="foo"} "lvl=error msg=boom" @ 10s [metadata trace_id="abc"] [parsed lvl="error" msg="boom"]
+
+# An empty metadata value is significant: it is present, and distinct from an absent label.
+clear
+load
+  {app="foo"} "x" @ 10s [metadata lvl=""]
+
+eval select from 0 to 30s forward {app="foo"}
+  {app="foo"} "x" @ 10s [metadata lvl=""]


### PR DESCRIPTION
Adds optional `[metadata key="value" ...]` and `[parsed key="value" ...]` clauses to `eval select` expected log lines. Each clause is the complete expected set for its category, so a line without one asserts the entry carries nothing there.

Every execution stack now pins the `categorize-labels` encoding flag (`X-Loki-Response-Encoding-Flags: categorize-labels`), which is what Grafana sends. Log-selection results therefore come back categorized: `{labels}` is the stream labels alone, and metadata and parsed fields sit on the entry.

Pinning it rather than taking the API default is deliberate:

- Without the flag all three categories merge into one label set, so there is nothing on an entry for `[metadata ...]` / `[parsed ...]` to assert against.
- The merged shape also splits a result into one stream per distinct metadata combination — with something like `trace_id`, one stream per log line. Categorized keeps them in a single stream, which is what a Grafana user actually sees.
- The most important client always sends this header and pinning this behavior is critical.

The flag applies to log-selection queries only, so metric scripts are unaffected.