### PR TITLE
fix(tail): Reject tail queries with invalid pipeline stages before upgrading the websocket

### DIFF
--- a/pkg/querier/tail/http.go
+++ b/pkg/querier/tail/http.go
@@ -1,6 +1,7 @@
 package tail
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -12,6 +13,8 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	loghttp_legacy "github.com/grafana/loki/v3/pkg/loghttp/legacy"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
@@ -32,6 +35,17 @@ func (q *Querier) TailHandler(w http.ResponseWriter, r *http.Request) {
 
 	req, err := loghttp.ParseTailQuery(r)
 	if err != nil {
+		serverutil.WriteError(httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error()), w)
+		return
+	}
+
+	// ParseTailQuery only validates the label matchers. Build the pipeline up
+	// front as well: a query whose pipeline stages can't be compiled (e.g. an
+	// invalid regexp in a line filter) is rejected by the ingesters after the
+	// websocket upgrade, and since the ingesters reject it on every reconnect
+	// the client hangs on an open connection that only receives pings. Fail
+	// with a 400 before upgrading, just like query_range does.
+	if err := validateTailQuery(req); err != nil {
 		serverutil.WriteError(httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error()), w)
 		return
 	}
@@ -144,4 +158,18 @@ func (q *Querier) TailHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// validateTailQuery compiles the pipeline stages of a parsed tail query so
+// that queries the ingesters will reject are refused before the websocket
+// upgrade. ParseTailQuery only validates label matchers; pipeline stages are
+// compiled lazily on the ingester side, which is too late to tell the HTTP
+// client about it.
+func validateTailQuery(req *logproto.TailRequest) error {
+	expr, ok := req.Plan.AST.(syntax.LogSelectorExpr)
+	if !ok {
+		return fmt.Errorf("unsupported query expression: want (LogSelectorExpr), got (%T)", req.Plan.AST)
+	}
+	_, err := expr.Pipeline()
+	return err
 }

