### PR TITLE
fix: prevent WAL replay liveness probe restart loop

### DIFF
--- a/docs/sources/operations/storage/wal.md
+++ b/docs/sources/operations/storage/wal.md
@@ -125,6 +125,57 @@ Then you may recreate the (updated) StatefulSet and one-by-one start deleting th
 
 By following the above steps, you can ensure a smooth scaling down process for the Loki ingesters while maintaining data integrity and minimizing potential disruptions.
 
+
+
+### Kubernetes liveness probe restart loop warning
+
+**IMPORTANT:** When deploying Loki on Kubernetes with a liveness probe on the `/ready` endpoint, you may encounter a restart loop. The `/ready` endpoint returns HTTP 503 until WAL replay has completed, which can take many minutes for large WALs (e.g., >1 GB with 650 segments).
+
+When a liveness probe fails during WAL replay:
+1. Kubernetes sends SIGTERM to the pod mid-replay
+2. The interrupted flush leaves the WAL larger than before
+3. On the next restart, replay takes even longer
+4. This repeats until a cluster operator manually intervenes
+
+**Recommended configurations:**
+
+- **Best practice (no liveness probe):** Leave `loki.livenessProbe` empty (`{}`) in your `values.yaml`. The default is no liveness probe, which is recommended for most deployments.
+
+- **Using `/metrics` instead:** If you need a liveness probe, use the `/metrics` endpoint which is always available:
+  ```yaml
+  livenessProbe:
+    httpGet:
+      path: /metrics
+      port: http-metrics
+    initialDelaySeconds: 15
+    timeoutSeconds: 1
+  ```
+
+- **Pairing liveness + startup probes:** If you must use a liveness probe on `/ready`, provide a generous startup probe with a long failure threshold (30+ minutes):
+  ```yaml
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+  # ... (other settings as needed)
+  startupProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    periodSeconds: 10
+    initialDelaySeconds: 30
+    failureThreshold: 180  # 1800s = 30 minutes
+  ```
+
+**Recovery from the loop:**
+If you encounter this restart loop, the pod can recover by:
+1. Deleting the problematic pod gracefully: `kubectl delete pod <pod-name>`
+2. The pod will shut down cleanly, flush its WAL to storage, and checkpoint
+3. The next startup will replay a smaller WAL quickly
+4. No further restarts will occur
+
+Do not use `kubectl delete pod --force --grace-period=0` as this will leave the WAL corrupted.
+
 ### Non-Kubernetes or baremetal deployments
 
 * When the ingester restarts for any reason (upgrade, crash, etc), it should be able to attach to the same volume in order to recover back the WAL and tokens.

--- a/docs/sources/operations/storage/wal.md
+++ b/docs/sources/operations/storage/wal.md
@@ -174,7 +174,7 @@ If you encounter this restart loop, the pod can recover by:
 3. The next startup will replay a smaller WAL quickly
 4. No further restarts will occur
 
-Do not use `kubectl delete pod --force --grace-period=0` as this will leave the WAL corrupted.
+Do not use `kubectl delete pod --force --grace-period=0` as this skips the flush/checkpoint, so the next replay is as long or longer.
 
 ### Non-Kubernetes or baremetal deployments
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -69,6 +69,29 @@ commonLabels: {}
 # @default -- See values.yaml
 loki:
   # Configures the liveness probe for all of the Loki pods
+  # NOTE: Do not use /ready for liveness probes on ingesters or single-binary deployments.
+  # The /ready endpoint returns 503 until WAL replay completes, which can take many minutes
+  # for large WALs (e.g., >1 GB with 650 segments). A liveness probe on /ready will cause
+  # the pod to be SIGTERM'd mid-replay, leaving the WAL larger and creating a restart loop.
+  #
+  # If a liveness probe is desired, use /metrics which is always available:
+  #   livenessProbe:
+  #     httpGet:
+  #       path: /metrics
+  #       port: http-metrics
+  #       initialDelaySeconds: 15
+  #       timeoutSeconds: 1
+  #
+  # Or pair a liveness probe with a very generous startupProbe on /ready:
+  #   startupProbe:
+  #     httpGet:
+  #       path: /ready
+  #       port: http-metrics
+  #       periodSeconds: 10
+  #       initialDelaySeconds: 30
+  #       failureThreshold: 180  # 1800s = 30 minutes to allow WAL replay completion
+  #
+  # Default is no liveness probe ({}), which is recommended for most deployments.
   livenessProbe: {}
   # Configures the readiness probe for all of the Loki pods
   readinessProbe:
