### PR TITLE
fix(distributor): Map Kafka producer and context-cancellation errors to retryable statuses

### DIFF
--- a/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
@@ -819,7 +819,9 @@ The Loki service is unavailable or not listening on the expected port.
 
 **Cause:**
 
-Requests are timing out due to slow response times or network issues.
+Requests are timing out due to slow response times or network issues. This
+includes the distributor's own request context expiring while still waiting
+on Kafka or ingester writes to complete.
 
 **Default configuration:**
 

--- a/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
@@ -965,6 +965,28 @@ The distributor's Kafka producer wasn't able to deliver records to the Kafka bro
 - HTTP status: 503 Service Unavailable
 - Configurable per tenant: No
 
+### Error: Kafka producer closed
+
+**Error message:**
+
+- `client closed`
+
+**Cause:**
+
+The distributor's Kafka producer was closed while a push was in flight, most commonly a distributor pod shutting down during a rollout or scale-down. Unlike the backpressure errors above, this isn't caused by Kafka broker load.
+
+**Resolution:**
+
+* **Implement retry logic** with exponential backoff in your client; a retry lands on a different distributor replica.
+* If this occurs outside of rollouts or scaling events, check for distributor pods crashing or being OOM killed.
+
+**Properties:**
+
+- Enforced by: Distributor (Kafka producer)
+- Retryable: Yes
+- HTTP status: 503 Service Unavailable
+- Configurable per tenant: No
+
 ## Structured metadata errors
 
 These errors occur when using structured metadata incorrectly.

--- a/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
@@ -924,6 +924,47 @@ Loki is temporarily unable to handle requests due to high load or maintenance. T
 - HTTP status: 503 Service Unavailable
 - Configurable per tenant: No
 
+### Error: Kafka producer backpressure
+
+These errors occur only when the distributor is configured to write to Kafka (`-distributor.kafka-writes-enabled=true`), and indicate that the Kafka producer could not keep up with the incoming write volume.
+
+**Error messages:**
+
+- `records have timed out before they were able to be produced`
+- `the maximum amount of records are buffered, cannot buffer more`
+
+**Cause:**
+
+The distributor's Kafka producer wasn't able to deliver records to the Kafka brokers within `kafka_config.write_timeout`, or the amount of unacknowledged, buffered data reached `kafka_config.producer_max_buffered_bytes`. Both are transient backpressure conditions: the Kafka brokers or the network path to them are slower than the rate at which the distributor is trying to produce records, for example during a broker rollout, a partition rebalance, or a broker-side incident.
+
+**Default configuration:**
+
+- `kafka_config.write_timeout` (`-kafka.write-timeout`): 10s
+- `kafka_config.producer_max_buffered_bytes` (`-kafka.producer-max-buffered-bytes`): 1 GiB (0 disables the limit)
+
+**Resolution:**
+
+* **Implement retry logic** with exponential backoff in your client; this is a retryable condition.
+* **Check Kafka broker health and load** (under-replicated partitions, broker CPU/disk/network saturation, ongoing rollouts).
+* **Increase `kafka_config.write_timeout`** if brokers are healthy but consistently slow to acknowledge writes:
+
+   ```yaml
+   kafka_config:
+     write_timeout: 20s
+   ```
+
+* **Review distributor and Kafka client metrics** for write latency and backpressure:
+  - `loki_kafka_client_produce_failures_total{component="distributor", reason=~"timeout|buffer-full"}`: counts these failures directly, by reason.
+  - `loki_distributor_kafka_appends_total` (check the `status="fail"` series)
+  - `loki_distributor_kafka_latency_seconds`: only observed when at least one record in the batch succeeds, so it stays quiet during a total failure.
+
+**Properties:**
+
+- Enforced by: Distributor (Kafka producer)
+- Retryable: Yes
+- HTTP status: 503 Service Unavailable
+- Configurable per tenant: No
+
 ## Structured metadata errors
 
 These errors occur when using structured metadata incorrectly.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1083,14 +1083,14 @@ func (d *Distributor) pushWithResolver(ctx context.Context, req *logproto.PushRe
 // kafkaProduceErrToStatusErr maps Kafka producer backpressure errors to a
 // retryable HTTP status.
 func kafkaProduceErrToStatusErr(err error) error {
-	if errors.Is(err, kgo.ErrRecordTimeout) || errors.Is(err, kgo.ErrMaxBuffered) {
+	if errors.Is(err, kgo.ErrRecordTimeout) || errors.Is(err, kgo.ErrMaxBuffered) || errors.Is(err, kgo.ErrClientClosed) {
 		return httpgrpc.Error(http.StatusServiceUnavailable, err.Error())
 	}
 	return err
 }
 
 func isCircuitBreakerTrialErr(err error) bool {
-	return errors.Is(err, kgo.ErrMaxBuffered) || errors.Is(err, errServiceUnavailableMaxLoad)
+	return errors.Is(err, kgo.ErrMaxBuffered) || errors.Is(err, kgo.ErrRecordTimeout) || errors.Is(err, errServiceUnavailableMaxLoad)
 }
 
 // missingEnforcedLabels returns true if the stream is missing any of the required labels.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -59,6 +59,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
+	"github.com/grafana/loki/v3/pkg/util/server"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -659,7 +660,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 		return nil, err
 	}
 	resp, err := d.pushWithResolver(ctx, req, newRequestScopedStreamResolver(tenantID, d.validator.Limits, d.logger), constants.Loki)
-	return resp, kafkaProduceErrToStatusErr(err)
+	return resp, pushErrToStatusErr(err)
 }
 
 // Push a set of streams.
