### PR TITLE
refactor: Rename default-order sample iterators to timestamp-first

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1189,7 +1189,7 @@ func (i *Ingester) QuerySample(req *logproto.SampleQueryRequest, queryServer log
 			return err
 		}
 
-		it = iter.NewMergeSampleIterator(ctx, []iter.SampleIterator{it, storeItr})
+		it = iter.NewTimestampFirstMergeSampleIterator(ctx, []iter.SampleIterator{it, storeItr})
 	}
 
 	defer util.LogErrorWithContext(ctx, "closing iterator", it.Close)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1081,9 +1081,9 @@ func Test_DedupeIngester(t *testing.T) {
 				Plan:     testutil.MustPlan(`sum(rate({foo="bar"}[1m])) by (bar)`),
 			})
 			require.NoError(t, err)
-			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
+			iterators = append(iterators, iter.NewTimestampFirstSampleQueryClientIterator(stream))
 		}
-		it := iter.NewMergeSampleIterator(ctx, iterators)
+		it := iter.NewTimestampFirstMergeSampleIterator(ctx, iterators)
 		var expectedLabels []string
 		for _, s := range streams {
 			expectedLabels = append(expectedLabels, labels.NewBuilder(s).Del("foo").Labels().String())
@@ -1117,9 +1117,9 @@ func Test_DedupeIngester(t *testing.T) {
 				Plan:     testutil.MustPlan(`sum(rate({foo="bar"}[1m]))`),
 			})
 			require.NoError(t, err)
-			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
+			iterators = append(iterators, iter.NewTimestampFirstSampleQueryClientIterator(stream))
 		}
-		it := iter.NewMergeSampleIterator(ctx, iterators)
+		it := iter.NewTimestampFirstMergeSampleIterator(ctx, iterators)
 		for i := int64(0); i < requests; i++ {
 			actualHashes := []uint64{}
 			for j := 0; j < int(streamCount); j++ {
@@ -1231,9 +1231,9 @@ func Test_DedupeIngesterParser(t *testing.T) {
 				Plan:     testutil.MustPlan(`rate({foo="bar"} | json [1m])`),
 			})
 			require.NoError(t, err)
-			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
+			iterators = append(iterators, iter.NewTimestampFirstSampleQueryClientIterator(stream))
 		}
-		it := iter.NewMergeSampleIterator(ctx, iterators)
+		it := iter.NewTimestampFirstMergeSampleIterator(ctx, iterators)
 
 		for i := 0; i < requests; i++ {
 			for j := 0; j < streamCount; j++ {
@@ -1257,9 +1257,9 @@ func Test_DedupeIngesterParser(t *testing.T) {
 				Plan:     testutil.MustPlan(`sum by (c,d,e,foo) (rate({foo="bar"} | json [1m]))`),
 			})
 			require.NoError(t, err)
-			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
+			iterators = append(iterators, iter.NewTimestampFirstSampleQueryClientIterator(stream))
 		}
