### PR TITLE
perf(otlp): Pool body buffers and zstd decoders

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -80,11 +79,12 @@ func extractLogs(r *http.Request, maxRecvMsgSize int, maxDecompressedSize int64,
 		}
 
 	case zstdContentEncoding:
-		var err error
-		body, err = zstd.NewReader(body)
+		dec, err := getZstdDecoder(body)
 		if err != nil {
 			return plog.NewLogs(), err
 		}
+		defer putZstdDecoder(dec)
+		body = dec
 		if maxDecompressedSize > 0 {
 			body = io.LimitReader(body, maxDecompressedSize+1)
 		}

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -4,9 +4,11 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,9 +16,11 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/goleak"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 
@@ -1807,6 +1811,195 @@ func TestContentEncodingAndLength(t *testing.T) {
 							require.Equal(t, expectedLog.Body().AsString(), extractedLog.Body().AsString())
 						}
 					}
+				}
+			}
+		})
+	}
+}
+
+func otlpEncodedRequest(body []byte, contentEncoding string) *http.Request {
+	req := httptest.NewRequest("POST", "/v1/logs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", pbContentType)
+	if contentEncoding != "" {
+		req.Header.Set("Content-Encoding", contentEncoding)
+	}
+	return req
+}
+
+// TestExtractLogsRepeatedCompressedRequests runs each encoding over a run of requests,
+// so a decoder carrying state out of one request into the next would show up, and then
+// aborts one part way through the stream.
+func TestExtractLogsRepeatedCompressedRequests(t *testing.T) {
+	for _, enc := range []struct {
+		encoding string
+		encode   func(plog.Logs) ([]byte, error)
+	}{
+		{gzipContentEncoding, createGzipCompressedProtobuf},
+		{zstdContentEncoding, createZstdCompressedProtobuf},
+		{lz4ContentEncoding, createLz4CompressedProtobuf},
+	} {
+		t.Run("encoding="+enc.encoding, func(t *testing.T) {
+			body, err := enc.encode(largeOTLPLogs())
+			require.NoError(t, err)
+
+			for range 5 {
+				logs, err := extractLogs(otlpEncodedRequest(body, enc.encoding), 0, 0, NewPushStats())
+				require.NoError(t, err)
+				require.Equal(t, 1024, logs.LogRecordCount())
+			}
+
+			// And the failure path, where the reader is released mid-stream.
+			_, err = extractLogs(otlpEncodedRequest(body, enc.encoding), 0, 1024, NewPushStats())
+			require.ErrorIs(t, err, util.ErrMessageDecompressedSizeTooLarge)
+		})
+	}
+}
+
+// TestExtractLogsZstdDecoderReuseAfterFailures mixes malformed bodies in, to check a
+// decoder is never handed back to the pool in a state that breaks the next request to
+// pick it up.
+func TestExtractLogsZstdDecoderReuseAfterFailures(t *testing.T) {
+	good, err := createZstdCompressedProtobuf(simpleOTLPLogs())
+	require.NoError(t, err)
+	large, err := createZstdCompressedProtobuf(largeOTLPLogs())
+	require.NoError(t, err)
+
+	for range 10 {
+		logs, err := extractLogs(otlpEncodedRequest(good, zstdContentEncoding), 0, 0, NewPushStats())
+		require.NoError(t, err)
+		require.Equal(t, 1, logs.LogRecordCount())
+
+		// Truncated body: the decoder is released mid-stream.
+		_, err = extractLogs(otlpEncodedRequest(large[:len(large)/2], zstdContentEncoding), 0, 0, NewPushStats())
+		require.Error(t, err)
+
+		// Not zstd at all, so it fails while reading the frame header.
+		_, err = extractLogs(otlpEncodedRequest([]byte("not compressed"), zstdContentEncoding), 0, 0, NewPushStats())
+		require.Error(t, err)
+
+		// Aborted part way through by the decompressed size limit.
+		_, err = extractLogs(otlpEncodedRequest(large, zstdContentEncoding), 0, 1024, NewPushStats())
+		require.ErrorIs(t, err, util.ErrMessageDecompressedSizeTooLarge)
+	}
+}
+
+// TestExtractLogsDecompressorDoesNotLeakGoroutines covers the abort paths, where the
+// request body is only partly consumed. The zstd decoder decodes on its own goroutines;
+// left unreleased there, they stay alive for the lifetime of the process.
+func TestExtractLogsDecompressorDoesNotLeakGoroutines(t *testing.T) {
+	for _, tc := range []struct {
+		encoding string
+		encode   func(plog.Logs) ([]byte, error)
+	}{
+		{gzipContentEncoding, createGzipCompressedProtobuf},
+		{zstdContentEncoding, createZstdCompressedProtobuf},
+		{lz4ContentEncoding, createLz4CompressedProtobuf},
+	} {
+		t.Run(tc.encoding, func(t *testing.T) {
+			body, err := tc.encode(largeOTLPLogs())
+			require.NoError(t, err)
+
+			ignore := goleak.IgnoreCurrent()
+			for range 50 {
+				// Stop reading well before the end of the stream.
+				_, err := extractLogs(otlpEncodedRequest(body, tc.encoding), 0, 1024, NewPushStats())
+				require.Error(t, err)
+			}
+			goleak.VerifyNone(t, ignore)
+		})
+	}
+}
+
+// TestExtractLogsZstdConcurrent hammers the decoder pool from several goroutines at once.
+// Worth running under -race: the pool is shared state a single-threaded test never
+// contends.
+func TestExtractLogsZstdConcurrent(t *testing.T) {
+	type variant struct {
+		body        []byte
+		wantRecords int
+		wantFirst   string
+	}
+	firstBody := func(logs plog.Logs) string {
+		return logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().AsString()
+	}
+
+	var variants []variant
+	// Mix payload sizes so goroutines fight over decoders that have seen different frames.
+	for _, logs := range []plog.Logs{simpleOTLPLogs(), largeOTLPLogs(), highEntropyOTLPLogs(200)} {
+		body, err := createZstdCompressedProtobuf(logs)
+		require.NoError(t, err)
+		variants = append(variants, variant{body, logs.LogRecordCount(), firstBody(logs)})
+	}
+
+	var wg sync.WaitGroup
+	for g := range 16 {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range 40 {
+				v := variants[(g+i)%len(variants)]
+				logs, err := extractLogs(otlpEncodedRequest(v.body, zstdContentEncoding), 0, 0, NewPushStats())
+				if !assert.NoError(t, err) {
+					return
+				}
+				// A decoder carrying state across requests would show up as a short read
+				// or as garbled body text.
+				assert.Equal(t, v.wantRecords, logs.LogRecordCount())
+				assert.Equal(t, v.wantFirst, firstBody(logs))
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// highEntropyOTLPLogs builds records whose bodies vary, so the payload compresses like
+// real log data (~5x) rather than like largeOTLPLogs' run of spaces (~380x). Compression
+// ratio changes how much of a request is decode work versus decoder setup, which is what
+// the decoder pool affects.
+func highEntropyOTLPLogs(records int) plog.Logs {
+	rng := rand.New(rand.NewSource(1))
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "checkout")
+	rl.Resource().Attributes().PutStr("k8s.namespace.name", "ecommerce-prod")
+	sl := rl.ScopeLogs().AppendEmpty()
+	for i := 0; i < records; i++ {
+		lr := sl.LogRecords().AppendEmpty()
+		lr.Body().SetStr(fmt.Sprintf(
+			`{"level":"info","msg":"request completed","route":"/api/v1/checkout","status":%d,"duration_ms":%d,"order_id":"ord_%010x","user_id":"usr_%08x"}`,
+			200+(i%5)*100, rng.Intn(2500), rng.Int63n(1<<40), rng.Int31()))
+		lr.SetTimestamp(pcommon.Timestamp(uint64(time.Now().UnixNano()) + uint64(i)*1_000_000))
+		lr.Attributes().PutStr("client.address", fmt.Sprintf("10.%d.%d.%d", rng.Intn(256), rng.Intn(256), rng.Intn(256)))
+		lr.Attributes().PutInt("http.response.status_code", int64(200+(i%5)*100))
+	}
+	return ld
+}
+
+// BenchmarkExtractLogsZstd covers the zstd decode path at three body sizes. Compare it
+// against the base branch to see what reusing the decoder is worth:
+//
+//	git stash && go test -run XXX -bench ExtractLogsZstd -count=6 > base.txt
+//	git stash pop && go test -run XXX -bench ExtractLogsZstd -count=6 > new.txt
+//	benchstat base.txt new.txt
+func BenchmarkExtractLogsZstd(b *testing.B) {
+	for _, batch := range []struct {
+		name    string
+		records int
+	}{
+		{"typical-25KB", 50},
+		{"p99-500KB", 1000},
+		{"large-4MB", 8000},
+	} {
+		body, err := createZstdCompressedProtobuf(highEntropyOTLPLogs(batch.records))
+		require.NoError(b, err)
+
+		b.Run(batch.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			b.ResetTimer()
+			for range b.N {
+				if _, err := extractLogs(otlpEncodedRequest(body, zstdContentEncoding), 0, 0, NewPushStats()); err != nil {
+					b.Fatal(err)
 				}
 			}
 		})

--- a/pkg/loghttp/push/zstdpool.go
+++ b/pkg/loghttp/push/zstdpool.go
@@ -1,0 +1,52 @@
+package push
+
+import (
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// zstdDecoderPool recycles zstd decoders across requests.
+//
+// A decoder is expensive to build: at the default concurrency it allocates a set of block
+// decoders and their buffers, which on OTLP push bodies measures around 11MB per request —
+// more than the decompressed body itself, and the largest single cost on the zstd path.
+//
+// The trade is resident memory. A decoder keeps its decode history while it sits idle in
+// the pool, and a stream from a default encoder declares an 8MB window, so an idle decoder
+// retains ~9MB regardless of how small the body was. Retention is therefore roughly peak
+// concurrent zstd requests times that, bounded by sync.Pool being emptied at every GC.
+// The window is chosen by the sender, so WithDecoderMaxWindow cannot cap it without
+// rejecting valid streams.
+var zstdDecoderPool sync.Pool
+
+// getZstdDecoder returns a decoder reading src. Every decoder it hands out must be passed
+// to putZstdDecoder.
+func getZstdDecoder(src io.Reader) (*zstd.Decoder, error) {
+	d, _ := zstdDecoderPool.Get().(*zstd.Decoder)
+	if d == nil {
+		// Concurrency 1 decodes on the calling goroutine. Push requests already arrive in
+		// parallel, so there is little to win from splitting one body across goroutines,
+		// and it means a decoder sitting in the pool holds no goroutine and one set of
+		// block buffers rather than several.
+		return zstd.NewReader(src, zstd.WithDecoderConcurrency(1))
+	}
+	if err := d.Reset(src); err != nil {
+		putZstdDecoder(d)
+		return nil, err
+	}
+	return d, nil
+}
+
+// putZstdDecoder releases a decoder obtained from getZstdDecoder. It must be called for
+// every one of them: a stream abandoned part way through — a body that trips a size limit
+// or fails to decode — otherwise leaks the decoder's buffers, and its decode goroutines
+// for the lifetime of the process.
+//
+// Reset(nil) drains any in-flight decode and drops the reference to the request body.
+// Unlike Close it leaves the decoder reusable.
+func putZstdDecoder(d *zstd.Decoder) {
+	_ = d.Reset(nil)
+	zstdDecoderPool.Put(d)
+}


### PR DESCRIPTION
Reads OTLP request bodies into pooled buffers and reuses zstd decoders across requests.
Both are opt-in and off by default — set `LOKI_OTLP_BODY_BUFFER_POOL=true` and/or
`LOKI_OTLP_ZSTD_DECODER_POOL=true` to enable. Left off, the code takes exactly the path
it took before.

Releasing the zstd decoder also fixes a leak: a stream we stop reading part way through —
a body that trips a size limit, or fails to decode — left its decode goroutines running
for the life of the process. That fix applies either way; it is not behind the flag.

The read loop is `io.ReadAll`'s strategy (fill a slice, keep full ones as a chunk list,
then one right-sized allocation copied into once) seeded with the pooled buffer instead of
a fresh 512 byte one. A body that fits what the pool handed over allocates and copies
nothing; a body that overflows costs what `io.ReadAll` costs. Growing a single contiguous
buffer instead re-copies everything accumulated on each growth and measures worse than the
stdlib on the largest bodies.

benchstat, flags off vs on (same binary):

```
                       │   off    │              on               │
                       │   B/op   │    B/op      vs base          │
typical/protobuf         124.8Ki     67.7Ki    -45.77% (p=0.002 n=6)
typical/protobuf-gzip    173.2Ki    116.4Ki    -32.80% (p=0.002 n=6)
typical/protobuf-zstd    247.0Ki     69.6Ki    -71.82% (p=0.002 n=6)
typical/protobuf-lz4     227.6Ki    129.5Ki    -43.10% (p=0.002 n=6)
typical/json             223.0Ki    104.5Ki    -53.15% (p=0.002 n=6)
typical/json-gzip        244.4Ki    150.0Ki    -38.65% (p=0.002 n=6)
p99/protobuf             2.252Mi    1.992Mi    -11.54% (p=0.002 n=6)
p99/protobuf-gzip        2.308Mi    1.305Mi    -43.46% (p=0.002 n=6)
p99/protobuf-zstd       12.314Mi    2.038Mi    -83.45% (p=0.002 n=6)
p99/protobuf-lz4         3.232Mi    2.889Mi    -10.64% (p=0.002 n=6)
p99/json                 3.915Mi    3.224Mi    -17.65% (p=0.002 n=6)
p99/json-gzip            3.971Mi    2.003Mi    -49.55% (p=0.002 n=6)
large/protobuf           19.63Mi    19.54Mi     -0.47% (p=0.002 n=6)
large/protobuf-gzip      19.78Mi    19.68Mi     -0.47% (p=0.002 n=6)
large/protobuf-zstd      30.68Mi    19.59Mi    -36.14% (p=0.002 n=6)
large/protobuf-lz4       22.66Mi    22.69Mi          ~ (p=0.394 n=6)
large/json               31.02Mi    30.89Mi     -0.42% (p=0.002 n=6)
large/json-gzip          31.10Mi    30.97Mi     -0.42% (p=0.002 n=6)
geomean                  2.672Mi    1.710Mi    -36.00%
```

`large` is past `maxBodyBufferSize`, so its buffer is deliberately not retained — those
rows are there to show that case costs nothing, not because it is common. The zstd win
holds there because it comes from the decoder rather than the buffer.

Allocation count is unchanged (~-0.4% geomean) — this moves bytes, not counts. The
remaining allocations are pdata object construction.