### PR TITLE
chore: fix typos in comments and one error message

### DIFF
--- a/clients/pkg/logentry/logql/ast.go
+++ b/clients/pkg/logentry/logql/ast.go
@@ -78,7 +78,7 @@ func (e *filterExpr) Filter() (Filter, error) {
 		}
 
 	default:
-		return nil, fmt.Errorf("unknow matcher: %v", e.match)
+		return nil, fmt.Errorf("unknown matcher: %v", e.match)
 	}
 	next, ok := e.left.(*filterExpr)
 	if ok {

--- a/clients/pkg/logentry/stages/drop.go
+++ b/clients/pkg/logentry/stages/drop.go
@@ -208,7 +208,7 @@ func (m *dropStage) shouldDrop(e Entry) bool {
 				level.Debug(m.logger).Log("msg", "line met drop criteria for finding source key in extracted map")
 			}
 		} else {
-			// Not found in extact map, don't drop
+			// Not found in extracted map, don't drop
 			if Debug {
 				level.Debug(m.logger).Log("msg", "line will not be dropped, the provided source was not found in the extracted map")
 			}

--- a/cmd/chunks-inspect/loki.go
+++ b/cmd/chunks-inspect/loki.go
@@ -147,7 +147,7 @@ func parseLokiChunk(chunkHeader *ChunkHeader, r io.Reader) (*LokiChunk, error) {
 
 		structuredMetadata := data[structuredMetadataOffset : structuredMetadataOffset+structuredMetadataLength]
 
-		// Structured Metadata is compresed by extracting the string keys and values and storing them in a separate section.
+		// Structured Metadata is compressed by extracting the string keys and values and storing them in a separate section.
 		// The order of the strings determines the index of the string in the metadata section of each row.
 
 		// First we read the number of symbols

--- a/operator/internal/certrotation/var.go
+++ b/operator/internal/certrotation/var.go
@@ -30,7 +30,7 @@ func CABundleName(stackName string) string {
 	return fmt.Sprintf("%s-ca-bundle", stackName)
 }
 
-// ComponentCertSecretNames retruns a list of all loki component certificate secret names.
+// ComponentCertSecretNames returns a list of all loki component certificate secret names.
 func ComponentCertSecretNames(stackName string) []string {
 	return []string{
 		fmt.Sprintf("%s-gateway-client-http", stackName),

--- a/operator/internal/handlers/internal/gateway/base_domain.go
+++ b/operator/internal/handlers/internal/gateway/base_domain.go
@@ -16,7 +16,7 @@ import (
 // getOpenShiftBaseDomain returns the cluster DNS base domain on OpenShift
 // clusters to auto-create redirect URLs for OpenShift Auth or an error.
 // If the config.openshift.io/DNS object is not found the whole lokistack
-// resoure is set to a degraded state.
+// resource is set to a degraded state.
 func getOpenShiftBaseDomain(ctx context.Context, k k8s.Client) (string, error) {
 	var cluster configv1.DNS
 	key := client.ObjectKey{Name: "cluster"}

--- a/operator/internal/handlers/internal/rules/cleanup.go
+++ b/operator/internal/handlers/internal/rules/cleanup.go
@@ -72,7 +72,7 @@ func removeRuler(ctx context.Context, c client.Client, stack client.ObjectKey) e
 	var ruler appsv1.StatefulSet
 	if err := c.Get(ctx, key, &ruler); err != nil {
 		if apierrors.IsNotFound(err) {
-			// resource doesnt exist, so nothing to do.
+			// resource does not exist, so nothing to do.
 			return nil
 		}
 		return kverrors.Wrap(err, "failed to lookup Statefulset", "name", key)

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -233,7 +233,7 @@ const (
 )
 
 // ReplayMemoryCeiling calculates 50% of the ingester memory
-// for the ingester to use for the write-ahead-log capbability.
+// for the ingester to use for the write-ahead-log capability.
 func (w WriteAheadLog) ReplayMemoryCeiling() string {
 	value := max(int64(math.Ceil(float64(w.IngesterMemoryRequest)*float64(0.5))), minimumReplayCeiling)
 	return fmt.Sprintf("%d", value)

--- a/operator/internal/manifests/openshift/serviceaccount.go
+++ b/operator/internal/manifests/openshift/serviceaccount.go
@@ -9,7 +9,7 @@ import (
 
 // BuildRulerServiceAccount returns a k8s object for the LokiStack Ruler
 // serviceaccount.
-// This ServiceAccount is used to autheticate and access the alertmanager host.
+// This ServiceAccount is used to authenticate and access the alertmanager host.
 func BuildRulerServiceAccount(opts Options) client.Object {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{

--- a/operator/internal/manifests/storage/configure.go
+++ b/operator/internal/manifests/storage/configure.go
@@ -107,7 +107,7 @@ func configureDeploymentCA(d *appsv1.Deployment, tls *TLSConfig, secretType loki
 	return nil
 }
 
-// ConfigureStatefulSet merges a the object storage secrect volume into the statefulset spec.
+// ConfigureStatefulSet merges the object storage secret volume into the statefulset spec.
 // With this, the statefulset will expose credentials specific environment variable.
 func configureStatefulSet(s *appsv1.StatefulSet, opts Options) error {
 	p := ensureObjectStoreCredentials(&s.Spec.Template.Spec, opts)

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -561,7 +561,7 @@ func gatewayServiceMonitorEndpoint(gatewayName, portName, serviceName, namespace
 	}
 }
 
-// configureAffinity returns an Affinity struture that can be used directly
+// configureAffinity returns an Affinity structure that can be used directly
 // in a Deployment/StatefulSet. Parameters will affected configuration of the
 // different fields in Affinity (NodeAffinity, PodAffinity, PodAntiAffinity).
 func configureAffinity(componentLabel, stackName string, enableNodeAffinity bool, cSpec *lokiv1.LokiComponentSpec) *corev1.Affinity {


### PR DESCRIPTION
**What this PR does / why we need it**:

Typo fixes found with codespell. No functional changes; no identifiers renamed, and CRD-generating API type comments were deliberately left untouched.

Comments:
- `extact map` -> `extracted map` (logentry/stages/drop.go)
- `compresed` -> `compressed` (cmd/chunks-inspect)
- `retruns` -> `returns` (operator/internal/certrotation)
- `struture` -> `structure` (operator/internal/manifests)
- `capbability` -> `capability` (operator config options)
- `merges a the object storage secrect` -> `merges the object storage secret` (operator storage)
- `autheticate` -> `authenticate` (operator openshift serviceaccount)
- `doesnt` -> `does not` (operator rules cleanup)
- `resoure` -> `resource` (operator gateway base_domain)

Error message:
- `unknow matcher` -> `unknown matcher` (logentry/logql/ast.go)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Reviewed the [contributors guide](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md)
- [x] Documentation added / not needed
- [x] Tests updated / not needed
- [x] Title matches the required conventional commits format
- [x] `CHANGELOG.md` updated / not needed (typo-only change)