-		it := iter.NewMergeSampleIterator(ctx, iterators)
+		it := iter.NewTimestampFirstMergeSampleIterator(ctx, iterators)
 
 		for i := 0; i < requests; i++ {
 			for j := 0; j < streamCount; j++ {

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -164,11 +164,12 @@ type mergeSampleIterator struct {
 	errs   []error
 }
 
-// NewMergeSampleIterator returns a new iterator which uses a heap to merge together samples for multiple iterators and deduplicate if any.
+// NewTimestampFirstMergeSampleIterator returns a new iterator which uses a heap to merge together samples for multiple iterators and deduplicate if any.
 // The iterator only order and merge entries across given `is` iterators, it does not merge entries within individual iterator.
 // This means using this iterator with a single iterator will result in the same result as the input iterator.
+// Samples are returned in global timestamp order, as long as each input iterator is itself timestamp-ordered.
 // If you don't need to deduplicate sample, use `NewSortSampleIterator` instead.
-func NewMergeSampleIterator(ctx context.Context, is []SampleIterator) SampleIterator {
+func NewTimestampFirstMergeSampleIterator(ctx context.Context, is []SampleIterator) SampleIterator {
 	h := SampleIteratorHeap{
 		its: make([]SampleIterator, 0, len(is)),
 	}
@@ -502,8 +503,8 @@ type QuerySampleClient interface {
 	CloseSend() error
 }
 
-// NewSampleQueryClientIterator returns an iterator over a QueryClient.
-func NewSampleQueryClientIterator(client QuerySampleClient) SampleIterator {
+// NewTimestampFirstSampleQueryClientIterator returns a timestamp-first iterator over a QueryClient.
+func NewTimestampFirstSampleQueryClientIterator(client QuerySampleClient) SampleIterator {
 	return &sampleQueryClientIterator{
 		client: client,
 	}
@@ -524,7 +525,7 @@ func (i *sampleQueryClientIterator) Next() bool {
 		stats.JoinIngesters(ctx, batch.Stats)
 		_ = metadata.AddWarnings(ctx, batch.Warnings...)
 
-		i.curr = NewSampleQueryResponseIterator(batch)
+		i.curr = NewTimestampFirstSampleQueryResponseIterator(batch)
 	}
 	return true
 }
@@ -549,8 +550,8 @@ func (i *sampleQueryClientIterator) Close() error {
 	return i.client.CloseSend()
 }
 
-// NewSampleQueryResponseIterator returns an iterator over a SampleQueryResponse.
-func NewSampleQueryResponseIterator(resp *logproto.SampleQueryResponse) SampleIterator {
+// NewTimestampFirstSampleQueryResponseIterator returns a timestamp-first iterator over a SampleQueryResponse.
+func NewTimestampFirstSampleQueryResponseIterator(resp *logproto.SampleQueryResponse) SampleIterator {
 	return NewMultiSeriesIterator(resp.Series)
 }
 

--- a/pkg/iter/sample_iterator_test.go
+++ b/pkg/iter/sample_iterator_test.go
@@ -107,9 +107,9 @@ var carSeries = logproto.Series{
 	},
 }
 
-func TestNewMergeSampleIterator(t *testing.T) {
+func TestNewTimestampFirstMergeSampleIterator(t *testing.T) {
 	t.Run("with labels", func(t *testing.T) {
-		it := NewMergeSampleIterator(context.Background(),
+		it := NewTimestampFirstMergeSampleIterator(context.Background(),
 			[]SampleIterator{
 				NewSeriesIterator(varSeries),
 				NewSeriesIterator(carSeries),
@@ -133,7 +133,7 @@ func TestNewMergeSampleIterator(t *testing.T) {
 		require.NoError(t, it.Close())
 	})
 	t.Run("no labels", func(t *testing.T) {
-		it := NewMergeSampleIterator(context.Background(),
+		it := NewTimestampFirstMergeSampleIterator(context.Background(),
 			[]SampleIterator{
 				NewSeriesIterator(logproto.Series{
 					Labels:     ``,
@@ -198,8 +198,8 @@ func (f *fakeSampleClient) Recv() (*logproto.SampleQueryResponse, error) {
 
 func (fakeSampleClient) Context() context.Context { return context.Background() }
 func (fakeSampleClient) CloseSend() error         { return nil }
-func TestNewSampleQueryClientIterator(t *testing.T) {
-	it := NewSampleQueryClientIterator(&fakeSampleClient{
+func TestNewTimestampFirstSampleQueryClientIterator(t *testing.T) {
+	it := NewTimestampFirstSampleQueryClientIterator(&fakeSampleClient{
 		series: [][]logproto.Series{
 			{varSeries},
 			{carSeries},
@@ -294,7 +294,7 @@ func TestMergeSampleIterator_ShouldCloseEverySource(t *testing.T) {
 		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2), sample(5)}, labels: `{s="b"}`}
 		c := &erroringSampleIterator{samples: []logproto.Sample{sample(3)}, labels: `{s="c"}`}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b, c})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{a, b, c})
 		var got int
 		for it.Next() {
 			got++
@@ -311,7 +311,7 @@ func TestMergeSampleIterator_ShouldCloseEverySource(t *testing.T) {
 	t.Run("single source drained through the shortcut is closed once", func(t *testing.T) {
 		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(2)}, labels: `{s="a"}`}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{a})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{a})
 		for it.Next() { //nolint:revive
 		}
 		require.NoError(t, it.Close())
@@ -323,7 +323,7 @@ func TestMergeSampleIterator_ShouldCloseEverySource(t *testing.T) {
 		empty := &erroringSampleIterator{labels: `{s="empty"}`}
 		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{empty, a})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{empty, a})
 		for it.Next() { //nolint:revive
 		}
 		require.NoError(t, it.Close())
@@ -336,7 +336,7 @@ func TestMergeSampleIterator_ShouldCloseEverySource(t *testing.T) {
 		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
 		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2)}, labels: `{s="b"}`}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{a, b})
 		require.True(t, it.Next()) // drains a; b stays on the heap
 		require.NoError(t, it.Close())
 
@@ -350,7 +350,7 @@ func TestMergeSampleIterator_ShouldCloseEverySource(t *testing.T) {
 		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(3)}, labels: `{s="a"}`, closeErr: errors.New("close a")}
 		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2), sample(4)}, labels: `{s="b"}`, closeErr: errors.New("close b")}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{a, b})
 		require.True(t, it.Next()) // prefetch both onto the heap
 		it.Close()
 
@@ -363,7 +363,7 @@ func TestMergeSampleIterator_ShouldCloseEverySource(t *testing.T) {
 		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
 		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2)}, labels: `{s="b"}`}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{a, b})
 		require.NoError(t, it.Close())
 
 		require.Equal(t, 1, a.closed, "an un-prefetched source is closed by Close")
@@ -383,7 +383,7 @@ func TestMergeSampleIterator_ShouldSurfaceDrainError(t *testing.T) {
 		errored := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(2)}, labels: `{s="a"}`, err: wantErr}
 		healthy := &erroringSampleIterator{samples: []logproto.Sample{sample(3)}, labels: `{s="b"}`}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{errored, healthy})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{errored, healthy})
 		for it.Next() { //nolint:revive
 		}
 		require.ErrorIs(t, it.Err(), wantErr)
@@ -396,7 +396,7 @@ func TestMergeSampleIterator_ShouldSurfaceDrainError(t *testing.T) {
 		// A lone source that fails at EOF drains through the heap.Len()==1 shortcut.
 		errored := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(2)}, labels: `{s="a"}`, err: wantErr}
 
-		it := NewMergeSampleIterator(ctx, []SampleIterator{errored})
+		it := NewTimestampFirstMergeSampleIterator(ctx, []SampleIterator{errored})
 		for it.Next() { //nolint:revive
 		}
 		require.ErrorIs(t, it.Err(), wantErr)
@@ -583,7 +583,7 @@ func BenchmarkSortSampleIterator(b *testing.B) {
 				itrs = append(itrs, NewSeriesIterator(series[i]))
 			}
 			b.StartTimer()
-			it := NewMergeSampleIterator(ctx, itrs)
+			it := NewTimestampFirstMergeSampleIterator(ctx, itrs)
 			for it.Next() {
 				it.At()
 			}
@@ -675,7 +675,7 @@ func Test_SampleSortIterator(t *testing.T) {
 }
 
 func TestDedupeMergeSampleIterator(t *testing.T) {
-	it := NewMergeSampleIterator(context.Background(),
+	it := NewTimestampFirstMergeSampleIterator(context.Background(),
 		[]SampleIterator{
 			NewSeriesIterator(logproto.Series{
 				Labels: ``,
@@ -746,7 +746,7 @@ func TestMergeSampleIteratorZeroHash(t *testing.T) {
 		},
 	}
 
-	it := NewMergeSampleIterator(context.Background(), []SampleIterator{
+	it := NewTimestampFirstMergeSampleIterator(context.Background(), []SampleIterator{
 		NewSeriesIterator(series1),
 		NewSeriesIterator(series2),
 	})

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -697,7 +697,7 @@ func newRangeAggEvaluator(
 ) (StepEvaluator, error) {
 	switch expr.Operation {
 	case syntax.OpRangeTypeAbsent:
-		iter, err := newRangeVectorIterator(
+		iter, err := newTimestampFirstRangeVectorIterator(
 			it, expr,
 			expr.Left.Interval.Nanoseconds(),
 			q.Step().Nanoseconds(),
@@ -749,7 +749,7 @@ func newRangeAggEvaluator(
 			iter: iter,
 		}, nil
 	default:
-		iter, err := newRangeVectorIterator(
+		iter, err := newTimestampFirstRangeVectorIterator(
 			it, expr,
 			expr.Left.Interval.Nanoseconds(),
 			q.Step().Nanoseconds(),

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -38,7 +38,9 @@ type RangeVectorIterator interface {
 	Error() error
 }
 
-func newRangeVectorIterator(
+// newTimestampFirstRangeVectorIterator returns a range-vector iterator. The input
+// iterator must return samples in global timestamp order.
+func newTimestampFirstRangeVectorIterator(
 	it iter.PeekingSampleIterator,
 	expr *syntax.RangeAggregationExpr,
 	selRange, step, start, end, offset int64) (RangeVectorIterator, error) {

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -198,7 +198,7 @@ func Benchmark_RangeVectorIterator(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		i := 0
-		it, err := newRangeVectorIterator(newfakePeekingSampleIterator(samples),
+		it, err := newTimestampFirstRangeVectorIterator(newfakePeekingSampleIterator(samples),
 			&syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}, tt.selRange,
 			tt.step, tt.start.UnixNano(), tt.end.UnixNano(), tt.offset)
 		if err != nil {
@@ -322,7 +322,7 @@ func Test_RangeVectorIterator_InstantQuery(t *testing.T) {
 		t.Run(
 			fmt.Sprintf("%d logs[%s] - start %s - end %s", i, tt.selRange, tt.now.Add(-tt.selRange), tt.now),
 			func(t *testing.T) {
-				it, err := newRangeVectorIterator(
+				it, err := newTimestampFirstRangeVectorIterator(
 					newfakePeekingSampleIterator(samples),
 					&syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount},
 					tt.selRange.Nanoseconds(),
@@ -467,7 +467,7 @@ func Test_RangeVectorIterator(t *testing.T) {
 		t.Run(
 			fmt.Sprintf("logs[%s] - step: %s - offset: %s", time.Duration(tt.selRange), time.Duration(tt.step), time.Duration(tt.offset)),
 			func(t *testing.T) {
-				it, err := newRangeVectorIterator(newfakePeekingSampleIterator(samples),
+				it, err := newTimestampFirstRangeVectorIterator(newfakePeekingSampleIterator(samples),
 					&syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}, tt.selRange,
 					tt.step, tt.start.UnixNano(), tt.end.UnixNano(), tt.offset)
 				require.NoError(t, err)
@@ -491,7 +491,7 @@ func Test_RangeVectorIteratorBadLabels(t *testing.T) {
 			Labels:  "{badlabels=}",
 			Samples: samples,
 		}))
-	it, err := newRangeVectorIterator(badIterator,
+	it, err := newTimestampFirstRangeVectorIterator(badIterator,
 		&syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}, (30 * time.Second).Nanoseconds(),
 		(30 * time.Second).Nanoseconds(), time.Unix(10, 0).UnixNano(), time.Unix(100, 0).UnixNano(), 0)
 	require.NoError(t, err)
@@ -537,7 +537,7 @@ func Test_InstantQueryRangeVectorAggregations(t *testing.T) {
 	var start, end int64 = 4, 4 // Instant query
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("testing aggregation %s", tt.name), func(t *testing.T) {
-			it, err := newRangeVectorIterator(sampleIter(tt.negative),
+			it, err := newTimestampFirstRangeVectorIterator(sampleIter(tt.negative),
 				&syntax.RangeAggregationExpr{Left: &syntax.LogRangeExpr{Interval: 2}, Params: proto.Float64(0.99), Operation: tt.op},
 				3, 1, start, end, 0)
 			require.NoError(t, err)

--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -267,7 +267,7 @@ func (q *IngesterQuerier) SelectSample(ctx context.Context, params logql.SelectS
 
 	iterators := make([]iter.SampleIterator, len(resps))
 	for i := range resps {
-		iterators[i] = iter.NewSampleQueryClientIterator(resps[i].response.(logproto.Querier_QuerySampleClient))
+		iterators[i] = iter.NewTimestampFirstSampleQueryClientIterator(resps[i].response.(logproto.Querier_QuerySampleClient))
 	}
 	return iterators, nil
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -271,7 +271,7 @@ func (q *SingleTenantQuerier) SelectSamples(ctx context.Context, params logql.Se
 
 		iters = append(iters, storeIter)
 	}
-	return iter.NewMergeSampleIterator(ctx, iters), nil
+	return iter.NewTimestampFirstMergeSampleIterator(ctx, iters), nil
 }
 
 func (q *SingleTenantQuerier) isWithinIngesterMaxLookbackPeriod(maxLookback time.Duration, queryEnd time.Time) bool {

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -574,7 +574,7 @@ func mockStreamIterator(from int, quantity int) iter.EntryIterator {
 // where entries timestamp and line string are constructed as sequential numbers
 // starting at from
 func mockSampleIterator(client iter.QuerySampleClient) iter.SampleIterator {
-	return iter.NewSampleQueryClientIterator(client)
+	return iter.NewTimestampFirstSampleQueryClientIterator(client)
 }
 
 // mockStream return a stream with quantity entries, where entries timestamp and

--- a/pkg/querier/store_combiner.go
+++ b/pkg/querier/store_combiner.go
@@ -123,7 +123,7 @@ func (sc *StoreCombiner) SelectSamples(ctx context.Context, req logql.SelectSamp
 		iters = append(iters, iter)
 	}
 
-	return iter.NewMergeSampleIterator(ctx, iters), nil
+	return iter.NewTimestampFirstMergeSampleIterator(ctx, iters), nil
 }
 
 // SelectLogs implements Store

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -469,7 +469,7 @@ type sampleBatchIterator struct {
 	extractor syntax.SampleExtractor
 }
 
-func newSampleBatchIterator(
+func newTimestampFirstSampleBatchIterator(
 	ctx context.Context,
 	schemas config.SchemaConfig,
 	metrics *ChunkMetrics,
@@ -618,7 +618,7 @@ func (it *sampleBatchIterator) buildHeapIterator(
 		result = append(result, iter.NewNonOverlappingSampleIterator(iterators))
 	}
 
-	return iter.NewMergeSampleIterator(it.ctx, result), nil
+	return iter.NewTimestampFirstMergeSampleIterator(it.ctx, result), nil
 }
 
 func removeMatchersByName(matchers []*labels.Matcher, names ...string) []*labels.Matcher {

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1414,7 +1414,7 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 			ex, err := log.NewLineSampleExtractor(log.CountExtractor, nil, nil, false, false)
 			require.NoError(t, err)
 
-			it, err := newSampleBatchIterator(
+			it, err := newTimestampFirstSampleBatchIterator(
 				context.Background(),
 				s,
 				NilMetrics,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -637,7 +637,7 @@ func (s *LokiStore) SelectSamples(ctx context.Context, req logql.SelectSamplePar
 		chunkFilterer = s.chunkFilterer.ForRequest(ctx)
 	}
 
-	return newSampleBatchIterator(
+	return newTimestampFirstSampleBatchIterator(
 		ctx,
 		s.schemaCfg,
 		s.chunkMetrics,


### PR DESCRIPTION
**What this PR does / why we need it**:
Upcoming work adds per-stream ("stream-first") sample iterators as an alternative to the current global-timestamp-ordered merge, for metric queries reading data objects. This PR renames the existing default-order iterators and helpers to an explicit "timestamp-first" name so the two orderings pair up by name, keeping that follow-up diff small and readable.

Pure rename: no behavior change, only identifiers, a couple of doc-comment clarifications, and call-site updates.

- `NewMergeSampleIterator` → `NewTimestampFirstMergeSampleIterator`
- `NewSampleQueryClientIterator` → `NewTimestampFirstSampleQueryClientIterator`
- `NewSampleQueryResponseIterator` → `NewTimestampFirstSampleQueryResponseIterator`
- `newSampleBatchIterator` → `newTimestampFirstSampleBatchIterator`
- `newRangeVectorIterator` → `newTimestampFirstRangeVectorIterator`

**Which issue(s) this PR fixes**:
Part of the first action item in grafana/loki-private#2798.

**Special notes for your reviewer**:
Scoped deliberately tight: no new stream-first types, params, or metrics land here — those come in later PRs.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)