--- a/pkg/querier/tail/http_test.go
+++ b/pkg/querier/tail/http_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -39,6 +42,60 @@ func TestTailHandler(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 	require.Equal(t, "multiple org IDs present", rr.Body.String())
+}
+
+func TestTailHandlerRejectsInvalidPipelineRegexpBeforeUpgrade(t *testing.T) {
+	defaultLimits := defaultLimitsTestConfig()
+	limits, err := validation.NewOverrides(defaultLimits, nil)
+	require.NoError(t, err)
+
+	tailQuerier := NewQuerier(nil, nil, nil, limits, 1*time.Minute, NewMetrics(nil), log.NewNopLogger())
+
+	req, err := http.NewRequest("GET", `/`, nil)
+	require.NoError(t, err)
+	q := req.URL.Query()
+	q.Add("query", `{app="loki"} |~ "GET("`)
+	req.URL.RawQuery = q.Encode()
+	err = req.ParseForm()
+	require.NoError(t, err)
+
+	ctx := user.InjectOrgID(req.Context(), "fake")
+	req = req.WithContext(ctx)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(tailQuerier.TailHandler)
+
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "error parsing regexp")
+}
+
+func TestValidateTailQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{name: "matchers only", query: `{app="loki"}`},
+		{name: "valid line filter regexp", query: `{app="loki"} |~ "GET /"`},
+		{name: "invalid line filter regexp", query: `{app="loki"} |~ "GET("`, wantErr: "error parsing regexp"},
+		{name: "non-selector expression", query: `rate({app="loki"}[5m])`, wantErr: "unsupported query expression"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := syntax.ParseExpr(tc.query)
+			require.NoError(t, err)
+
+			req := &logproto.TailRequest{Plan: &plan.QueryPlan{AST: parsed}}
+			err = validateTailQuery(req)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }
 
 func defaultLimitsTestConfig() validation.Limits {

--- a/pkg/querier/tail/tail.go
+++ b/pkg/querier/tail/tail.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/grafana/loki/v3/pkg/iter"
 	loghttp "github.com/grafana/loki/v3/pkg/loghttp/legacy"
@@ -208,6 +210,18 @@ func (t *Tailer) dropTailClient(addr string) {
 	delete(t.querierTailClients, addr)
 }
 
+// stopAndSignal marks the tailer as stopped and pushes a fatal error to the
+// closeErrChan, so the tail handler can relay it to the client and tear the
+// connection down. The send must not block: the handler may already be gone
+// (e.g. the client disconnected), in which case the error is simply dropped.
+func (t *Tailer) stopAndSignal(err error) {
+	t.stopped.Store(true)
+	select {
+	case t.closeErrChan <- err:
+	default:
+	}
+}
+
 // keeps reading streams from grpc connection with ingesters
 func (t *Tailer) readTailClient(addr string, querierTailClient logproto.Querier_TailClient) {
 	var resp *logproto.TailResponse
@@ -228,6 +242,13 @@ func (t *Tailer) readTailClient(addr string, querierTailClient logproto.Querier_
 			// We don't want to log error when its due to stopping the tail request
 			if !stopped {
 				level.Error(logger).Log("msg", "Error receiving response from grpc tail client", "err", err)
+				// The ingester rejected the query itself (for example a pipeline
+				// stage it couldn't compile). Reconnecting will hit the same error
+				// forever and leave the client hanging on an open websocket, so
+				// surface the error and stop tailing instead of retrying.
+				if status.Code(err) == codes.InvalidArgument {
+					t.stopAndSignal(err)
+				}
 			}
 			break
 		}

--- a/pkg/querier/tail/tail.go
+++ b/pkg/querier/tail/tail.go
@@ -242,11 +242,16 @@ func (t *Tailer) readTailClient(addr string, querierTailClient logproto.Querier_
 			// We don't want to log error when its due to stopping the tail request
 			if !stopped {
 				level.Error(logger).Log("msg", "Error receiving response from grpc tail client", "err", err)
-				// The ingester rejected the query itself (for example a pipeline
-				// stage it couldn't compile). Reconnecting will hit the same error
-				// forever and leave the client hanging on an open websocket, so
-				// surface the error and stop tailing instead of retrying.
-				if status.Code(err) == codes.InvalidArgument {
+				// The ingester rejects an invalid query (for example a pipeline
+				// stage it couldn't compile) with a client error, but that error
+				// crosses the gRPC boundary wrapped by ClientGrpcStatusAndError,
+				// so it arrives as an httpgrpc status whose code is the HTTP
+				// status (400 for query errors), not codes.InvalidArgument. A 4xx
+				// here means the caller is at fault and reconnecting would hit
+				// the same rejection forever, leaving the client hanging on an
+				// open websocket, so surface the error and stop tailing instead
+				// of retrying.
+				if code := status.Code(err); code == codes.InvalidArgument || int(code)/100 == 4 {
 					t.stopAndSignal(err)
 				}
 			}

--- a/pkg/querier/tail/tail_test.go
+++ b/pkg/querier/tail/tail_test.go
@@ -1,10 +1,12 @@
 package tail
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -178,35 +180,50 @@ func TestTailer(t *testing.T) {
 func TestTailerStopsWhenIngesterRejectsQuery(t *testing.T) {
 	t.Parallel()
 
-	client := newTailClientMock()
-	client.On("Recv").Return((*logproto.TailResponse)(nil), status.Error(codes.InvalidArgument, `parse error : stage '|~ "GET("' : error parsing regexp: missing closing )`))
+	// The ingester wraps tail errors with ClientGrpcStatusAndError, so a query
+	// rejection reaches the querier as an httpgrpc error whose code is the HTTP
+	// status (400), not codes.InvalidArgument. Cover both shapes.
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "httpgrpc bad request", err: httpgrpc.Errorf(http.StatusBadRequest, `parse error : stage '|~ "GET("' : error parsing regexp: missing closing )`)},
+		{name: "raw invalid argument", err: status.Error(codes.InvalidArgument, `parse error : stage '|~ "GET("' : error parsing regexp: missing closing )`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	var reconnectCalls atomic.Int32
-	tailDisconnectedIngesters := func([]string) (map[string]logproto.Querier_TailClient, error) {
-		reconnectCalls.Inc()
-		return map[string]logproto.Querier_TailClient{}, nil
+			client := newTailClientMock()
+			client.On("Recv").Return((*logproto.TailResponse)(nil), tc.err)
+
+			var reconnectCalls atomic.Int32
+			tailDisconnectedIngesters := func([]string) (map[string]logproto.Querier_TailClient, error) {
+				reconnectCalls.Inc()
+				return map[string]logproto.Querier_TailClient{}, nil
+			}
+
+			tailer := newTailer(0, map[string]logproto.Querier_TailClient{"test": client}, testutil.NewFakeStreamIterator(0, 0), tailDisconnectedIngesters, timeout, throttle, false, NewMetrics(nil), log.NewNopLogger())
+			defer tailer.close()
+
+			select {
+			case err := <-tailer.getCloseErrorChan():
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "error parsing regexp")
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for the tailer to surface the ingester error")
+			}
+
+			require.Eventually(t, tailer.stopped.Load, 2*time.Second, 10*time.Millisecond)
+
+			// The ingester rejects the query for good, so the tailer must not keep
+			// reconnecting. Give any in-flight reconnect attempt a moment to land,
+			// then require that the retry loop has stopped.
+			time.Sleep(50 * time.Millisecond)
+			final := reconnectCalls.Load()
+			time.Sleep(100 * time.Millisecond)
+			require.Equal(t, final, reconnectCalls.Load())
+		})
 	}
-
-	tailer := newTailer(0, map[string]logproto.Querier_TailClient{"test": client}, testutil.NewFakeStreamIterator(0, 0), tailDisconnectedIngesters, timeout, throttle, false, NewMetrics(nil), log.NewNopLogger())
-	defer tailer.close()
-
-	select {
-	case err := <-tailer.getCloseErrorChan():
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "error parsing regexp")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for the tailer to surface the ingester error")
-	}
-
-	require.Eventually(t, tailer.stopped.Load, 2*time.Second, 10*time.Millisecond)
-
-	// The ingester rejects the query for good, so the tailer must not keep
-	// reconnecting. Give any in-flight reconnect attempt a moment to land,
-	// then require that the retry loop has stopped.
-	time.Sleep(50 * time.Millisecond)
-	final := reconnectCalls.Load()
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, final, reconnectCalls.Load())
 }
 
 func TestTailerKeepsReconnectingOnTransientIngesterError(t *testing.T) {

--- a/pkg/querier/tail/tail_test.go
+++ b/pkg/querier/tail/tail_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gotest.tools/assert"
 
 	"github.com/grafana/loki/v3/pkg/iter"
@@ -170,6 +173,64 @@ func TestTailer(t *testing.T) {
 			test.tester(t, tailer, test.tailClient)
 		})
 	}
