### PR TITLE
fix(operator): Enable flush_on_shutdown and increase ingester terminationGracePeriodSeconds

### DIFF
--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -76,6 +76,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 	a := commonAnnotations(opts)
 	podSpec := corev1.PodSpec{
 		ServiceAccountName: opts.Name,
+		TerminationGracePeriodSeconds: ptr.To(int64(600)),
 		Affinity:           configureAffinity(LabelIngesterComponent, opts.Name, opts.Gates.DefaultNodeAffinity, opts.Stack.Template.Ingester),
 		Volumes: []corev1.Volume{
 			{

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -75,9 +75,9 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)
 	a := commonAnnotations(opts)
 	podSpec := corev1.PodSpec{
-		ServiceAccountName: opts.Name,
-		TerminationGracePeriodSeconds: ptr.To(int64(600)),
-		Affinity:           configureAffinity(LabelIngesterComponent, opts.Name, opts.Gates.DefaultNodeAffinity, opts.Stack.Template.Ingester),
+		ServiceAccountName:            opts.Name,
+		TerminationGracePeriodSeconds: ptr.To(defaultIngesterTerminationGracePeriodSeconds),
+		Affinity:                      configureAffinity(LabelIngesterComponent, opts.Name, opts.Gates.DefaultNodeAffinity, opts.Stack.Template.Ingester),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -186,3 +186,21 @@ func TestNewIngesterStatefulSet_TopologySpreadConstraints(t *testing.T) {
 		},
 	}, ss.Spec.Template.Spec.TopologySpreadConstraints)
 }
