### PR TITLE
fix(operator): Set ingester terminationGracePeriodSeconds to 300s

### DIFF
--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -76,6 +76,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 	a := commonAnnotations(opts)
 	podSpec := corev1.PodSpec{
 		ServiceAccountName: opts.Name,
+		TerminationGracePeriodSeconds: ptr.To(int64(300)),
 		Affinity:           configureAffinity(LabelIngesterComponent, opts.Name, opts.Gates.DefaultNodeAffinity, opts.Stack.Template.Ingester),
 		Volumes: []corev1.Volume{
 			{

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -75,9 +75,9 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)
 	a := commonAnnotations(opts)
 	podSpec := corev1.PodSpec{
-		ServiceAccountName: opts.Name,
-		TerminationGracePeriodSeconds: ptr.To(int64(300)),
-		Affinity:           configureAffinity(LabelIngesterComponent, opts.Name, opts.Gates.DefaultNodeAffinity, opts.Stack.Template.Ingester),
+		ServiceAccountName:            opts.Name,
+		TerminationGracePeriodSeconds: ptr.To(defaultIngesterTerminationGracePeriodSeconds),
+		Affinity:                      configureAffinity(LabelIngesterComponent, opts.Name, opts.Gates.DefaultNodeAffinity, opts.Stack.Template.Ingester),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -186,3 +186,21 @@ func TestNewIngesterStatefulSet_TopologySpreadConstraints(t *testing.T) {
 		},
 	}, ss.Spec.Template.Spec.TopologySpreadConstraints)
 }
+
+func TestNewIngesterStatefulSet_TerminationGracePeriodSeconds(t *testing.T) {
+	ss := NewIngesterStatefulSet(Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			StorageClassName: "standard",
+			Template: &lokiv1.LokiTemplateSpec{
+				Ingester: &lokiv1.LokiComponentSpec{
+					Replicas: 1,
+				},
+			},
+		},
+	})
+
+	require.NotNil(t, ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	require.Equal(t, int64(300), *ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
+}

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -202,5 +202,5 @@ func TestNewIngesterStatefulSet_TerminationGracePeriodSeconds(t *testing.T) {
 	})
 
 	require.NotNil(t, ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
-	require.Equal(t, int64(300), *ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	require.Equal(t, defaultIngesterTerminationGracePeriodSeconds, *ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
 }

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -275,6 +275,7 @@ func mutatePodSpec(existing *corev1.PodSpec, desired *corev1.PodSpec) {
 	existing.Containers = desired.Containers
 	existing.InitContainers = desired.InitContainers
 	existing.NodeSelector = desired.NodeSelector
+	existing.TerminationGracePeriodSeconds = desired.TerminationGracePeriodSeconds
 	existing.Tolerations = desired.Tolerations
 	existing.TopologySpreadConstraints = desired.TopologySpreadConstraints
 	existing.Volumes = desired.Volumes

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -275,7 +275,10 @@ func mutatePodSpec(existing *corev1.PodSpec, desired *corev1.PodSpec) {
 	existing.Containers = desired.Containers
 	existing.InitContainers = desired.InitContainers
 	existing.NodeSelector = desired.NodeSelector
-	existing.TerminationGracePeriodSeconds = desired.TerminationGracePeriodSeconds
+	// Only set TerminationGracePeriodSeconds when explicitly configured to avoid clearing the Kubernetes API server default.
+	if desired.TerminationGracePeriodSeconds != nil {
+		existing.TerminationGracePeriodSeconds = desired.TerminationGracePeriodSeconds
+	}
 	existing.Tolerations = desired.Tolerations
 	existing.TopologySpreadConstraints = desired.TopologySpreadConstraints
 	existing.Volumes = desired.Volumes

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -1200,3 +1200,68 @@ func TestGetMutateFunc_MutatePodDisruptionBudget(t *testing.T) {
 	require.Exactly(t, got.Labels, want.Labels)
 	require.Exactly(t, got.Spec, want.Spec)
 }
+
+func TestMutateFuncFor_TerminationGracePeriodSeconds(t *testing.T) {
+	type test struct {
+		name     string
+		got      *appsv1.Deployment
+		want     *appsv1.Deployment
+		expected *int64
+	}
+	table := []test{
+		{
+			name: "preserve existing value when desired is nil",
+			got: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: ptr.To(int64(30)),
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: nil,
+						},
+					},
+				},
+			},
+			expected: ptr.To(int64(30)),
+		},
+		{
+			name: "update when desired is set",
+			got: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: ptr.To(int64(30)),
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: ptr.To(int64(600)),
+						},
+					},
+				},
+			},
+			expected: ptr.To(int64(600)),
+		},
+	}
+
+	for _, tst := range table {
+		t.Run(tst.name, func(t *testing.T) {
+			t.Parallel()
+			f := MutateFuncFor(tst.got, tst.want, nil)
+			err := f()
+			require.NoError(t, err)
+			require.Equal(t, tst.expected, tst.got.Spec.Template.Spec.TerminationGracePeriodSeconds)
+		})
+	}
+}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -36,6 +36,8 @@ const (
 
 	lokiFrontendContainerName = "loki-query-frontend"
 
+	defaultIngesterTerminationGracePeriodSeconds = int64(300)
+
 	gatewayContainerName    = "gateway"
 	gatewayHTTPPort         = 8080
 	gatewayInternalPort     = 8081


### PR DESCRIPTION
 **What this PR does / why we need it:**
  Sets ingester terminationGracePeriodSeconds to 300s to prevent abrupt pod kills and data loss during graceful shutdown

  **Which issue(s) this PR fixes:**
  https://redhat.atlassian.net/browse/LOG-9863
  
  **Special notes for your reviewer:**
  The Kubernetes default terminationGracePeriodSeconds of 30s is too short for ingesters. During pod termination (rollouts, node drains), ingesters need time to flush in-memory chunks and avoid ingest/query disruption.

  This change sets terminationGracePeriodSeconds to 300s, matching Grafana's upstream Loki helm chart default. This provides sufficient time for graceful shutdown while flush-on-shutdown is not yet available in the operator.

  **Checklist**

  - [x] Reviewed the CONTRIBUTING.md guide (required)
  - [ ] Documentation added
  - [x] Tests updated
  - [x] Title matches the required conventional commits format, see here
  - [ ] Changes that require user attention or interaction to upgrade are documented in docs/sources/setup/upgrade/_index.md
  - [ ] If the change is deprecating or removing a configuration option, update the deprecated-config.yaml and deleted-config.yaml files respectively in the tools/deprecated-config-checker directory. Example PR