+}
+
+func TestTailerStopsWhenIngesterRejectsQuery(t *testing.T) {
+	t.Parallel()
+
+	client := newTailClientMock()
+	client.On("Recv").Return((*logproto.TailResponse)(nil), status.Error(codes.InvalidArgument, `parse error : stage '|~ "GET("' : error parsing regexp: missing closing )`))
+
+	var reconnectCalls atomic.Int32
+	tailDisconnectedIngesters := func([]string) (map[string]logproto.Querier_TailClient, error) {
+		reconnectCalls.Inc()
+		return map[string]logproto.Querier_TailClient{}, nil
+	}
+
+	tailer := newTailer(0, map[string]logproto.Querier_TailClient{"test": client}, testutil.NewFakeStreamIterator(0, 0), tailDisconnectedIngesters, timeout, throttle, false, NewMetrics(nil), log.NewNopLogger())
+	defer tailer.close()
+
+	select {
+	case err := <-tailer.getCloseErrorChan():
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error parsing regexp")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the tailer to surface the ingester error")
+	}
+
+	require.Eventually(t, tailer.stopped.Load, 2*time.Second, 10*time.Millisecond)
+
+	// The ingester rejects the query for good, so the tailer must not keep
+	// reconnecting. Give any in-flight reconnect attempt a moment to land,
+	// then require that the retry loop has stopped.
+	time.Sleep(50 * time.Millisecond)
+	final := reconnectCalls.Load()
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, final, reconnectCalls.Load())
+}
+
+func TestTailerKeepsReconnectingOnTransientIngesterError(t *testing.T) {
+	t.Parallel()
+
+	client := newTailClientMock()
+	client.On("Recv").Return((*logproto.TailResponse)(nil), status.Error(codes.Unavailable, "connection refused"))
+
+	var reconnectCalls atomic.Int32
+	tailDisconnectedIngesters := func([]string) (map[string]logproto.Querier_TailClient, error) {
+		reconnectCalls.Inc()
+		return map[string]logproto.Querier_TailClient{}, nil
+	}
+
+	tailer := newTailer(0, map[string]logproto.Querier_TailClient{"test": client}, testutil.NewFakeStreamIterator(0, 0), tailDisconnectedIngesters, timeout, throttle, false, NewMetrics(nil), log.NewNopLogger())
+	defer tailer.close()
+
+	// A transient error must not stop the tailer: the querier keeps trying to
+	// reconnect so a recovered ingester is picked up again.
+	require.Eventually(t, func() bool {
+		return reconnectCalls.Load() > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.False(t, tailer.stopped.Load())
 }
 
 func TestCategorizedLabels(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Ran into this on 3.7.4 while wiring up a live tail view. A tail query with a typo'd regexp in a line filter (like `{job=~".+"} |~ "GET("`) gets a `101 Switching Protocols`, then just sits there. No entries, no error, no close frame, only pings. Meanwhile the ingester rejects the stream with a 400 parse error that gets logged every ~500ms for as long as the client stays connected.

Two things are going on:

1. `ParseTailQuery` validates the label matchers but never compiles the pipeline, so an invalid pipeline stage sails straight through the websocket upgrade. The fix compiles the pipeline before upgrading and returns 400 for anything the ingesters would reject, same as `query_range`.

2. On top of that, the tailer treats every gRPC error from an ingester as a dropped connection and reconnects forever, so even a rejection that does land after the upgrade never reaches the client. Added a terminal-error check: when an ingester answers with `InvalidArgument`, stop retrying and push the error into the close channel so the client gets a proper close frame with the message instead of an eternal ping-only connection.

Only `InvalidArgument` is treated as terminal. `Unavailable`, deadline stuff, etc. still go through the normal reconnect path — that behavior is untouched, and there's a test locking it in.

**Which issue(s) this PR fixes**:
Fixes #24249

**Special notes for your reviewer**:

The reporter's repro was against a fresh instance with no flushed chunks (deterministic). Verified the pre-upgrade 400 with a handler-level test, plus unit tests for `validateTailQuery` and for the terminal-vs-transient classification in the tailer loop. Ran the full `pkg/querier/tail` suite locally, all green.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