+
+func TestNewIngesterStatefulSet_TerminationGracePeriodSeconds(t *testing.T) {
+	ss := NewIngesterStatefulSet(Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			StorageClassName: "standard",
+			Template: &lokiv1.LokiTemplateSpec{
+				Ingester: &lokiv1.LokiComponentSpec{
+					Replicas: 1,
+				},
+			},
+		},
+	})
+
+	require.NotNil(t, ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	require.Equal(t, int64(600), *ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
+}

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -202,5 +202,5 @@ func TestNewIngesterStatefulSet_TerminationGracePeriodSeconds(t *testing.T) {
 	})
 
 	require.NotNil(t, ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
-	require.Equal(t, int64(600), *ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	require.Equal(t, defaultIngesterTerminationGracePeriodSeconds, *ss.Spec.Template.Spec.TerminationGracePeriodSeconds)
 }

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -161,6 +161,7 @@ ingester:
   wal:
     enabled: true
     dir: {{ .WriteAheadLog.Directory }}
+    flush_on_shutdown: true
     replay_memory_ceiling: {{ .WriteAheadLog.ReplayMemoryCeiling }}
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/both-generated/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/both-generated/config.yaml
@@ -53,6 +53,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/no-runtime-config/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/no-runtime-config/config.yaml
@@ -54,6 +54,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 536870912
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-alert-relabel-configs/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-alert-relabel-configs/config.yaml
@@ -54,6 +54,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-client/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-client/config.yaml
@@ -54,6 +54,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-overrides/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-overrides/config.yaml
@@ -54,6 +54,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-auth-basic/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-auth-basic/config.yaml
@@ -54,6 +54,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-auth-header/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-auth-header/config.yaml
@@ -53,6 +53,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-relabel-configs/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-relabel-configs/config.yaml
@@ -54,6 +54,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/schemas-template.yaml
+++ b/operator/internal/manifests/internal/config/testdata/schemas-template.yaml
@@ -53,6 +53,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/sts/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/sts/config.yaml
@@ -51,6 +51,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-hashring-spec-ipv6/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-hashring-spec-ipv6/config.yaml
@@ -56,6 +56,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-hashring-spec/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-hashring-spec/config.yaml
@@ -55,6 +55,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-manual-stream-ratelimits/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-manual-stream-ratelimits/config.yaml
@@ -54,6 +54,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-otlp-config/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-otlp-config/config.yaml
@@ -57,6 +57,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-replication-spec/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-replication-spec/config.yaml
@@ -56,6 +56,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-retention/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-retention/config.yaml
@@ -58,6 +58,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-s3-sse-kms/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-s3-sse-kms/config.yaml
@@ -59,6 +59,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-s3-sse-s3/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-s3-sse-s3/config.yaml
@@ -56,6 +56,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/internal/config/testdata/with-tls/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-tls/config.yaml
@@ -67,6 +67,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
+    flush_on_shutdown: true
     replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -275,6 +275,7 @@ func mutatePodSpec(existing *corev1.PodSpec, desired *corev1.PodSpec) {
 	existing.Containers = desired.Containers
 	existing.InitContainers = desired.InitContainers
 	existing.NodeSelector = desired.NodeSelector
+	existing.TerminationGracePeriodSeconds = desired.TerminationGracePeriodSeconds
 	existing.Tolerations = desired.Tolerations
 	existing.TopologySpreadConstraints = desired.TopologySpreadConstraints
 	existing.Volumes = desired.Volumes

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -275,7 +275,10 @@ func mutatePodSpec(existing *corev1.PodSpec, desired *corev1.PodSpec) {
 	existing.Containers = desired.Containers
 	existing.InitContainers = desired.InitContainers
 	existing.NodeSelector = desired.NodeSelector
-	existing.TerminationGracePeriodSeconds = desired.TerminationGracePeriodSeconds
+	// Only set TerminationGracePeriodSeconds when explicitly configured to avoid clearing the Kubernetes API server default.
+	if desired.TerminationGracePeriodSeconds != nil {
+		existing.TerminationGracePeriodSeconds = desired.TerminationGracePeriodSeconds
+	}
 	existing.Tolerations = desired.Tolerations
 	existing.TopologySpreadConstraints = desired.TopologySpreadConstraints
 	existing.Volumes = desired.Volumes

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -1200,3 +1200,68 @@ func TestGetMutateFunc_MutatePodDisruptionBudget(t *testing.T) {
 	require.Exactly(t, got.Labels, want.Labels)
 	require.Exactly(t, got.Spec, want.Spec)
 }
+
+func TestMutateFuncFor_TerminationGracePeriodSeconds(t *testing.T) {
+	type test struct {
+		name     string
+		got      *appsv1.Deployment
+		want     *appsv1.Deployment
+		expected *int64
+	}
+	table := []test{
+		{
+			name: "preserve existing value when desired is nil",
+			got: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: ptr.To(int64(30)),
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: nil,
+						},
+					},
+				},
+			},
+			expected: ptr.To(int64(30)),
+		},
+		{
+			name: "update when desired is set",
+			got: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: ptr.To(int64(30)),
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: ptr.To(int64(600)),
+						},
+					},
+				},
+			},
+			expected: ptr.To(int64(600)),
+		},
+	}
+
+	for _, tst := range table {
+		t.Run(tst.name, func(t *testing.T) {
+			t.Parallel()
+			f := MutateFuncFor(tst.got, tst.want, nil)
+			err := f()
+			require.NoError(t, err)
+			require.Equal(t, tst.expected, tst.got.Spec.Template.Spec.TerminationGracePeriodSeconds)
+		})
+	}
+}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -36,6 +36,8 @@ const (
 
 	lokiFrontendContainerName = "loki-query-frontend"
 
+	defaultIngesterTerminationGracePeriodSeconds = int64(600)
+
 	gatewayContainerName    = "gateway"
 	gatewayHTTPPort         = 8080
 	gatewayInternalPort     = 8081


### PR DESCRIPTION
**What this PR does / why we need it:**
Enables flush_on_shutdown for ingesters and increases terminationGracePeriodSeconds to 600s to ensure reliable chunk flushing during pod shutdown

**Which issue(s) this PR fixes:**
https://redhat.atlassian.net/browse/LOG-9864
related to:  https://redhat.atlassian.net/browse/LOG-9863

**Special notes for your reviewer:**
After evaluating flush_on_shutdown in RHOBS since end of June, we confirmed it significantly improves deployment reliability during cluster updates and configuration changes. This PR enables it by default in operator-managed deployments.

Since flush_on_shutdown increases the time required for ingesters to shut down, this PR also increases terminationGracePeriodSeconds to 600s to match the RHOBS configuration and provide sufficient time for chunk flushing to complete.

Changes:
- Enabled `flush_on_shutdown: true` in ingester WAL configuration
- Increased `terminationGracePeriodSeconds` to 600s for ingester pods
- Updated all test data files to reflect the new configuration

**Checklist**

- [x] Reviewed the CONTRIBUTING.md guide (required)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see here
- [ ] Changes that require user attention or interaction to upgrade are documented in docs/sources/setup/upgrade/_index.md
- [ ] If the change is deprecating or removing a configuration option, update the deprecated-config.yaml and deleted-config.yaml files respectively in the tools/deprecated-config-checker directory. Example PR
