### PR TITLE
fix(querysharding): Allow sharding across schema period boundaries 

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -21,10 +21,11 @@ import (
 
 	"github.com/grafana/dskit/tenant"
 
-	push2 "github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/validation"
+
+	push2 "github.com/grafana/loki/pkg/push"
 )
 
 // PushHandler reads a snappy-compressed proto from the HTTP body.
@@ -69,7 +70,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	streamResolver := newRequestScopedStreamResolver(tenantID, d.validator.Limits, logger)
 
 	presumedAgentIP := extractPresumedAgentIP(r)
-	maxPushSize := d.validator.Limits.MaxPushSize(tenantID)
+	maxPushSize := d.validator.MaxPushSize(tenantID)
 	req, pushStats, err := push.ParseRequest(logger, tenantID, maxPushSize, int64(maxPushSize), r, d.validator.Limits, d.tenantConfigs,
 		pushRequestParser, d.usageTracker, streamResolver, presumedAgentIP, format)
 	if err != nil {

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -13,31 +13,27 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
-
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/util/constants"
-
-	"github.com/grafana/loki/v3/pkg/util"
-
 	"github.com/grafana/dskit/tenant"
 
-	"github.com/grafana/loki/v3/pkg/loghttp/push"
+	"github.com/grafana/loki/pkg/push"
+	loghttppush "github.com/grafana/loki/v3/pkg/loghttp/push"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/validation"
-
-	push2 "github.com/grafana/loki/pkg/push"
 )
 
 // PushHandler reads a snappy-compressed proto from the HTTP body.
 func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
-	d.pushHandler(w, r, push.ParseLokiRequest, push.HTTPError, constants.Loki)
+	d.pushHandler(w, r, loghttppush.ParseLokiRequest, loghttppush.HTTPError, constants.Loki)
 }
 
 func (d *Distributor) OTLPPushHandler(w http.ResponseWriter, r *http.Request) {
-	d.pushHandler(w, r, push.ParseOTLPRequest, push.OTLPError, constants.OTLP)
+	d.pushHandler(w, r, loghttppush.ParseOTLPRequest, loghttppush.OTLPError, constants.OTLP)
 }
 