@@ -81,6 +104,10 @@ loki:
     failureThreshold: 3
     timeoutSeconds: 1
   # Configures the startup probe for all of the Loki pods
+  # This allows WAL replay to complete without triggering pod restarts.
+  # On each restart, Kubernetes cancels in-flight replay, leaving the WAL
+  # larger and causing the next replay to take even longer—a restart loop.
+  # Set failureThreshold high (e.g., 180) to allow WAL replay to complete.
   startupProbe: {}
   image:
     # -- The Docker registry

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -83,13 +83,13 @@ loki:
   #       timeoutSeconds: 1
   #
   # Or pair a liveness probe with a very generous startupProbe on /ready:
-  #   startupProbe:
-  #     httpGet:
-  #       path: /ready
-  #       port: http-metrics
-  #       periodSeconds: 10
-  #       initialDelaySeconds: 30
-  #       failureThreshold: 180  # 1800s = 30 minutes to allow WAL replay completion
+  # startupProbe:
+  #   httpGet:
+  #     path: /ready
+  #     port: http-metrics
+  #     periodSeconds: 10
+  #     initialDelaySeconds: 30
+  #     failureThreshold: 180  # 1800s = 30 minutes to allow WAL replay completion
   #
   # Default is no liveness probe ({}), which is recommended for most deployments.
   livenessProbe: {}


### PR DESCRIPTION
Problem
-------
An ingester's `/ready` endpoint returns 503 until WAL replay has finished. With a large WAL (>1 GB, ~650 segments), replay can take many minutes. If a **liveness** probe points at `/ready` with default settings, Kubernetes SIGTERM's Loki mid-replay, the interrupted flush leaves the WAL larger, and the next start replays even longer—a self-sustaining restart loop (observed 666 restarts over ~5 days, exit code 1 "failed services").

Root cause
----------
This issue is not caused by the current `production/helm/loki/values.yaml` chart, which has `livenessProbe: {}` (no default probe). The problematic `/ready` liveness probe was from the deprecated `loki-stack` chart. However, deployments using liveness probes on `/ready` can still encounter restart loops due to pod timing during WAL replay.

Fix
---
1. **Added comprehensive documentation**: Added detailed comments in `production/helm/loki/values.yaml` explaining why `/ready` should not be used for liveness probes on ingesters/single-binary deployments, the mechanism causing the restart loop, and two recommended alternatives:
   - Use `/metrics` for liveness (always available)
   - Pair a liveness probe with a generous startupProbe (failureThreshold of 180 = 30 minutes)
2. **Updated operations documentation**: Added a new section "Kubernetes liveness probe restart loop warning" in `docs/sources/operations/storage/wal.md` covering:
   - The mechanism causing the loop
   - Three recommended configurations
   - Recovery steps from a running loop
   - Command for graceful recovery: `kubectl delete pod <pod-name>`
   - Note that `--force --grace-period=0` skips the flush/checkpoint, so the next replay is as long or longer

How tested
----------
`helm template` output is unchanged for default values (comments only); the docs page builds.


Links
-----
- Issue: https://github.com/grafana/loki/issues/24396
- `/ready` endpoint docs: `docs/sources/reference/loki-http-api.md`
- WAL documentation: `docs/sources/operations/storage/wal.md`
- Helm chart: `production/helm/loki/values.yaml`

Notes
-----
- This fix was prepared with an AI agent operated by KR-Ravindra (AI-contribution policies: https://grafana.com/cnf-services/ai-contribution-policy/)
- Existing deployments experiencing the loop can recover by gracefully deleting the pod
- Migration from deprecated `loki-stack` chart is encouraged
