### PR TITLE
fix(storage): Merge shard results across schema periods for bounded strategy

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -244,7 +244,6 @@ type querySizeLimiter struct {
 	logger            log.Logger
 	next              queryrangebase.Handler
 	statsHandler      queryrangebase.Handler
-	cfg               []config.PeriodConfig
 	maxLookBackPeriod time.Duration
 	limitFunc         func(context.Context, string) int
 	spec              querySizeLimitSpec
@@ -252,7 +251,6 @@ type querySizeLimiter struct {
 
 func newQuerySizeLimiter(
 	next queryrangebase.Handler,
-	cfg []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	logger log.Logger,
 	limitFunc func(context.Context, string) int,
@@ -262,7 +260,6 @@ func newQuerySizeLimiter(
 	q := &querySizeLimiter{
 		logger:            logger,
 		next:              next,
-		cfg:               cfg,
 		maxLookBackPeriod: engineOpts.MaxLookBackPeriod,
 		limitFunc:         limitFunc,
 		spec:              spec,
@@ -278,27 +275,25 @@ func newQuerySizeLimiter(
 
 // NewQuerierSizeLimiterMiddleware creates a new Middleware that enforces query size limits after sharding and splitting.
 func NewQuerierSizeLimiterMiddleware(
-	cfg []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	logger log.Logger,
 	limits Limits,
 	statsHandler ...queryrangebase.Handler,
 ) queryrangebase.Middleware {
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return newQuerySizeLimiter(next, cfg, engineOpts, logger, limits.MaxQuerierBytesRead, maxQuerierBytesReadSpec, statsHandler...)
+		return newQuerySizeLimiter(next, engineOpts, logger, limits.MaxQuerierBytesRead, maxQuerierBytesReadSpec, statsHandler...)
 	})
 }
 
 // NewQuerySizeLimiterMiddleware creates a new Middleware that enforces query size limits.
 func NewQuerySizeLimiterMiddleware(
-	cfg []config.PeriodConfig,
 	engineOpts logql.EngineOpts,
 	logger log.Logger,
 	limits Limits,
 	statsHandler ...queryrangebase.Handler,
 ) queryrangebase.Middleware {
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return newQuerySizeLimiter(next, cfg, engineOpts, logger, limits.MaxQueryBytesRead, maxQueryBytesReadSpec, statsHandler...)
+		return newQuerySizeLimiter(next, engineOpts, logger, limits.MaxQueryBytesRead, maxQueryBytesReadSpec, statsHandler...)
 	})
 }
 

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -748,14 +748,6 @@ func Test_WeightedParallelism_DivideByZeroError(t *testing.T) {
 func Test_MaxQuerySize(t *testing.T) {
 	const statsBytes = 1000
 
-	schemas := []config.PeriodConfig{
-		{
-			// TSDB -> Time -2 days
-			From:      config.DayTime{Time: model.TimeFromUnix(testTime.Add(-48 * time.Hour).Unix())},
-			IndexType: types.IndexTypeTSDB,
-		},
-	}
-
 	for _, tc := range []struct {
 		desc       string
 		query      string
@@ -861,8 +853,8 @@ func Test_MaxQuerySize(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), "foo")
 
 			middlewares := []queryrangebase.Middleware{
-				NewQuerySizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, queryStatsHandler),
-				NewQuerierSizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, querierStatsHandler),
+				NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, tc.limits, queryStatsHandler),
+				NewQuerierSizeLimiterMiddleware(testEngineOpts, util_log.Logger, tc.limits, querierStatsHandler),
 			}
 
 			_, err := queryrangebase.MergeMiddlewares(middlewares...).Wrap(promHandler).Do(ctx, lokiReq)
@@ -882,12 +874,6 @@ func Test_MaxQuerySize(t *testing.T) {
 func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 	// a sentinal query value to control when our mock stats handler returns context stats
 	ctxSentinal := `{context="true"}`
-	schemas := []config.PeriodConfig{
-		{
-			From:      config.DayTime{Time: model.TimeFromUnix(testTime.Add(-48 * time.Hour).Unix())},
-			IndexType: types.IndexTypeTSDB,
-		},
-	}
 
 	for _, tc := range []struct {
 		desc              string
@@ -998,7 +984,7 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 			}
 
 			middlewares := []queryrangebase.Middleware{
-				NewQuerySizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, fakeLimits{
+				NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
 					maxQueryBytesRead: tc.limit,
 				}, statsHandler),
 			}
@@ -1042,11 +1028,11 @@ func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {
 	}{
 		{
 			desc:       "QuerySizeLimiter",
-			middleware: NewQuerySizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, statsHandler),
+			middleware: NewQuerySizeLimiterMiddleware(engineOpts, util_log.Logger, lim, statsHandler),
 		},
 		{
 			desc:       "QuerierSizeLimiter",
-			middleware: NewQuerierSizeLimiterMiddleware(testSchemasTSDB, engineOpts, util_log.Logger, lim, statsHandler),
+			middleware: NewQuerierSizeLimiterMiddleware(engineOpts, util_log.Logger, lim, statsHandler),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -647,7 +647,7 @@ func NewLogFilterTripperware(cfg Config, engineOpts logql.EngineOpts, routerConf
 			QueryMetricsMiddleware(metrics.QueryMetrics),
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(limits),
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 		}
 
 		// Splitting, sharding, caching and retry middlwares are not added to v2 engine splits
@@ -684,7 +684,7 @@ func NewLogFilterTripperware(cfg Config, engineOpts logql.EngineOpts, routerConf
 			// The sharding middleware takes care of enforcing this limit for both shardable and non-shardable queries.
 			// If we are not using sharding, we enforce the limit by adding this middleware after time splitting.
 			chunksEngineMWs = append(chunksEngineMWs,
-				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+				NewQuerierSizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 			)
 		}
 
@@ -998,7 +998,7 @@ func NewMetricTripperware(cfg Config, engineOpts logql.EngineOpts, routerConfig 
 
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 		)
 
 		// Splitting, sharding, caching and retry middlwares are not added to v2 engine splits
@@ -1036,7 +1036,7 @@ func NewMetricTripperware(cfg Config, engineOpts logql.EngineOpts, routerConfig 
 
 			// TODO: also add for v2 splits?
 			chunksEngineMWs = append(chunksEngineMWs,
-				NewQuerierSizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+				NewQuerierSizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 			)
 		}
 
@@ -1131,7 +1131,7 @@ func NewInstantMetricTripperware(
 		queryRangeMiddleware := []base.Middleware{
 			StatsCollectorMiddleware(),
 			NewLimitsMiddleware(limits),
-			NewQuerySizeLimiterMiddleware(schema.Configs, engineOpts, log, limits, statsHandler),
+			NewQuerySizeLimiterMiddleware(engineOpts, log, limits, statsHandler),
 			NewSplitByRangeMiddleware(log, engineOpts, limits, cfg.InstantMetricQuerySplitAlign, metrics.rangeMapper),
 		}
 

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -227,33 +227,57 @@ func (c CompositeStore) GetShards(
 	targetBytesPerShard uint64,
 	predicate chunk.Predicate,
 ) (*logproto.ShardsResponse, error) {
-	// TODO(owen-d): improve. Since shards aren't easily merge-able,
-	// we choose the store which returned the highest shard count.
-	// This is only used when a query crosses a schema boundary
-	var groups []*logproto.ShardsResponse
+	var responses []*logproto.ShardsResponse
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		shards, err := store.GetShards(innerCtx, userID, from, through, targetBytesPerShard, predicate)
 		if err != nil {
 			return err
 		}
-		groups = append(groups, shards)
+		responses = append(responses, shards)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	switch {
-	case len(groups) == 1:
-		return groups[0], nil
-	case len(groups) == 0:
+	switch len(responses) {
+	case 0:
 		return nil, nil
-	default:
-		sort.Slice(groups, func(i, j int) bool {
-			return len(groups[i].Shards) > len(groups[j].Shards)
-		})
-		return groups[0], nil
+	case 1:
+		return responses[0], nil
 	}
+
+	// Multiple periods contributed. Each store bin-packs shard bounds from
+	// only its own fingerprints and bytes, so bounds aren't aligned across
+	// stores and can't be merged index-for-index. Keep the bounds from the
+	// store holding the most bytes -- the partition most representative of
+	// this query's data -- and drop every chunk group: a chunk group is only
+	// valid paired with its own store's bounds, so downstream re-resolves
+	// chunks live against the merged range instead, the same fallback
+	// power_of_two sharding always uses.
+	best := responses[0]
+	bestBytes := sumShardBytes(best)
+	for _, r := range responses[1:] {
+		if b := sumShardBytes(r); b > bestBytes {
+			best, bestBytes = r, b
+		}
+	}
+
+	merged := &logproto.ShardsResponse{Shards: best.Shards}
+	for _, r := range responses {
+		merged.Statistics.Merge(r.Statistics)
+	}
+	return merged, nil
+}
+
+func sumShardBytes(r *logproto.ShardsResponse) uint64 {
+	var total uint64
+	for _, s := range r.Shards {
+		if s.Stats != nil {
+			total += s.Stats.Bytes
+		}
+	}
+	return total
 }
 
 func (c CompositeStore) HasForSeries(from, through model.Time) (sharding.ForSeries, bool) {

--- a/pkg/storage/stores/composite_store_test.go
+++ b/pkg/storage/stores/composite_store_test.go
@@ -362,6 +362,80 @@ func TestVolume(t *testing.T) {
 	})
 }
 
+type mockStoreShards struct {
+	mockStore
+	resp *logproto.ShardsResponse
+	err  error
+}
+
+func (m mockStoreShards) GetShards(_ context.Context, _ string, _, _ model.Time, _ uint64, _ chunk.Predicate) (*logproto.ShardsResponse, error) {
+	return m.resp, m.err
+}
+
+func TestCompositeStore_GetShards(t *testing.T) {
+	t.Run("a single contributing store is returned unmodified, chunk groups included", func(t *testing.T) {
+		resp := &logproto.ShardsResponse{
+			Shards:      []logproto.Shard{{Bounds: logproto.FPBounds{Min: 0, Max: 100}, Stats: &stats.Stats{Bytes: 10}}},
+			ChunkGroups: []logproto.ChunkRefGroup{{Refs: []*logproto.ChunkRef{{Checksum: 1}}}},
+		}
+		resp.Statistics.Summary.Shards = 3
+		cs := CompositeStore{
+			stores: []compositeStoreEntry{
+				{model.TimeFromUnix(10), mockStoreShards{mockStore: mockStore(0), resp: resp}},
+			},
+		}
+
+		got, err := cs.GetShards(context.Background(), "fake", model.TimeFromUnix(10), model.TimeFromUnix(20), 100, chunk.Predicate{})
+		require.NoError(t, err)
+		require.Same(t, resp, got)
+	})
+
+	t.Run("the highest-byte store's bounds win, chunk groups are dropped, statistics are summed", func(t *testing.T) {
+		// The second store has fewer shards but more total bytes, and must win.
+		smaller := &logproto.ShardsResponse{
+			Shards: []logproto.Shard{
+				{Bounds: logproto.FPBounds{Min: 0, Max: 50}, Stats: &stats.Stats{Bytes: 10}},
+				{Bounds: logproto.FPBounds{Min: 51, Max: 100}, Stats: &stats.Stats{Bytes: 10}},
+				{Bounds: logproto.FPBounds{Min: 101, Max: 150}, Stats: &stats.Stats{Bytes: 10}},
+			},
+			ChunkGroups: []logproto.ChunkRefGroup{{}, {}, {Refs: []*logproto.ChunkRef{{Checksum: 1}}}},
+		}
+		smaller.Statistics.Summary.Shards = 2
+		bigger := &logproto.ShardsResponse{
+			Shards: []logproto.Shard{
+				{Bounds: logproto.FPBounds{Min: 0, Max: 100}, Stats: &stats.Stats{Bytes: 1000}},
+			},
+			ChunkGroups: []logproto.ChunkRefGroup{{Refs: []*logproto.ChunkRef{{Checksum: 2}}}},
+		}
+		bigger.Statistics.Summary.Shards = 5
+		cs := CompositeStore{
+			stores: []compositeStoreEntry{
+				{model.TimeFromUnix(10), mockStoreShards{mockStore: mockStore(0), resp: smaller}},
+				{model.TimeFromUnix(20), mockStoreShards{mockStore: mockStore(1), resp: bigger}},
+			},
+		}
+
+		got, err := cs.GetShards(context.Background(), "fake", model.TimeFromUnix(10), model.TimeFromUnix(30), 100, chunk.Predicate{})
+		require.NoError(t, err)
+		require.Equal(t, bigger.Shards, got.Shards)
+		require.Nil(t, got.ChunkGroups)
+		require.Equal(t, int64(7), got.Statistics.Summary.Shards)
+	})
+
+	t.Run("it returns an error if any store returns an error", func(t *testing.T) {
+		cs := CompositeStore{
+			stores: []compositeStoreEntry{
+				{model.TimeFromUnix(10), mockStoreShards{mockStore: mockStore(0), resp: &logproto.ShardsResponse{}}},
+				{model.TimeFromUnix(20), mockStoreShards{mockStore: mockStore(1), err: errors.New("something bad")}},
+			},
+		}
+
+		got, err := cs.GetShards(context.Background(), "fake", model.TimeFromUnix(10), model.TimeFromUnix(30), 100, chunk.Predicate{})
+		require.Error(t, err)
+		require.Nil(t, got)
+	})
+}
+
 func TestFilterForTimeRange(t *testing.T) {
 	mkRefs := func(from, through model.Time) (res []*logproto.ChunkRef) {
 		for i := from; i <= through; i++ {


### PR DESCRIPTION
## What this PR does

Builds on #24318, which removes the schema-period restriction on query sharding but leaves `CompositeStore.GetShards` unfixed: it picks the store with the highest shard count on a cross-period query and discards every other period's response, including chunk groups. That's fine for `power_of_two` (data-independent), but for the `bounded` strategy it silently drops chunk groups for whichever period didn't "win" once cross-period sharding is allowed.

This PR:
- Picks the response with the most total bytes instead of the highest shard count, drops `ChunkGroups` when more than one period contributes (so those shards resolve chunks live instead, the same fallback `power_of_two` already uses), and merges `Statistics` across periods.
- Removes the `cfg` parameter left unused on `querySizeLimiter`/its constructors after #24318 dropped the check that used it.

## Test plan

- [x] `pkg/storage/stores` unit tests cover the merge logic directly (byte-based selection, dropped chunk groups, merged statistics).
- [x] Full `querier/queryrange` and `storage/stores` suites pass.