@@ -1091,6 +1092,24 @@ func kafkaProduceErrToStatusErr(err error) error {
 
 func isCircuitBreakerTrialErr(err error) bool {
 	return errors.Is(err, kgo.ErrMaxBuffered) || errors.Is(err, kgo.ErrRecordTimeout) || errors.Is(err, errServiceUnavailableMaxLoad)
+}
+
+// contextErrToStatusErr maps a bare context cancellation/timeout to the status
+// codes Loki uses elsewhere for the same condition, since neither implements
+// GRPCStatus() and so would otherwise fall through to an unclassified 500.
+func contextErrToStatusErr(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return httpgrpc.Error(server.StatusClientClosedRequest, err.Error())
+	case errors.Is(err, context.DeadlineExceeded):
+		return httpgrpc.Error(http.StatusGatewayTimeout, err.Error())
+	}
+	return err
+}
+
+// pushErrToStatusErr applies all of the push-path error-to-status mappings.
+func pushErrToStatusErr(err error) error {
+	return contextErrToStatusErr(kafkaProduceErrToStatusErr(err))
 }
 
 // missingEnforcedLabels returns true if the stream is missing any of the required labels.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -507,9 +507,7 @@ func New(
 			cfg.CircuitBreaker.OpenPeriod,
 			cfg.CircuitBreaker.MinFailures,
 			cfg.CircuitBreaker.PermittedTrials,
-			func(err error) bool {
-				return errors.Is(err, kgo.ErrMaxBuffered) || errors.Is(err, errServiceUnavailableMaxLoad)
-			},
+			isCircuitBreakerTrialErr,
 		)
 		registerer.MustRegister(circuitBreaker)
 		d.circuitBreaker = circuitBreaker
@@ -660,7 +658,8 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	if err != nil {
 		return nil, err
 	}
-	return d.pushWithResolver(ctx, req, newRequestScopedStreamResolver(tenantID, d.validator.Limits, d.logger), constants.Loki)
+	resp, err := d.pushWithResolver(ctx, req, newRequestScopedStreamResolver(tenantID, d.validator.Limits, d.logger), constants.Loki)
+	return resp, kafkaProduceErrToStatusErr(err)
 }
 
 // Push a set of streams.