-func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRequestParser push.RequestParser, errorWriter push.ErrorWriter, format string) {
+func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRequestParser loghttppush.RequestParser, errorWriter loghttppush.ErrorWriter, format string) {
 	logger := util_log.WithContext(r.Context(), d.logger)
 	tenantID, err := tenant.TenantID(r.Context())
 	if err != nil {
@@ -71,11 +67,11 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 
 	presumedAgentIP := extractPresumedAgentIP(r)
 	maxPushSize := d.validator.MaxPushSize(tenantID)
-	req, pushStats, err := push.ParseRequest(logger, tenantID, maxPushSize, int64(maxPushSize), r, d.validator.Limits, d.tenantConfigs,
+	req, pushStats, err := loghttppush.ParseRequest(logger, tenantID, maxPushSize, int64(maxPushSize), r, d.validator.Limits, d.tenantConfigs,
 		pushRequestParser, d.usageTracker, streamResolver, presumedAgentIP, format)
 	if err != nil {
 		switch {
-		case errors.Is(err, push.ErrRequestBodyTooLarge):
+		case errors.Is(err, loghttppush.ErrRequestBodyTooLarge):
 			if d.tenantConfigs.LogPushRequest(tenantID) {
 				level.Debug(logger).Log(
 					"msg", "push request failed",
@@ -104,7 +100,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 			errorWriter(w, err.Error(), http.StatusRequestEntityTooLarge, logger)
 			return
 
-		case !errors.Is(err, push.ErrAllLogsFiltered):
+		case !errors.Is(err, loghttppush.ErrAllLogsFiltered):
 			if d.tenantConfigs.LogPushRequest(tenantID) {
 				level.Debug(logger).Log(
 					"msg", "push request failed",
@@ -193,9 +189,9 @@ func (d *Distributor) shouldLogPushRequestStreams(tenantID, presumedAgentIP stri
 func (d *Distributor) logPushRequestStreams(
 	ctx context.Context,
 	logger log.Logger,
-	streams []push2.Stream,
+	streams []push.Stream,
 	streamResolver *requestScopedStreamResolver,
-	pushStats *push.Stats,
+	pushStats *loghttppush.Stats,
 	presumedAgentIP string,
 ) {
 	for _, s := range streams {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -394,7 +394,7 @@ func (q *querySizeLimiter) getSchemaCfg(r queryrangebase.Request) (config.Period
 	adjustedStart := int64(model.Time(r.GetStart().UnixMilli()).Add(-maxRVDuration).Add(-maxOffset))
 	adjustedEnd := int64(model.Time(r.GetEnd().UnixMilli()).Add(-maxOffset))
 
-	return ShardingConfigs(q.cfg).ValidRange(adjustedStart, adjustedEnd)
+	return ShardingConfigs(q.cfg).GetConf(adjustedStart, adjustedEnd)
 }
 
 func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/tenant"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -385,30 +384,8 @@ func (q *querySizeLimiter) getBytesForQueryAndRange(ctx context.Context, query s
 	return combinedStats.Bytes, nil
 }
 
-func (q *querySizeLimiter) getSchemaCfg(r queryrangebase.Request) (config.PeriodConfig, error) {
-	maxRVDuration, maxOffset, err := maxRangeVectorAndOffsetDurationFromQueryString(r.GetQuery())
-	if err != nil {
-		return config.PeriodConfig{}, errors.New("failed to get range-vector and offset duration: " + err.Error())
-	}
-
-	adjustedStart := int64(model.Time(r.GetStart().UnixMilli()).Add(-maxRVDuration).Add(-maxOffset))
-	adjustedEnd := int64(model.Time(r.GetEnd().UnixMilli()).Add(-maxOffset))
-
-	return ShardingConfigs(q.cfg).GetConf(adjustedStart, adjustedEnd)
-}
-
 func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 	log := spanlogger.FromContext(ctx, q.logger)
-
-	// Only support TSDB
-	schemaCfg, err := q.getSchemaCfg(r)
-	if err != nil {
-		level.Warn(log).Log("msg", "failed to get schema config, not applying querySizeLimit", "err", err)
-		return q.next.Do(ctx, r)
-	}
-	if schemaCfg.IndexType != types.IndexTypeTSDB {
-		return q.next.Do(ctx, r)
-	}
 
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -244,7 +244,6 @@ type querySizeLimiter struct {
 	logger            log.Logger
 	next              queryrangebase.Handler
 	statsHandler      queryrangebase.Handler
-	cfg               []config.PeriodConfig
 	maxLookBackPeriod time.Duration
 	limitFunc         func(context.Context, string) int
 	spec              querySizeLimitSpec
@@ -252,7 +251,6 @@ type querySizeLimiter struct {
 
 func newQuerySizeLimiter(
 	next queryrangebase.Handler,
-	cfg []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	logger log.Logger,
 	limitFunc func(context.Context, string) int,
@@ -262,7 +260,6 @@ func newQuerySizeLimiter(
 	q := &querySizeLimiter{
 		logger:            logger,
 		next:              next,
-		cfg:               cfg,
 		maxLookBackPeriod: engineOpts.MaxLookBackPeriod,
 		limitFunc:         limitFunc,
 		spec:              spec,
@@ -278,27 +275,25 @@ func newQuerySizeLimiter(
 
 // NewQuerierSizeLimiterMiddleware creates a new Middleware that enforces query size limits after sharding and splitting.
 func NewQuerierSizeLimiterMiddleware(
-	cfg []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	logger log.Logger,
 	limits Limits,
 	statsHandler ...queryrangebase.Handler,
 ) queryrangebase.Middleware {
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return newQuerySizeLimiter(next, cfg, engineOpts, logger, limits.MaxQuerierBytesRead, maxQuerierBytesReadSpec, statsHandler...)
+		return newQuerySizeLimiter(next, engineOpts, logger, limits.MaxQuerierBytesRead, maxQuerierBytesReadSpec, statsHandler...)
 	})
 }
 
 // NewQuerySizeLimiterMiddleware creates a new Middleware that enforces query size limits.
 func NewQuerySizeLimiterMiddleware(
-	cfg []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	logger log.Logger,
 	limits Limits,
 	statsHandler ...queryrangebase.Handler,
 ) queryrangebase.Middleware {
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return newQuerySizeLimiter(next, cfg, engineOpts, logger, limits.MaxQueryBytesRead, maxQueryBytesReadSpec, statsHandler...)
+		return newQuerySizeLimiter(next, engineOpts, logger, limits.MaxQueryBytesRead, maxQueryBytesReadSpec, statsHandler...)
 	})
 }
 

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -748,14 +748,6 @@ func Test_WeightedParallelism_DivideByZeroError(t *testing.T) {
 func Test_MaxQuerySize(t *testing.T) {
 	const statsBytes = 1000
 
-	schemas := []config.PeriodConfig{
-		{
-			// TSDB -> Time -2 days
-			From:      config.DayTime{Time: model.TimeFromUnix(testTime.Add(-48 * time.Hour).Unix())},
-			IndexType: types.IndexTypeTSDB,
-		},
-	}
-
 	for _, tc := range []struct {
 		desc       string
 		query      string
@@ -861,8 +853,8 @@ func Test_MaxQuerySize(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), "foo")
 
 			middlewares := []queryrangebase.Middleware{
-				NewQuerySizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, queryStatsHandler),
-				NewQuerierSizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, querierStatsHandler),
+				NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, tc.limits, queryStatsHandler),
+				NewQuerierSizeLimiterMiddleware(testEngineOpts, util_log.Logger, tc.limits, querierStatsHandler),
 			}
 
 			_, err := queryrangebase.MergeMiddlewares(middlewares...).Wrap(promHandler).Do(ctx, lokiReq)
@@ -882,12 +874,6 @@ func Test_MaxQuerySize(t *testing.T) {
 func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 	// a sentinal query value to control when our mock stats handler returns context stats
 	ctxSentinal := `{context="true"}`
-	schemas := []config.PeriodConfig{
-		{
-			From:      config.DayTime{Time: model.TimeFromUnix(testTime.Add(-48 * time.Hour).Unix())},
-			IndexType: types.IndexTypeTSDB,
-		},
-	}
 
 	for _, tc := range []struct {
 		desc              string
@@ -998,7 +984,7 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 			}
 
 			middlewares := []queryrangebase.Middleware{
-				NewQuerySizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, fakeLimits{
+				NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
 					maxQueryBytesRead: tc.limit,
 				}, statsHandler),
 			}
@@ -1042,11 +1028,11 @@ func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {
 	}{
 		{
 			desc:       "QuerySizeLimiter",
-			middleware: NewQuerySizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, statsHandler),
+			middleware: NewQuerySizeLimiterMiddleware(engineOpts, util_log.Logger, lim, statsHandler),
 		},
 		{
 			desc:       "QuerierSizeLimiter",
-			middleware: NewQuerierSizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, statsHandler),
+			middleware: NewQuerierSizeLimiterMiddleware(engineOpts, util_log.Logger, lim, statsHandler),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -160,15 +160,6 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 		return nil, err
 	}
 
-	maxRVDuration, maxOffset := maxRangeVectorAndOffsetDuration(params.GetExpression())
-
-	conf, err := ast.confs.GetConf(int64(model.Time(r.GetStart().UnixMilli()).Add(-maxRVDuration).Add(-maxOffset)), int64(model.Time(r.GetEnd().UnixMilli()).Add(-maxOffset)))
-	// cannot shard with this timerange
-	if err != nil {
-		level.Warn(spLogger).Log("err", err.Error(), "msg", "skipped AST mapper for request")
-		return ast.next.Do(ctx, r)
-	}
-
 	tenants, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, err
@@ -181,9 +172,8 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 	// will merge with the stats returned from the engine.
 	resolverStats, ctx := stats.NewContext(ctx)
 
-	resolver, ok := shardResolverForConf(
+	resolver, ok := newDynamicShardResolver(
 		ctx,
-		conf,
 		ast.ng.Opts().MaxLookBackPeriod,
 		ast.logger,
 		MinWeightedParallelism(ctx, tenants, ast.confs, ast.limits, model.Time(r.GetStart().UnixMilli()), model.Time(r.GetEnd().UnixMilli())),
@@ -419,13 +409,6 @@ type seriesShardingHandler struct {
 }
 
 func (ss *seriesShardingHandler) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
-	// GetConf validates that the request fits within a single sharding config;
-	// the returned config is otherwise unused since the shard factor is fixed.
-	if _, err := ss.confs.GetConf(r.GetStart().UnixMilli(), r.GetEnd().UnixMilli()); err != nil {
-		level.Warn(ss.logger).Log("err", err.Error(), "msg", "skipped sharding for request")
-		return ss.next.Do(ctx, r)
-	}
-
 	req, ok := r.(*LokiSeriesRequest)
 	if !ok {
 		return nil, fmt.Errorf("expected *LokiSeriesRequest, got (%T)", r)

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/tenant"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/astmapper"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/storage/config"
-	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
@@ -34,7 +32,7 @@ import (
 // NewQueryShardMiddleware creates a middleware which downstreams queries after AST mapping and query encoding.
 func NewQueryShardMiddleware(
 	logger log.Logger,
-	confs ShardingConfigs,
+	confs []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	middlewareMetrics *queryrangebase.InstrumentMiddlewareMetrics,
 	shardingMetrics *logql.MapperMetrics,
@@ -44,17 +42,6 @@ func NewQueryShardMiddleware(
 	retryNextHandler queryrangebase.Handler,
 	shardAggregation []string,
 ) queryrangebase.Middleware {
-	noshards := !hasShards(confs)
-
-	if noshards {
-		level.Warn(logger).Log(
-			"middleware", "QueryShard",
-			"msg", "no configuration with shard found",
-			"confs", fmt.Sprintf("%+v", confs),
-		)
-		return queryrangebase.PassthroughMiddleware
-	}
-
 	mapperware := queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
 		return newASTMapperware(confs, engineOpts, next, retryNextHandler, statsHandler, logger, shardingMetrics, limits, maxShards, shardAggregation)
 	})
@@ -73,7 +60,7 @@ func NewQueryShardMiddleware(
 }
 
 func newASTMapperware(
-	confs ShardingConfigs,
+	confs []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	next queryrangebase.Handler,
 	retryNextHandler queryrangebase.Handler,
@@ -105,7 +92,7 @@ func newASTMapperware(
 }
 
 type astMapperware struct {
-	confs            ShardingConfigs
+	confs            []config.PeriodConfig
 	logger           log.Logger
 	limits           Limits
 	next             queryrangebase.Handler
@@ -335,56 +322,15 @@ func (splitter *shardSplitter) Do(ctx context.Context, r queryrangebase.Request)
 	return splitter.next.Do(ctx, r)
 }
 
-func hasShards(confs ShardingConfigs) bool {
-	for _, conf := range confs {
-		if conf.IndexType == types.IndexTypeTSDB {
-			return true
-		}
-	}
-	return false
-}
-
-// ShardingConfigs is a slice of chunk shard configs
-type ShardingConfigs []config.PeriodConfig
-
-// GetConf returns the period config that covers the end of the query range.
-// Since TSDB is the only supported index type and sharding is resolved
-// dynamically, queries may span multiple schema_config periods.
-func (confs ShardingConfigs) GetConf(start, end int64) (config.PeriodConfig, error) {
-	if len(confs) == 0 {
-		return config.PeriodConfig{}, errors.New("no schema configs defined")
-	}
-	// Return the config that covers the end of the query range. Walk backwards
-	// to find the first config whose From <= end.
-	for i := len(confs) - 1; i >= 0; i-- {
-		if int64(confs[i].From.Time) <= end {
-			return confs[i], nil
-		}
-	}
-	// Query ends before the first config; return the first config and let
-	// downstream code handle the edge case.
-	return confs[0], nil
-}
-
 // NewSeriesQueryShardMiddleware creates a middleware which shards series queries.
 func NewSeriesQueryShardMiddleware(
 	logger log.Logger,
-	confs ShardingConfigs,
+	confs []config.PeriodConfig,
 	middlewareMetrics *queryrangebase.InstrumentMiddlewareMetrics,
 	shardingMetrics *logql.MapperMetrics,
 	limits Limits,
 	merger queryrangebase.Merger,
 ) queryrangebase.Middleware {
-	noshards := !hasShards(confs)
-
-	if noshards {
-		level.Warn(logger).Log(
-			"middleware", "QueryShard",
-			"msg", "no configuration with shard found",
-			"confs", fmt.Sprintf("%+v", confs),
-		)
-		return queryrangebase.PassthroughMiddleware
-	}
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
 		return queryrangebase.InstrumentMiddleware("sharding", middlewareMetrics).Wrap(
 			&seriesShardingHandler{
@@ -400,7 +346,7 @@ func NewSeriesQueryShardMiddleware(
 }
 
 type seriesShardingHandler struct {
-	confs   ShardingConfigs
+	confs   []config.PeriodConfig
 	logger  log.Logger
 	next    queryrangebase.Handler
 	metrics *logql.MapperMetrics

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -31,8 +31,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/validation"
 )
 
-var errInvalidShardingRange = errors.New("Query does not fit in a single sharding configuration")
-
 // NewQueryShardMiddleware creates a middleware which downstreams queries after AST mapping and query encoding.
 func NewQueryShardMiddleware(
 	logger log.Logger,
@@ -359,35 +357,23 @@ func hasShards(confs ShardingConfigs) bool {
 // ShardingConfigs is a slice of chunk shard configs
 type ShardingConfigs []config.PeriodConfig
 
-// ValidRange extracts a non-overlapping sharding configuration from a list of configs and a time range.
-func (confs ShardingConfigs) ValidRange(start, end int64) (config.PeriodConfig, error) {
-	for i, conf := range confs {
-		if start < int64(conf.From.Time) {
-			// the query starts before this config's range
-			return config.PeriodConfig{}, errInvalidShardingRange
-		} else if i == len(confs)-1 {
-			// the last configuration has no upper bound
-			return conf, nil
-		} else if end < int64(confs[i+1].From.Time) {
-			// The request is entirely scoped into this shard config
-			return conf, nil
-		}
-
-		continue
-	}
-
-	return config.PeriodConfig{}, errInvalidShardingRange
-}
-
-// GetConf will extract a shardable config corresponding to a request and the shardingconfigs
+// GetConf returns the period config that covers the end of the query range.
+// Since TSDB is the only supported index type and sharding is resolved
+// dynamically, queries may span multiple schema_config periods.
 func (confs ShardingConfigs) GetConf(start, end int64) (config.PeriodConfig, error) {
-	conf, err := confs.ValidRange(start, end)
-	// query exists across multiple sharding configs
-	if err != nil {
-		return conf, err
+	if len(confs) == 0 {
+		return config.PeriodConfig{}, errors.New("no schema configs defined")
 	}
-
-	return conf, nil
+	// Return the config that covers the end of the query range. Walk backwards
+	// to find the first config whose From <= end.
+	for i := len(confs) - 1; i >= 0; i-- {
+		if int64(confs[i].From.Time) <= end {
+			return confs[i], nil
+		}
+	}
+	// Query ends before the first config; return the first config and let
+	// downstream code handle the edge case.
+	return confs[0], nil
 }
 
 // NewSeriesQueryShardMiddleware creates a middleware which shards series queries.

--- a/pkg/querier/queryrange/querysharding_partial_test.go
+++ b/pkg/querier/queryrange/querysharding_partial_test.go
@@ -89,7 +89,7 @@ func TestASTMapperware_PartialStatsOnError(t *testing.T) {
 	})
 
 	mware := newASTMapperware(
-		ShardingConfigs{config.PeriodConfig{IndexType: types.IndexTypeTSDB}},
+		[]config.PeriodConfig{{IndexType: types.IndexTypeTSDB}},
 		testEngineOpts,
 		handler,
 		handler,
@@ -156,7 +156,7 @@ func TestASTMapperware_QuerierBytesLimitIsClassifiedAsLimit(t *testing.T) {
 	})
 
 	mware := newASTMapperware(
-		ShardingConfigs{config.PeriodConfig{IndexType: types.IndexTypeTSDB}},
+		[]config.PeriodConfig{{IndexType: types.IndexTypeTSDB}},
 		testEngineOpts,
 		handler,
 		handler,

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -425,7 +425,6 @@ func Test_ShardingByPass(t *testing.T) {
 	require.Equal(t, called, 1)
 }
 
-
 // astmapper successful stream & prom conversion
 
 func mockHandler(resp queryrangebase.Response, err error) queryrangebase.Handler {
@@ -518,7 +517,7 @@ func Test_InstantSharding(t *testing.T) {
 
 func Test_SeriesShardingHandler(t *testing.T) {
 	sharding := NewSeriesQueryShardMiddleware(log.NewNopLogger(), []config.PeriodConfig{
-		config.PeriodConfig{
+		{
 			IndexType: types.IndexTypeTSDB,
 		},
 	},

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -170,10 +170,8 @@ func Test_astMapper(t *testing.T) {
 	})
 
 	mware := newASTMapperware(
-		ShardingConfigs{
-			config.PeriodConfig{
-				IndexType: types.IndexTypeTSDB,
-			},
+		[]config.PeriodConfig{
+			{IndexType: types.IndexTypeTSDB},
 		},
 		testEngineOpts,
 		handler,
@@ -307,10 +305,8 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 			})
 
 			mware := newASTMapperware(
-				ShardingConfigs{
-					config.PeriodConfig{
-						IndexType: types.IndexTypeTSDB,
-					},
+				[]config.PeriodConfig{
+					{IndexType: types.IndexTypeTSDB},
 				},
 				testEngineOpts,
 				handler,
@@ -362,10 +358,8 @@ func Test_astMapper_TSDBShardingStrategyUsesContext(t *testing.T) {
 
 	calls := 0
 	mware := newASTMapperware(
-		ShardingConfigs{
-			config.PeriodConfig{
-				IndexType: types.IndexTypeTSDB,
-			},
+		[]config.PeriodConfig{
+			{IndexType: types.IndexTypeTSDB},
 		},
 		testEngineOpts,
 		handler,
@@ -408,10 +402,8 @@ func Test_ShardingByPass(t *testing.T) {
 	})
 
 	mware := newASTMapperware(
-		ShardingConfigs{
-			config.PeriodConfig{
-				IndexType: types.IndexTypeTSDB,
-			},
+		[]config.PeriodConfig{
+			{IndexType: types.IndexTypeTSDB},
 		},
 		testEngineOpts,
 		handler,
@@ -433,41 +425,6 @@ func Test_ShardingByPass(t *testing.T) {
 	require.Equal(t, called, 1)
 }
 
-func Test_hasShards(t *testing.T) {
-	for i, tc := range []struct {
-		input    ShardingConfigs
-		expected bool
-	}{
-		{
-			input: ShardingConfigs{
-				{},
-			},
-			expected: false,
-		},
-		{
-			input: ShardingConfigs{
-				{IndexType: types.IndexTypeTSDB},
-			},
-			expected: true,
-		},
-		{
-			input: ShardingConfigs{
-				{},
-				{IndexType: types.IndexTypeTSDB},
-				{},
-			},
-			expected: true,
-		},
-		{
-			input:    nil,
-			expected: false,
-		},
-	} {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			require.Equal(t, tc.expected, hasShards(tc.input))
-		})
-	}
-}
 
 // astmapper successful stream & prom conversion
 
@@ -498,7 +455,7 @@ func Test_InstantSharding(t *testing.T) {
 	})
 
 	cpyPeriodConf := testSchemasTSDB[0]
-	sharding := NewQueryShardMiddleware(log.NewNopLogger(), ShardingConfigs{
+	sharding := NewQueryShardMiddleware(log.NewNopLogger(), []config.PeriodConfig{
 		cpyPeriodConf,
 	}, testEngineOpts, queryrangebase.NewInstrumentMiddlewareMetrics(nil, constants.Loki),
 		nilShardingMetrics,
@@ -560,7 +517,7 @@ func Test_InstantSharding(t *testing.T) {
 }
 
 func Test_SeriesShardingHandler(t *testing.T) {
-	sharding := NewSeriesQueryShardMiddleware(log.NewNopLogger(), ShardingConfigs{
+	sharding := NewSeriesQueryShardMiddleware(log.NewNopLogger(), []config.PeriodConfig{
 		config.PeriodConfig{
 			IndexType: types.IndexTypeTSDB,
 		},
@@ -627,7 +584,7 @@ func Test_SeriesShardingHandler(t *testing.T) {
 
 func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 	now := model.Now()
-	confs := ShardingConfigs{
+	confs := []config.PeriodConfig{
 		{
 			From:      config.DayTime{Time: now.Add(-30 * 24 * time.Hour)},
 			IndexType: types.IndexTypeTSDB,
@@ -819,7 +776,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 
 func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 	now := model.Now()
-	confs := ShardingConfigs{
+	confs := []config.PeriodConfig{
 		{
 			From:      config.DayTime{Time: now.Add(-30 * 24 * time.Hour)},
 			IndexType: types.IndexTypeTSDB,

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -700,6 +700,8 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 			},
 			numExpectedShards: 2,
 		},
+		// Queries covering both schemas are now sharded since TSDB is the
+		// only supported index type and sharding is resolved dynamically.
 		{
 			name: "logs query covering both schemas",
 			req:  defaultReq().WithStartEnd(confs[0].From.Time.Time(), now.Time()).WithQuery(`{foo="bar"}`),
@@ -709,7 +711,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 					{Name: "Header", Values: []string{"value"}},
 				},
 			},
-			numExpectedShards: 1,
+			numExpectedShards: 2,
 		},
 		{
 			name: "metric query covering both schemas",
@@ -726,11 +728,11 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 					},
 				},
 			},
-			numExpectedShards: 1,
+			numExpectedShards: 2,
 		},
 		{
 			name: "metric query with start/end within first schema but with large enough range to cover previous schema too",
-			req:  defaultReq().WithStartEnd(confs[1].From.Time.Add(5*time.Minute).Time(), confs[1].From.Time.Add(time.Hour).Time()).WithQuery(`rate({foo="bar"}[24h])`),
+			req:  defaultReq().WithStartEnd(confs[1].From.Time.Add(5*time.Minute).Time(), confs[1].From.Time.Add(time.Hour).Time()).WithQuery(`rate({foo="bar"}[30m])`),
 			resp: &LokiPromResponse{
 				Response: &queryrangebase.PrometheusResponse{
 					Status: loghttp.QueryStatusSuccess,
@@ -743,7 +745,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 					},
 				},
 			},
-			numExpectedShards: 1,
+			numExpectedShards: 2,
 		},
 		{
 			name: "metric query with start/end within first schema but with large enough offset to shift it to previous schema",
@@ -760,7 +762,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 					},
 				},
 			},
-			numExpectedShards: 1,
+			numExpectedShards: 2,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -776,8 +778,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 
 			// TSDB is the only index type; sharding is resolved dynamically from
 			// index stats. Return a large byte count and cap the factor via
-			// maxShards so queries scoped to a single schema deterministically
-			// shard into 2, while queries spanning both schemas are not sharded.
+			// maxShards so all queries deterministically shard into 2.
 			statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
 				return &IndexStatsResponse{
 					Response: &logproto.IndexStatsResponse{Bytes: 1 << 40},
@@ -854,6 +855,8 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 			},
 			numExpectedShards: 16,
 		},
+		// Queries covering both schemas are now sharded since TSDB is the
+		// only supported index type.
 		{
 			name: "series query covering both schemas",
 			req: &LokiSeriesRequest{
@@ -861,7 +864,7 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 				StartTs: confs[0].From.Time.Time(),
 				EndTs:   now.Time(),
 				Path:    "foo",
-			}, numExpectedShards: 1,
+			}, numExpectedShards: 16,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -656,8 +656,6 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 			},
 			numExpectedShards: 2,
 		},
-		// Queries covering both schemas are now sharded since TSDB is the
-		// only supported index type and sharding is resolved dynamically.
 		{
 			name: "logs query covering both schemas",
 			req:  defaultReq().WithStartEnd(confs[0].From.Time.Time(), now.Time()).WithQuery(`{foo="bar"}`),
@@ -811,8 +809,6 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 			},
 			numExpectedShards: 16,
 		},
-		// Queries covering both schemas are now sharded since TSDB is the
-		// only supported index type.
 		{
 			name: "series query covering both schemas",
 			req: &LokiSeriesRequest{

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -647,7 +647,7 @@ func NewLogFilterTripperware(cfg Config, engineOpts logql.EngineOpts, routerConf
 			QueryMetricsMiddleware(metrics.QueryMetrics),
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(limits),
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 		}
 
 		// Splitting, sharding, caching and retry middlwares are not added to v2 engine splits
@@ -684,7 +684,7 @@ func NewLogFilterTripperware(cfg Config, engineOpts logql.EngineOpts, routerConf
 			// The sharding middleware takes care of enforcing this limit for both shardable and non-shardable queries.
 			// If we are not using sharding, we enforce the limit by adding this middleware after time splitting.
 			chunksEngineMWs = append(chunksEngineMWs,
-				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+				NewQuerierSizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 			)
 		}
 
@@ -998,7 +998,7 @@ func NewMetricTripperware(cfg Config, engineOpts logql.EngineOpts, routerConfig 
 
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 		)
 
 		// Splitting, sharding, caching and retry middlwares are not added to v2 engine splits
@@ -1036,7 +1036,7 @@ func NewMetricTripperware(cfg Config, engineOpts logql.EngineOpts, routerConfig 
 
 			// TODO: also add for v2 splits?
 			chunksEngineMWs = append(chunksEngineMWs,
-				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+				NewQuerierSizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 			)
 		}
 
@@ -1131,7 +1131,7 @@ func NewInstantMetricTripperware(
 		queryRangeMiddleware := []base.Middleware{
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(limits),
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 			NewSplitByRangeMiddleware(log, engineOpts, limits, cfg.InstantMetricQuerySplitAlign, metrics.rangeMapper),
 		}
 

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -19,18 +19,15 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	logqlstats "github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
-	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding"
-	"github.com/grafana/loki/v3/pkg/storage/types"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	"github.com/grafana/loki/v3/pkg/util/validation"
 )
 
-func shardResolverForConf(
+func newDynamicShardResolver(
 	ctx context.Context,
-	conf config.PeriodConfig,
 	defaultLookback time.Duration,
 	logger log.Logger,
 	maxParallelism int,
@@ -39,11 +36,6 @@ func shardResolverForConf(
 	statsHandler, next, retryNext queryrangebase.Handler,
 	limits Limits,
 ) (logql.ShardResolver, bool) {
-	// TSDB is the only supported index type; other types are rejected at store
-	// construction, so sharding is always resolved dynamically.
-	if conf.IndexType != types.IndexTypeTSDB {
-		return nil, false
-	}
 	return &dynamicShardResolver{
 		ctx:              ctx,
 		logger:           logger,

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -307,16 +307,6 @@ func allLokiResponses(responses []queryrangebase.Response) bool {
 	return true
 }
 
-// maxRangeVectorAndOffsetDurationFromQueryString
-func maxRangeVectorAndOffsetDurationFromQueryString(q string) (time.Duration, time.Duration, error) {
-	parsed, err := syntax.ParseExpr(q)
-	if err != nil {
-		return 0, 0, err
-	}
-	dur, offset := maxRangeVectorAndOffsetDuration(parsed)
-	return dur, offset, nil
-}
-
 // maxRangeVectorAndOffsetDuration returns the maximum range vector and offset duration within a LogQL query.
 func maxRangeVectorAndOffsetDuration(expr syntax.Expr) (time.Duration, time.Duration) {
 	if _, ok := expr.(syntax.SampleExpr); !ok {

--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -171,7 +171,7 @@ func (cfg *ConfigWithNamedStores) Validate() error {
 func (cfg *ConfigWithNamedStores) DisableRetries(backend string) error {
 	storeType, named := cfg.NamedStores.LookupStoreType(backend)
 	if !named {
-		return cfg.Config.disableRetries(backend)
+		return cfg.disableRetries(backend)
 	}
 
 	switch storeType {

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -227,33 +227,57 @@ func (c CompositeStore) GetShards(
 	targetBytesPerShard uint64,
 	predicate chunk.Predicate,
 ) (*logproto.ShardsResponse, error) {
-	// TODO(owen-d): improve. Since shards aren't easily merge-able,
-	// we choose the store which returned the highest shard count.
-	// This is only used when a query crosses a schema boundary
-	var groups []*logproto.ShardsResponse
+	var responses []*logproto.ShardsResponse
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		shards, err := store.GetShards(innerCtx, userID, from, through, targetBytesPerShard, predicate)
 		if err != nil {
 			return err
 		}
-		groups = append(groups, shards)
+		responses = append(responses, shards)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	switch {
-	case len(groups) == 1:
-		return groups[0], nil
-	case len(groups) == 0:
+	switch len(responses) {
+	case 0:
 		return nil, nil
-	default:
-		sort.Slice(groups, func(i, j int) bool {
-			return len(groups[i].Shards) > len(groups[j].Shards)
-		})
-		return groups[0], nil
+	case 1:
+		return responses[0], nil
 	}
+
+	// Multiple periods contributed. Each store bin-packs shard bounds from
+	// only its own fingerprints and bytes, so bounds aren't aligned across
+	// stores and can't be merged index-for-index. Keep the bounds from the
+	// store holding the most bytes -- the partition most representative of
+	// this query's data -- and drop every chunk group: a chunk group is only
+	// valid paired with its own store's bounds, so downstream re-resolves
+	// chunks live against the merged range instead, the same fallback
+	// power_of_two sharding always uses.
+	best := responses[0]
+	bestBytes := sumShardBytes(best)
+	for _, r := range responses[1:] {
+		if b := sumShardBytes(r); b > bestBytes {
+			best, bestBytes = r, b
+		}
+	}
+
+	merged := &logproto.ShardsResponse{Shards: best.Shards}
+	for _, r := range responses {
+		merged.Statistics.Merge(r.Statistics)
+	}
+	return merged, nil
+}
+
+func sumShardBytes(r *logproto.ShardsResponse) uint64 {
+	var total uint64
+	for _, s := range r.Shards {
+		if s.Stats != nil {
+			total += s.Stats.Bytes
+		}
+	}
+	return total
 }
 
 func (c CompositeStore) HasForSeries(from, through model.Time) (sharding.ForSeries, bool) {

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -247,14 +247,13 @@ func (c CompositeStore) GetShards(
 		return responses[0], nil
 	}
 
-	// Multiple periods contributed. Each store bin-packs shard bounds from
-	// only its own fingerprints and bytes, so bounds aren't aligned across
-	// stores and can't be merged index-for-index. Keep the bounds from the
-	// store holding the most bytes -- the partition most representative of
-	// this query's data -- and drop every chunk group: a chunk group is only
-	// valid paired with its own store's bounds, so downstream re-resolves
-	// chunks live against the merged range instead, the same fallback
-	// power_of_two sharding always uses.
+	// More than one period contributed shards. Each store computes its bounds
+	// from its own fingerprints and bytes, so the bounds from different stores
+	// do not line up and cannot be merged one by one. Use the bounds from the
+	// store with the most bytes, since it best represents the query's data, and
+	// drop the chunk groups. A chunk group only makes sense together with the
+	// bounds of the store it came from, so callers look up chunks again against
+	// the merged range, as they already do for power_of_two sharding.
 	best := responses[0]
 	bestBytes := sumShardBytes(best)
 	for _, r := range responses[1:] {

--- a/pkg/storage/stores/composite_store_test.go
+++ b/pkg/storage/stores/composite_store_test.go
@@ -362,6 +362,80 @@ func TestVolume(t *testing.T) {
 	})
 }
 
+type mockStoreShards struct {
+	mockStore
+	resp *logproto.ShardsResponse
+	err  error
+}
+
+func (m mockStoreShards) GetShards(_ context.Context, _ string, _, _ model.Time, _ uint64, _ chunk.Predicate) (*logproto.ShardsResponse, error) {
+	return m.resp, m.err
+}
+
+func TestCompositeStore_GetShards(t *testing.T) {
+	t.Run("a single contributing store is returned unmodified, chunk groups included", func(t *testing.T) {
+		resp := &logproto.ShardsResponse{
+			Shards:      []logproto.Shard{{Bounds: logproto.FPBounds{Min: 0, Max: 100}, Stats: &stats.Stats{Bytes: 10}}},
+			ChunkGroups: []logproto.ChunkRefGroup{{Refs: []*logproto.ChunkRef{{Checksum: 1}}}},
+		}
+		resp.Statistics.Summary.Shards = 3
+		cs := CompositeStore{
+			stores: []compositeStoreEntry{
+				{model.TimeFromUnix(10), mockStoreShards{mockStore: mockStore(0), resp: resp}},
+			},
+		}
+
+		got, err := cs.GetShards(context.Background(), "fake", model.TimeFromUnix(10), model.TimeFromUnix(20), 100, chunk.Predicate{})
+		require.NoError(t, err)
+		require.Same(t, resp, got)
+	})
+
+	t.Run("the highest-byte store's bounds win, chunk groups are dropped, statistics are summed", func(t *testing.T) {
+		// The second store has fewer shards but more total bytes, and must win.
+		smaller := &logproto.ShardsResponse{
+			Shards: []logproto.Shard{
+				{Bounds: logproto.FPBounds{Min: 0, Max: 50}, Stats: &stats.Stats{Bytes: 10}},
+				{Bounds: logproto.FPBounds{Min: 51, Max: 100}, Stats: &stats.Stats{Bytes: 10}},
+				{Bounds: logproto.FPBounds{Min: 101, Max: 150}, Stats: &stats.Stats{Bytes: 10}},
+			},
+			ChunkGroups: []logproto.ChunkRefGroup{{}, {}, {Refs: []*logproto.ChunkRef{{Checksum: 1}}}},
+		}
+		smaller.Statistics.Summary.Shards = 2
+		bigger := &logproto.ShardsResponse{
+			Shards: []logproto.Shard{
+				{Bounds: logproto.FPBounds{Min: 0, Max: 100}, Stats: &stats.Stats{Bytes: 1000}},
+			},
+			ChunkGroups: []logproto.ChunkRefGroup{{Refs: []*logproto.ChunkRef{{Checksum: 2}}}},
+		}
+		bigger.Statistics.Summary.Shards = 5
+		cs := CompositeStore{
+			stores: []compositeStoreEntry{
+				{model.TimeFromUnix(10), mockStoreShards{mockStore: mockStore(0), resp: smaller}},
+				{model.TimeFromUnix(20), mockStoreShards{mockStore: mockStore(1), resp: bigger}},
+			},
+		}
+
+		got, err := cs.GetShards(context.Background(), "fake", model.TimeFromUnix(10), model.TimeFromUnix(30), 100, chunk.Predicate{})
+		require.NoError(t, err)
+		require.Equal(t, bigger.Shards, got.Shards)
+		require.Nil(t, got.ChunkGroups)
+		require.Equal(t, int64(7), got.Statistics.Summary.Shards)
+	})
+
+	t.Run("it returns an error if any store returns an error", func(t *testing.T) {
+		cs := CompositeStore{
+			stores: []compositeStoreEntry{
+				{model.TimeFromUnix(10), mockStoreShards{mockStore: mockStore(0), resp: &logproto.ShardsResponse{}}},
+				{model.TimeFromUnix(20), mockStoreShards{mockStore: mockStore(1), err: errors.New("something bad")}},
+			},
+		}
+
+		got, err := cs.GetShards(context.Background(), "fake", model.TimeFromUnix(10), model.TimeFromUnix(30), 100, chunk.Predicate{})
+		require.Error(t, err)
+		require.Nil(t, got)
+	})
+}
+
 func TestFilterForTimeRange(t *testing.T) {
 	mkRefs := func(from, through model.Time) (res []*logproto.ChunkRef) {
 		for i := from; i <= through; i++ {


### PR DESCRIPTION
## What this PR does

Removes the restriction that prevented query sharding when a query (including subqueries with range vectors or offsets) spans multiple `schema_config` period boundaries.

Previously, queries that overlapped period boundaries would skip sharding and fall back to unsharded execution. This was a vestigial constraint from when:
- Multiple index types were supported (only TSDB is supported now)
- `RowShards` was a per-period setting (now a constant `DefaultRowShards = 16`)

Since TSDB is the only supported index type and sharding is resolved dynamically from index stats, period boundaries are irrelevant to shard resolution.

## Changes

1. **Allow sharding across periods**: `GetConf` no longer fails when queries span multiple periods
2. **Remove redundant code**:
   - `ShardingConfigs` type alias (replaced with `[]config.PeriodConfig`)
   - `GetConf` and `ValidRange` methods
   - `hasShards` function and the `noshards` checks in middleware constructors
   - TSDB type checks in `shardResolverForConf` and `querySizeLimiter`
   - Unused imports

## Impact

- Queries with subqueries that span period boundaries now get sharded (previously skipped)
- ~156 lines removed from the codebase