### PR TITLE
docs: Explain delayed visibility of logs with past timestamps 🤖🤖🤖

### DIFF
--- a/docs/sources/shared/troubleshoot-query.md
+++ b/docs/sources/shared/troubleshoot-query.md
@@ -1179,6 +1179,44 @@ When tailing logs, the WebSocket connection was closed unexpectedly. This can ha
 
 These errors occur when requested data is not available.
 
+### Logs with past timestamps are temporarily unavailable
+
+**Symptom:**
+
+Loki accepts log entries with past timestamps, but queries for those timestamps
+return an empty result. The entries appear later without another ingestion
+request.
+
+**Cause:**
+
+The `querier.query_ingesters_within` setting limits how far into the past a
+query can end and still reach ingesters. The default is `3h`. If a query ends
+more than three hours ago, Loki queries only the backing store. An ingester can
+still hold a newly accepted entry with a past timestamp in an in-memory chunk.
+Loki can't return the entry until the ingester flushes that chunk to the backing
+store.
+
+If you enable query result caching, Loki can cache an empty result obtained
+before the flush. That result can remain in the cache after the chunk reaches
+the backing store.
+
+**Resolution:**
+
+1. Confirm that Loki accepted the write request.
+1. Compare the query's end time with `querier.query_ingesters_within`.
+1. Wait for the ingester to flush the chunk, then retry after the cached result
+   expires, if applicable.
+1. If logs with past timestamps must be queryable immediately, increase
+   `query_ingesters_within` to cover the backfill window, or set it to `0s` to
+   query ingesters for all time ranges:
+
+   ```yaml
+   querier:
+     query_ingesters_within: 0s
+   ```
+
+   Querying ingesters for past time ranges increases ingester query load.
+
 ### Error: No data found
 
 **Error message:**


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents why Loki can accept log entries with past timestamps but temporarily omit them from queries. The new troubleshooting section connects `query_ingesters_within` with in-memory chunks and result caching, then gives operators recovery steps and explains the query-load tradeoff of widening the ingester lookback.

**Which issue(s) this PR fixes**:

Fixes #8621

**Special notes for your reviewer**:

The behavior and default were verified against `pkg/querier/intervals.go`, `pkg/querier/querier.go`, and the generated configuration reference on current `main`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated (documentation-only change)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` (not applicable; no behavior or configuration change)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15) (not applicable)