@@ -1071,12 +1070,27 @@ func (d *Distributor) pushWithResolver(ctx context.Context, req *logproto.PushRe
 
 	select {
 	case err := <-tracker.err:
+		// Left unmapped here: callers apply kafkaProduceErrToStatusErr after the
+		// circuit breaker has classified the raw error.
 		return nil, err
 	case <-tracker.done:
 		return &logproto.PushResponse{}, validationErr
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// kafkaProduceErrToStatusErr maps Kafka producer backpressure errors to a
+// retryable HTTP status.
+func kafkaProduceErrToStatusErr(err error) error {
+	if errors.Is(err, kgo.ErrRecordTimeout) || errors.Is(err, kgo.ErrMaxBuffered) {
+		return httpgrpc.Error(http.StatusServiceUnavailable, err.Error())
+	}
+	return err
+}
+
+func isCircuitBreakerTrialErr(err error) bool {
+	return errors.Is(err, kgo.ErrMaxBuffered) || errors.Is(err, errServiceUnavailableMaxLoad)
 }
 
 // missingEnforcedLabels returns true if the stream is missing any of the required labels.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -640,7 +640,7 @@ func TestDistributorPushToKafka(t *testing.T) {
 	})
 
 	t.Run("with kafka, producer backpressure is reported as a retryable error", func(t *testing.T) {
-		for _, writeErr := range []error{kgo.ErrRecordTimeout, kgo.ErrMaxBuffered} {
+		for _, writeErr := range []error{kgo.ErrRecordTimeout, kgo.ErrMaxBuffered, kgo.ErrClientClosed} {
 			t.Run(writeErr.Error(), func(t *testing.T) {
 				kafkaWriter := &mockKafkaProducer{
 					failOnWrite: true,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -639,6 +639,33 @@ func TestDistributorPushToKafka(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("with kafka, producer backpressure is reported as a retryable error", func(t *testing.T) {
+		for _, writeErr := range []error{kgo.ErrRecordTimeout, kgo.ErrMaxBuffered} {
+			t.Run(writeErr.Error(), func(t *testing.T) {
+				kafkaWriter := &mockKafkaProducer{
+					failOnWrite: true,
+					writeErr:    writeErr,
+				}
+				distributors, _ := prepareButDontStart(t, 1, 0, limits, nil)
+				for _, d := range distributors {
+					d.cfg.KafkaEnabled = true
+					d.cfg.IngesterEnabled = false
+					d.cfg.KafkaConfig.ProducerMaxRecordSizeBytes = 1000
+					d.kafkaWriter = kafkaWriter
+				}
+				startAndWaitRunningDistributors(t, distributors)
+
+				request := makeWriteRequest(10, 64)
+				_, err := distributors[0].Push(ctx, request)
+				require.Error(t, err)
+
+				resp, ok := httpgrpc.HTTPResponseFromError(err)
+				require.True(t, ok, "expected an httpgrpc error carrying a status code, got: %v", err)
+				require.Equal(t, int32(http.StatusServiceUnavailable), resp.Code)
+			})
+		}
+	})
+
 	t.Run("with kafka, no failures is successful", func(t *testing.T) {
 		kafkaWriter := &mockKafkaProducer{
 			failOnWrite: false,
@@ -2444,6 +2471,7 @@ func makeWriteRequest(lines, size int) *logproto.PushRequest {
 
 type mockKafkaProducer struct {
 	failOnWrite     bool
+	writeErr        error // error returned per record when failOnWrite is set; defaults to kgo.ErrRecordTimeout
 	pushes          uint64
 	records         []*kgo.Record
 	recordsPerTopic map[string][]*kgo.Record
@@ -2455,12 +2483,16 @@ func (m *mockKafkaProducer) ProduceSync(_ context.Context, records []*kgo.Record
 	defer m.mu.Unlock()
 	results := make(kgo.ProduceResults, 0, len(records))
 	if m.failOnWrite {
+		writeErr := m.writeErr
+		if writeErr == nil {
+			writeErr = kgo.ErrRecordTimeout
+		}
 		// We must append a result for each record that has both the record and the
 		// error, as this is how it works in [kgo].
 		for _, record := range records {
 			results = append(results, kgo.ProduceResult{
 				Record: record,
-				Err:    kgo.ErrRecordTimeout,
+				Err:    writeErr,
 			})
 		}
 	} else {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -50,6 +50,7 @@ import (
 	loki_flagext "github.com/grafana/loki/v3/pkg/util/flagext"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	loki_net "github.com/grafana/loki/v3/pkg/util/net"
+	"github.com/grafana/loki/v3/pkg/util/server"
 	"github.com/grafana/loki/v3/pkg/util/test"
 	"github.com/grafana/loki/v3/pkg/validation"
 
@@ -781,6 +782,81 @@ func TestDistributorPushToKafka(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestContextErrToStatusErr(t *testing.T) {
+	otherErr := errors.New("some other error")
+
+	for _, tc := range []struct {
+		name         string
+		err          error
+		expectedCode int32
+		unchanged    bool
+	}{
+		{name: "canceled", err: context.Canceled, expectedCode: server.StatusClientClosedRequest},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, expectedCode: http.StatusGatewayTimeout},
+		{name: "wrapped deadline exceeded", err: fmt.Errorf("produce: %w", context.DeadlineExceeded), expectedCode: http.StatusGatewayTimeout},
+		{name: "unrelated error", err: otherErr, unchanged: true},
+		{name: "nil", err: nil, unchanged: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := contextErrToStatusErr(tc.err)
+			if tc.unchanged {
+				require.Equal(t, tc.err, got)
+				return
+			}
+			resp, ok := httpgrpc.HTTPResponseFromError(got)
+			require.True(t, ok, "expected an httpgrpc error, got: %v", got)
+			require.Equal(t, tc.expectedCode, resp.Code)
+		})
+	}
+}
+
+func TestPushContextCanceled(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+
+	for _, tc := range []struct {
+		name         string
+		ctx          func() context.Context
+		expectedCode int32
+	}{
+		{
+			name: "canceled",
+			ctx: func() context.Context {
+				c, cancel := context.WithCancel(ctx)
+				cancel()
+				return c
+			},
+			expectedCode: server.StatusClientClosedRequest,
+		},
+		{
+			name: "deadline exceeded",
+			ctx: func() context.Context {
+				c, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+				t.Cleanup(cancel)
+				return c
+			},
+			expectedCode: http.StatusGatewayTimeout,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			distributors, _ := prepareButDontStart(t, 1, 0, limits, nil)
+			d := distributors[0]
+			// Kafka is disabled by default too, so nothing ever completes the
+			// push and the outer ctx.Done() is the only case that can fire.
+			d.cfg.IngesterEnabled = false
+			startAndWaitRunningDistributors(t, distributors)
+
+			request := makeWriteRequest(10, 64)
+			_, err := d.Push(tc.ctx(), request)
+			require.Error(t, err)
+
+			resp, ok := httpgrpc.HTTPResponseFromError(err)
+			require.True(t, ok, "expected an httpgrpc error, got: %v", err)
+			require.Equal(t, tc.expectedCode, resp.Code)
+		})
+	}
 }
 
 func Test_SortLabelsOnPush(t *testing.T) {

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -150,7 +150,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 
 	// circuitBreakerErr must be the raw error, not the mapped one below.
 	circuitBreakerErr = err
-	resp, ok := httpgrpc.HTTPResponseFromError(kafkaProduceErrToStatusErr(err))
+	resp, ok := httpgrpc.HTTPResponseFromError(pushErrToStatusErr(err))
 	if ok {
 		body := string(resp.Body)
 		if d.tenantConfigs.LogPushRequest(tenantID) {

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -148,8 +148,9 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 		return
 	}
 
+	// circuitBreakerErr must be the raw error, not the mapped one below.
 	circuitBreakerErr = err
-	resp, ok := httpgrpc.HTTPResponseFromError(err)
+	resp, ok := httpgrpc.HTTPResponseFromError(kafkaProduceErrToStatusErr(err))
 	if ok {
 		body := string(resp.Body)
 		if d.tenantConfigs.LogPushRequest(tenantID) {

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -309,39 +309,43 @@ func TestPushHandlerKafkaBackpressure(t *testing.T) {
 }
 
 func TestPushHandlerKafkaBackpressureTripsCircuitBreaker(t *testing.T) {
-	limits := &validation.Limits{}
-	flagext.DefaultValues(limits)
+	for _, writeErr := range []error{kgo.ErrMaxBuffered, kgo.ErrRecordTimeout} {
+		t.Run(writeErr.Error(), func(t *testing.T) {
+			limits := &validation.Limits{}
+			flagext.DefaultValues(limits)
 
-	kafkaWriter := &mockKafkaProducer{failOnWrite: true, writeErr: kgo.ErrMaxBuffered}
-	distributors, _ := prepareButDontStart(t, 1, 0, limits, nil)
-	d := distributors[0]
-	d.cfg.KafkaEnabled = true
-	d.cfg.IngesterEnabled = false
-	d.cfg.KafkaConfig.ProducerMaxRecordSizeBytes = 1000
-	d.kafkaWriter = kafkaWriter
-	d.circuitBreaker = newTrialCircuitBreaker(time.Minute, 1, 1, isCircuitBreakerTrialErr)
-	startAndWaitRunningDistributors(t, distributors)
+			kafkaWriter := &mockKafkaProducer{failOnWrite: true, writeErr: writeErr}
+			distributors, _ := prepareButDontStart(t, 1, 0, limits, nil)
+			d := distributors[0]
+			d.cfg.KafkaEnabled = true
+			d.cfg.IngesterEnabled = false
+			d.cfg.KafkaConfig.ProducerMaxRecordSizeBytes = 1000
+			d.kafkaWriter = kafkaWriter
+			d.circuitBreaker = newTrialCircuitBreaker(time.Minute, 1, 1, isCircuitBreakerTrialErr)
+			startAndWaitRunningDistributors(t, distributors)
 
-	b, err := proto.Marshal(&logproto.PushRequest{
-		Streams: []logproto.Stream{
-			{
-				Labels:  `{foo="bar"}`,
-				Entries: []logproto.Entry{{Timestamp: time.Now(), Line: "hello"}},
-			},
-		},
-	})
-	require.NoError(t, err)
+			b, err := proto.Marshal(&logproto.PushRequest{
+				Streams: []logproto.Stream{
+					{
+						Labels:  `{foo="bar"}`,
+						Entries: []logproto.Entry{{Timestamp: time.Now(), Line: "hello"}},
+					},
+				},
+			})
+			require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(snappy.Encode(nil, b)))
-	req = req.WithContext(user.InjectOrgID(t.Context(), "test"))
-	req.Header.Set("Content-Type", "application/x-protobuf")
+			req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(snappy.Encode(nil, b)))
+			req = req.WithContext(user.InjectOrgID(t.Context(), "test"))
+			req.Header.Set("Content-Type", "application/x-protobuf")
 
-	rec := httptest.NewRecorder()
-	d.pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
-	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+			rec := httptest.NewRecorder()
+			d.pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
+			require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 
-	allow, _ := d.circuitBreaker.Allow()
-	require.False(t, allow, "circuit breaker should have opened on the kgo.ErrMaxBuffered failure")
+			allow, _ := d.circuitBreaker.Allow()
+			require.False(t, allow, "circuit breaker should have opened on the %s failure", writeErr)
+		})
+	}
 }
 
 func TestPushHandlerLogPushRequestStreams(t *testing.T) {

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang/snappy"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/user"
+	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -229,6 +230,118 @@ func TestPushHandlerMaxPushSize(t *testing.T) {
 			require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
 		})
 	}
+}
+
+func TestPushHandlerKafkaBackpressure(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+	limits.SetGlobalOTLPConfig(push.GlobalOTLPConfig{DefaultOTLPResourceAttributesAsIndexLabels: []string{"service.name"}})
+
+	for _, tc := range []struct {
+		name        string
+		path        string
+		contentType string
+		format      string
+		parser      push.RequestParser
+		errorWriter push.ErrorWriter
+		buildBody   func(t *testing.T) []byte
+	}{
+		{
+			name:        "Loki push",
+			path:        "/loki/api/v1/push",
+			contentType: "application/x-protobuf",
+			format:      constants.Loki,
+			parser:      push.ParseLokiRequest,
+			errorWriter: push.HTTPError,
+			buildBody: func(t *testing.T) []byte {
+				b, err := proto.Marshal(&logproto.PushRequest{
+					Streams: []logproto.Stream{
+						{
+							Labels:  `{foo="bar"}`,
+							Entries: []logproto.Entry{{Timestamp: time.Now(), Line: "hello"}},
+						},
+					},
+				})
+				require.NoError(t, err)
+				return snappy.Encode(nil, b)
+			},
+		},
+		{
+			name:        "OTLP push",
+			path:        "/otlp/v1/logs",
+			contentType: "application/json",
+			format:      constants.OTLP,
+			parser:      push.ParseOTLPRequest,
+			errorWriter: push.OTLPError,
+			buildBody: func(t *testing.T) []byte {
+				otlpLogs := plog.NewLogs()
+				rl := otlpLogs.ResourceLogs().AppendEmpty()
+				rl.Resource().Attributes().PutStr("service.name", "test-service")
+				lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				lr.Body().SetStr("hello")
+				lr.SetTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+				body, err := plogotlp.NewExportRequestFromLogs(otlpLogs).MarshalJSON()
+				require.NoError(t, err)
+				return body
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			kafkaWriter := &mockKafkaProducer{failOnWrite: true}
+			distributors, _ := prepareButDontStart(t, 1, 0, limits, nil)
+			d := distributors[0]
+			d.cfg.KafkaEnabled = true
+			d.cfg.IngesterEnabled = false
+			d.cfg.KafkaConfig.ProducerMaxRecordSizeBytes = 1000
+			d.kafkaWriter = kafkaWriter
+			startAndWaitRunningDistributors(t, distributors)
+
+			req := httptest.NewRequest(http.MethodPost, tc.path, bytes.NewReader(tc.buildBody(t)))
+			req = req.WithContext(user.InjectOrgID(t.Context(), "test"))
+			req.Header.Set("Content-Type", tc.contentType)
+
+			rec := httptest.NewRecorder()
+			d.pushHandler(rec, req, tc.parser, tc.errorWriter, tc.format)
+
+			require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		})
+	}
+}
+
+func TestPushHandlerKafkaBackpressureTripsCircuitBreaker(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+
+	kafkaWriter := &mockKafkaProducer{failOnWrite: true, writeErr: kgo.ErrMaxBuffered}
+	distributors, _ := prepareButDontStart(t, 1, 0, limits, nil)
+	d := distributors[0]
+	d.cfg.KafkaEnabled = true
+	d.cfg.IngesterEnabled = false
+	d.cfg.KafkaConfig.ProducerMaxRecordSizeBytes = 1000
+	d.kafkaWriter = kafkaWriter
+	d.circuitBreaker = newTrialCircuitBreaker(time.Minute, 1, 1, isCircuitBreakerTrialErr)
+	startAndWaitRunningDistributors(t, distributors)
+
+	b, err := proto.Marshal(&logproto.PushRequest{
+		Streams: []logproto.Stream{
+			{
+				Labels:  `{foo="bar"}`,
+				Entries: []logproto.Entry{{Timestamp: time.Now(), Line: "hello"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(snappy.Encode(nil, b)))
+	req = req.WithContext(user.InjectOrgID(t.Context(), "test"))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	rec := httptest.NewRecorder()
+	d.pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	allow, _ := d.circuitBreaker.Allow()
+	require.False(t, allow, "circuit breaker should have opened on the kgo.ErrMaxBuffered failure")
 }
 
 func TestPushHandlerLogPushRequestStreams(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Maps a handful of push-path errors that were previously returned to the client unwrapped, surfacing as an unclassified HTTP 500 with no signal that the request was safe to retry:

- Add `kafkaProduceErrToStatusErr`, mapping Kafka producer backpressure/shutdown errors (`kgo.ErrRecordTimeout`, `kgo.ErrMaxBuffered`, `kgo.ErrClientClosed`) to a `503 Service Unavailable`.
- Extract the distributor's circuit breaker classifier into `isCircuitBreakerTrialErr`, and include `kgo.ErrRecordTimeout` alongside `kgo.ErrMaxBuffered`: the breaker needs this to reliably trip during an incident.

- Add `contextErrToStatusErr`, mapping a bare `context.Canceled`/`context.DeadlineExceeded` (returned when the distributor's own request context is done while still waiting on Kafka or ingester writes) to `499`/`504`, reusing the same status code and convention already used for query-path cancellation.
- Document the new error messages and their resolution in `troubleshoot-ingest.md`.

This finishes what #21740 started (closed unmerged): that PR only mapped `kgo.ErrMaxBuffered`, not `kgo.ErrRecordTimeout`, which is the error that actually surfaces under sustained Kafka backpressure given the client's buffer configuration.

**Which issue(s) this PR fixes**:
N/A — no public tracked issue; raised from an internal support investigation.

**Special notes for your reviewer**:

- The mapping is applied at the two callers of `pushWithResolver` (`Push`, and the HTTP push handler), not inside `pushWithResolver` itself, so the circuit breaker still classifies the raw error before it's wrapped for the client response.
- Known, deliberately out-of-scope follow-up: ordinary ingester gRPC `codes.Canceled`/`codes.DeadlineExceeded` that arrive without `httpgrpc` details still bypass this mapping (the ingester `Push()` gRPC path, not the distributor's own `ctx.Done()` path this PR covers)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
