### PR TITLE
fix(storage): Treat S3 error code TooManyRequests as a throttling error

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -49,6 +49,7 @@ const (
 const (
 	errCodeRequestTimeout           = "RequestTimeout"           // 400
 	errCodeTooManyRequestsException = "TooManyRequestsException" // 429
+	errCodeTooManyRequests          = "TooManyRequests"          // 429, S3-compatible stores such as OCI Object Storage
 	errCodeInternalError            = "InternalError"            // 500
 	errCodeServiceUnavailable       = "ServiceUnavailable"       // 503
 	errCodeSlowDown                 = "SlowDown"                 // 503
@@ -716,6 +717,7 @@ func isRetryableS3ErrorCode(code string) bool {
 	switch code {
 	case errCodeRequestTimeout,
 		errCodeTooManyRequestsException,
+		errCodeTooManyRequests,
 		errCodeInternalError,
 		errCodeServiceUnavailable,
 		errCodeSlowDown:

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -101,6 +101,11 @@ func TestIsRetryableErr(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "IsStorageThrottledErr - Too Many Requests (S3-compatible, e.g. OCI Object Storage)",
+			err:      &smithy.GenericAPIError{Code: errCodeTooManyRequests},
+			expected: true,
+		},
+		{
 			name:     "IsStorageThrottledErr - 503",
 			err:      &smithy.GenericAPIError{Code: errCodeSlowDown},
 			expected: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

S3-compatible object stores do not all use the AWS error code `TooManyRequestsException` for HTTP 429. OCI Object Storage returns `TooManyRequests`:

```
failed to get s3 object: operation error S3: GetObject, https response error StatusCode: 429, RequestID: iad-1:..., api error TooManyRequests: rate-limit exceeded
```

`isRetryableS3ErrorCode` did not match that code, so for a genuine throttle:

- `isStorageThrottledErr` / `IsRetryableErr` returned false;
- with storage congestion control enabled, `LimitedRetrier.Do` treated the error as non-retryable and returned without calling `onError`, so `AIMDController.multiplicativeDecrease` was never reached. The limit ramped to `upper_bound` on successes and stayed there — the controller was blind to the one signal it exists to react to.

Observed on a production Loki 3.7.1 cluster backed by OCI Object Storage via the S3-compatibility endpoint: the bucket was throttled at ~2,000 GETs/s while `loki_s3_request_duration_seconds_count{status_code="500"}` counted the 429s and the congestion controller reported no non-retryable errors it could act on.

This adds `TooManyRequests` to the retryable throttle codes and a test case.

**Which issue(s) this PR fixes**:
None filed; small enough to describe here.

**Special notes for your reviewer**:
`TooManyRequests` is the code OCI uses; AWS itself uses `TooManyRequestsException`, which is kept. Both are HTTP 429.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
