### PR TITLE
fix: Anchor label filter regexes to the whole label value

### DIFF
--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -233,6 +233,8 @@ We support multiple **value** types which are automatically inferred from the qu
 
 String type work exactly like Prometheus label matchers use in [log stream selector](#log-stream-selector). This means you can use the same operations (`=`,`!=`,`=~`,`!~`).
 
+**Note:** As in the [log stream selector](#log-stream-selector), and unlike the [line filter regex expressions](#line-filter-expression), the `=~` and `!~` operators in a label filter are fully anchored: the pattern has to match the whole label value. `| name=~"al.*"` matches `alpha` but not `prealpha`. Use `| name=~".*al.*"` for a substring match.
+
 > The string type is the only one that can test the `__error__` label, as in `| __error__=""`. The other comparison operators convert the label value before they compare it, and cannot read `__error__` or `__error_details__`. A predicate such as `| __error__ > 0` fails to parse; use a string comparison instead, such as `| __error__ != ""`.
 
 Using Duration, Number and Bytes will convert the label value prior to comparison and support the following comparators:

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -43,6 +43,17 @@ The default value of `-frontend.encoding` / `frontend.encoding` changed from `js
 
 Schedulers and queriers already accept both encodings, so mixed frontends during a rolling upgrade are safe. To keep the previous behavior, set `frontend.encoding: json` explicitly.
 
+### LogQL label filter regexes are anchored to the whole label value
+
+A label filter such as `| name=~"al.*"` now matches the whole label value, as the documentation has always stated and as stream selector matchers already behaved. It previously matched a substring for some patterns, so `| name=~"al.*"` also returned `prealpha`.
+
+Two shapes were affected, for `=~` and `!~`, on parsed fields, stream labels, and structured metadata:
+
+- a one-sided star, `foo.*` or `.*foo`, and their `(?i)` forms;
+- an alternation whose branches share a leading literal, such as `warn|warning`, `prod|preprod`, or `bar|buzz`, which Go factors into a common prefix. An alternation with no shared prefix, such as `foo|bar`, was not affected.
+
+Queries using those patterns return fewer results than before, and `!~` returns more. If a dashboard or alert relied on the substring behavior, write it explicitly: use `.*foo.*` for a substring match, and `foo.*` only when you mean a prefix.
+
 ### LogQL rejects numeric, duration, bytes, and `ip()` comparisons against `__error__` and `__error_details__`
 
 A query such as `| __error__ > 0`, `| __error__ != 1s`, `| __error_details__ == 1MB`, or `| __error__ = ip("1.2.3.4")` now fails to parse. These two labels always hold a string (or are unset), so a numeric, duration, bytes, or IP comparison against them could never find a match; such a query used to parse successfully and then silently return no results. This also applies after `| unwrap`. Use a string comparison instead, for example `| __error__ != ""` or `| __error__=""`.

--- a/pkg/logql/log/filter.go
+++ b/pkg/logql/log/filter.go
@@ -578,7 +578,7 @@ func (l prefixFilter) Filter(line []byte) bool {
 	if len(l.match) > len(line) {
 		return false
 	}
-	return equalBytes(line[:len(l.match)], l.match, l.caseInsensitive)
+	return contains(line[:len(l.match)], l.match, l.caseInsensitive)
 }
 
 func (l prefixFilter) ToStage() Stage {
@@ -620,7 +620,7 @@ func (l suffixFilter) Filter(line []byte) bool {
 	if len(l.match) > len(line) {
 		return false
 	}
-	return equalBytes(line[len(line)-len(l.match):], l.match, l.caseInsensitive)
+	return contains(line[len(line)-len(l.match):], l.match, l.caseInsensitive)
 }
 
 func (l suffixFilter) ToStage() Stage {
@@ -647,24 +647,6 @@ func newSuffixFilter(match []byte, caseInsensitive bool) MatcherFilterer {
 		match = bytes.ToLower(match)
 	}
 	return suffixFilter{match: match, caseInsensitive: caseInsensitive}
-}
-
-// equalBytes compares two equal-length slices. match MUST already be lowercase
-// when caseInsensitive is set, which the constructors guarantee.
-func equalBytes(line, match []byte, caseInsensitive bool) bool {
-	if !caseInsensitive {
-		return bytes.Equal(line, match)
-	}
-	for i := range match {
-		c := line[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		if c != match[i] {
-			return false
-		}
-	}
-	return true
 }
 
 type containsAllFilter struct {
@@ -888,6 +870,14 @@ func (s *RegexSimplifier) simplifyConcat(reg *syntax.Regexp, baseLiteral []byte,
 			if literals != 0 {
 				return nil, false
 			}
+			// A literal separated from an earlier one by `.*` is not contiguous
+			// with it, so appending the two and matching the result would be
+			// wrong. `a(.*c|d)` recurses here with baseLiteral "a" and would
+			// otherwise fold to "ac", which neither matches "axc" nor rejects
+			// "acb". Leave it to the regexp fallback.
+			if starAfter {
+				return nil, false
+			}
 			literals++
 			baseLiteral = append(baseLiteral, []byte(string(sub.Rune))...)
 			baseLiteralIsCaseInsensitive = util.IsCaseInsensitive(sub)
@@ -913,6 +903,13 @@ func (s *RegexSimplifier) simplifyConcat(reg *syntax.Regexp, baseLiteral []byte,
 
 	// if we have a filter from concat alternates.
 	if curr != nil {
+		// Anchored, a `.*` beside the alternation widens every branch: `a(bb|cc).*`
+		// accepts "abbX", which the per-branch equalities above would reject. The
+		// branch filters are already built by this point, so rather than rewrite
+		// them, leave the whole expression to the anchored regexp fallback.
+		if isLabel && (starBefore || starAfter) {
+			return nil, false
+		}
 		return curr, true
 	}
 

--- a/pkg/logql/log/filter.go
+++ b/pkg/logql/log/filter.go
@@ -566,6 +566,107 @@ func newContainsFilter(match []byte, caseInsensitive bool) MatcherFilterer {
 	}
 }
 
+// prefixFilter matches when the value starts with the literal. A fully anchored
+// label regex of the form `foo.*` means exactly this, where a contains match
+// would also accept `barfoo`.
+type prefixFilter struct {
+	match           []byte
+	caseInsensitive bool
+}
+
+func (l prefixFilter) Filter(line []byte) bool {
+	if len(l.match) > len(line) {
+		return false
+	}
+	return equalBytes(line[:len(l.match)], l.match, l.caseInsensitive)
+}
+
+func (l prefixFilter) ToStage() Stage {
+	return StageFunc{
+		process: func(_ int64, line []byte, _ *LabelsBuilder) ([]byte, bool) {
+			return line, l.Filter(line)
+		},
+	}
+}
+
+// Matches reports a non-exact test: the literal has to be present, but the
+// value is longer than the literal, so an exact index lookup would be wrong.
+func (l prefixFilter) Matches(test Checker) bool {
+	return test.Test(l.match, l.caseInsensitive, false)
+}
+
+func (l prefixFilter) String() string {
+	return string(l.match) + ".*"
+}
+
+func newPrefixFilter(match []byte, caseInsensitive bool) MatcherFilterer {
+	if len(match) == 0 {
+		return TrueFilter
+	}
+	if caseInsensitive {
+		match = bytes.ToLower(match)
+	}
+	return prefixFilter{match: match, caseInsensitive: caseInsensitive}
+}
+
+// suffixFilter matches when the value ends with the literal, which is what a
+// fully anchored `.*foo` means.
+type suffixFilter struct {
+	match           []byte
+	caseInsensitive bool
+}
+
+func (l suffixFilter) Filter(line []byte) bool {
+	if len(l.match) > len(line) {
+		return false
+	}
+	return equalBytes(line[len(line)-len(l.match):], l.match, l.caseInsensitive)
+}
+
+func (l suffixFilter) ToStage() Stage {
+	return StageFunc{
+		process: func(_ int64, line []byte, _ *LabelsBuilder) ([]byte, bool) {
+			return line, l.Filter(line)
+		},
+	}
+}
+
+func (l suffixFilter) Matches(test Checker) bool {
+	return test.Test(l.match, l.caseInsensitive, false)
+}
+
+func (l suffixFilter) String() string {
+	return ".*" + string(l.match)
+}
+
+func newSuffixFilter(match []byte, caseInsensitive bool) MatcherFilterer {
+	if len(match) == 0 {
+		return TrueFilter
+	}
+	if caseInsensitive {
+		match = bytes.ToLower(match)
+	}
+	return suffixFilter{match: match, caseInsensitive: caseInsensitive}
+}
+
+// equalBytes compares two equal-length slices. match MUST already be lowercase
+// when caseInsensitive is set, which the constructors guarantee.
+func equalBytes(line, match []byte, caseInsensitive bool) bool {
+	if !caseInsensitive {
+		return bytes.Equal(line, match)
+	}
+	for i := range match {
+		c := line[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != match[i] {
+			return false
+		}
+	}
+	return true
+}
+
 type containsAllFilter struct {
 	matches []containsFilter
 }
@@ -677,6 +778,8 @@ type NewMatcherFiltererFunc func(match []byte, caseInsensitive bool) MatcherFilt
 type RegexSimplifier struct {
 	newContainsFilter NewMatcherFiltererFunc
 	newEqualFilter    NewMatcherFiltererFunc
+	newPrefixFilter   NewMatcherFiltererFunc
+	newSuffixFilter   NewMatcherFiltererFunc
 }
 
 var defaultRegexSimplifier = NewRegexSimplifier(newContainsFilter, newEqualFilter)
@@ -688,6 +791,8 @@ func NewRegexSimplifier(
 	return &RegexSimplifier{
 		newContainsFilter: newContainsFilter,
 		newEqualFilter:    newEqualFilter,
+		newPrefixFilter:   newPrefixFilter,
+		newSuffixFilter:   newSuffixFilter,
 	}
 }
 
@@ -698,7 +803,7 @@ func (s *RegexSimplifier) Simplify(reg *syntax.Regexp, isLabel bool) (MatcherFil
 	case syntax.OpAlternate:
 		return s.simplifyAlternate(reg, isLabel)
 	case syntax.OpConcat:
-		return s.simplifyConcat(reg, nil)
+		return s.simplifyConcat(reg, nil, isLabel)
 	case syntax.OpCapture:
 		util.ClearCapture(reg)
 		return s.Simplify(reg, isLabel)
@@ -746,7 +851,7 @@ func (s *RegexSimplifier) simplifyAlternate(reg *syntax.Regexp, isLabel bool) (M
 // which is a literalFilter.
 // Or a literal and alternates operation (see simplifyConcatAlternate), which represent a multiplication of alternates.
 // Anything else is rejected.
-func (s *RegexSimplifier) simplifyConcat(reg *syntax.Regexp, baseLiteral []byte) (MatcherFilterer, bool) {
+func (s *RegexSimplifier) simplifyConcat(reg *syntax.Regexp, baseLiteral []byte, isLabel bool) (MatcherFilterer, bool) {
 	util.ClearCapture(reg.Sub...)
 	// remove empty match as we don't need them for filtering
 	i := 0
@@ -768,6 +873,15 @@ func (s *RegexSimplifier) simplifyConcat(reg *syntax.Regexp, baseLiteral []byte)
 	var ok bool
 	literals := 0
 	var baseLiteralIsCaseInsensitive bool
+	// A label filter is anchored at both ends, so where the `.*` sit relative to
+	// the literal decides the match: `foo.*` is a prefix, `.*foo` a suffix,
+	// `.*foo.*` a contains, and a bare `foo` an equality. A line filter is
+	// unanchored, so all four are the same contains.
+	// baseLiteral is non-nil when recursing from simplifyConcatAlternate, in
+	// which case the caller's literal already precedes everything here, so a
+	// leading `.*` here still sits after it.
+	hadBaseLiteral := baseLiteral != nil
+	starBefore, starAfter := false, false
 	for _, sub := range reg.Sub {
 		if sub.Op == syntax.OpLiteral {
 			// only one literal is allowed.
@@ -781,12 +895,17 @@ func (s *RegexSimplifier) simplifyConcat(reg *syntax.Regexp, baseLiteral []byte)
 		}
 		// if we have an alternate we must also have a base literal to apply the concatenation with.
 		if sub.Op == syntax.OpAlternate && baseLiteral != nil {
-			if curr, ok = s.simplifyConcatAlternate(sub, baseLiteral, curr, baseLiteralIsCaseInsensitive); !ok {
+			if curr, ok = s.simplifyConcatAlternate(sub, baseLiteral, curr, baseLiteralIsCaseInsensitive, isLabel); !ok {
 				return nil, false
 			}
 			continue
 		}
 		if sub.Op == syntax.OpStar && sub.Sub[0].Op == syntax.OpAnyCharNotNL {
+			if literals == 0 && !hadBaseLiteral {
+				starBefore = true
+			} else {
+				starAfter = true
+			}
 			continue
 		}
 		return nil, false
@@ -799,17 +918,45 @@ func (s *RegexSimplifier) simplifyConcat(reg *syntax.Regexp, baseLiteral []byte)
 
 	// if we have only a concat with literals.
 	if baseLiteral != nil {
+		if isLabel {
+			return s.newAnchoredLiteralFilter(baseLiteral, baseLiteralIsCaseInsensitive, starBefore, starAfter), true
+		}
 		return s.newContainsFilter(baseLiteral, baseLiteralIsCaseInsensitive), true
 	}
 
 	return nil, false
 }
 
+// newAnchoredLiteralFilter picks the filter for a fully anchored match around a
+// single literal, given whether the pattern allowed anything before or after it.
+func (s *RegexSimplifier) newAnchoredLiteralFilter(literal []byte, caseInsensitive, starBefore, starAfter bool) MatcherFilterer {
+	switch {
+	case starBefore && starAfter:
+		return s.newContainsFilter(literal, caseInsensitive)
+	case starAfter:
+		return s.newPrefixFilter(literal, caseInsensitive)
+	case starBefore:
+		return s.newSuffixFilter(literal, caseInsensitive)
+	default:
+		return s.newEqualFilter(literal, caseInsensitive)
+	}
+}
+
+// newLiteralBranchFilter returns the filter for one alternation branch that
+// resolves to a plain literal: an equality when the match is anchored, a
+// contains otherwise.
+func (s *RegexSimplifier) newLiteralBranchFilter(literal []byte, caseInsensitive, isLabel bool) MatcherFilterer {
+	if isLabel {
+		return s.newEqualFilter(literal, caseInsensitive)
+	}
+	return s.newContainsFilter(literal, caseInsensitive)
+}
+
 // simplifyConcatAlternate simplifies concat alternate operations.
 // A concat alternate is found when a concat operation has a sub alternate and is preceded by a literal.
 // For instance bar|b|buzz is expressed as b(ar|(?:)|uzz) => b concat alternate(ar,(?:),uzz).
 // (?:) being an OpEmptyMatch and b being the literal to concat all alternates (ar,(?:),uzz) with.
-func (s *RegexSimplifier) simplifyConcatAlternate(reg *syntax.Regexp, literal []byte, curr MatcherFilterer, baseLiteralIsCaseInsensitive bool) (MatcherFilterer, bool) {
+func (s *RegexSimplifier) simplifyConcatAlternate(reg *syntax.Regexp, literal []byte, curr MatcherFilterer, baseLiteralIsCaseInsensitive bool, isLabel bool) (MatcherFilterer, bool) {
 	for _, alt := range reg.Sub {
 		// we should not consider the case where baseLiteral is not marked as case insensitive
 		// and alternate expression is marked as case insensitive. For example, for the original expression
@@ -821,16 +968,17 @@ func (s *RegexSimplifier) simplifyConcatAlternate(reg *syntax.Regexp, literal []
 		}
 		switch alt.Op {
 		case syntax.OpEmptyMatch:
-			curr = ChainOrMatcherFilterer(curr, s.newContainsFilter(literal, baseLiteralIsCaseInsensitive))
+			// Anchored, an empty branch means the value is exactly the literal.
+			curr = ChainOrMatcherFilterer(curr, s.newLiteralBranchFilter(literal, baseLiteralIsCaseInsensitive, isLabel))
 		case syntax.OpLiteral:
 			// concat the root literal with the alternate one.
 			altBytes := []byte(string(alt.Rune))
 			altLiteral := make([]byte, 0, len(literal)+len(altBytes))
 			altLiteral = append(altLiteral, literal...)
 			altLiteral = append(altLiteral, altBytes...)
-			curr = ChainOrMatcherFilterer(curr, s.newContainsFilter(altLiteral, baseLiteralIsCaseInsensitive))
+			curr = ChainOrMatcherFilterer(curr, s.newLiteralBranchFilter(altLiteral, baseLiteralIsCaseInsensitive, isLabel))
 		case syntax.OpConcat:
-			f, ok := s.simplifyConcat(alt, literal)
+			f, ok := s.simplifyConcat(alt, literal, isLabel)
 			if !ok {
 				return nil, false
 			}
@@ -838,6 +986,11 @@ func (s *RegexSimplifier) simplifyConcatAlternate(reg *syntax.Regexp, literal []
 		case syntax.OpStar:
 			if alt.Sub[0].Op != syntax.OpAnyCharNotNL {
 				return nil, false
+			}
+			// Anchored, `literal` followed by `.*` is a prefix match.
+			if isLabel {
+				curr = ChainOrMatcherFilterer(curr, s.newPrefixFilter(literal, baseLiteralIsCaseInsensitive))
+				continue
 			}
 			curr = ChainOrMatcherFilterer(curr, s.newContainsFilter(literal, baseLiteralIsCaseInsensitive))
 		default:

--- a/pkg/logql/log/filter_test.go
+++ b/pkg/logql/log/filter_test.go
@@ -2,8 +2,10 @@ package log
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 )
 
@@ -386,4 +388,71 @@ func BenchmarkContainsLower(b *testing.B) {
 		})
 	}
 	res = m // Avoid compiler optimization
+}
+
+// A label filter regex is anchored at both ends, exactly like a stream selector
+// matcher. Simplification must preserve that: `foo.*` is a prefix match, `.*foo`
+// a suffix, `.*foo.*` a contains, and a bare literal an equality.
+//
+// The regression in issue #23892 was that the OpConcat branch of Simplify
+// dropped isLabel, so every one of those collapsed to a contains. The same drop
+// affected alternations that Go factors into a shared literal prefix, which is
+// why `warn|warning` is covered here: it parses as `warn(?:(?:)|ing)`, a concat
+// with an alternate, not as a top level alternate.
+func TestLabelFilterRegexIsAnchored(t *testing.T) {
+	for _, re := range []string{
+		// one sided stars
+		"al.*", ".*al", ".*al.*", "(?i)al.*", "(?i).*al",
+		// literals and alternations without a shared prefix
+		"alpha", "alpha|beta", "400|404",
+		// alternations Go factors into a shared literal prefix
+		"warn|warning", "prod|preprod", "bar|buzz", "b(ar|uzz)", "GET|GETALL",
+		"a|ab|abc", "al.*|be.*",
+		// shapes that were already correct, kept as regression cover
+		"pre.*ha", "al[a-z]*", "a.*a", "foo.*bar", ".*", ".+",
+	} {
+		t.Run(re, func(t *testing.T) {
+			anchored := regexp.MustCompile("^(?:" + re + ")$")
+
+			for _, matchType := range []labels.MatchType{labels.MatchRegexp, labels.MatchNotRegexp} {
+				f, err := NewLabelFilter(re, matchType)
+				require.NoError(t, err)
+
+				for _, v := range []string{
+					"", "a", "ab", "abc", "abcd", "al", "AL", "alpha", "ALPHA",
+					"prealpha", "alphabet", "beta", "bar", "buzz", "barbell", "rebar",
+					"warn", "warning", "prewarn", "warnings",
+					"prod", "preprod", "nonprod", "production",
+					"GET", "GETALL", "TARGET", "400", "404", "4041", "foobar", "xfoobary",
+				} {
+					want := anchored.MatchString(v)
+					if matchType == labels.MatchNotRegexp {
+						want = !want
+					}
+					require.Equalf(t, want, f.Filter([]byte(v)),
+						"label filter %q (%v) on value %q", re, matchType, v)
+				}
+			}
+		})
+	}
+}
+
+// Line filters are not anchored, so the same patterns must keep substring
+// semantics. This is the guard against over-correcting the fix onto the line
+// path, which shares the simplifier.
+func TestLineFilterRegexStaysUnanchored(t *testing.T) {
+	for _, re := range []string{
+		"al.*", ".*al", "alpha", "warn|warning", "prod|preprod", "bar|buzz", "b(ar|uzz)",
+	} {
+		t.Run(re, func(t *testing.T) {
+			unanchored := regexp.MustCompile(re)
+			f, err := NewFilter(re, LineMatchRegexp)
+			require.NoError(t, err)
+
+			for _, v := range []string{"alpha", "prealpha", "barbell", "rebar", "prewarn", "nonprod", "xfoobary"} {
+				require.Equalf(t, unanchored.MatchString(v), f.Filter([]byte(v)),
+					"line filter %q on value %q", re, v)
+			}
+		})
+	}
 }

--- a/pkg/logql/log/filter_test.go
+++ b/pkg/logql/log/filter_test.go
@@ -410,6 +410,13 @@ func TestLabelFilterRegexIsAnchored(t *testing.T) {
 		"a|ab|abc", "al.*|be.*",
 		// shapes that were already correct, kept as regression cover
 		"pre.*ha", "al[a-z]*", "a.*a", "foo.*bar", ".*", ".+",
+		// an alternation beside a `.*` widens every branch, so it must not fold
+		// to per-branch equalities (review on #24421)
+		"a(bb|cc).*", "(?i)a(bb|cc).*", "foo(bar|baz).*", "(bar|baz).*",
+		// a literal separated from an earlier one by `.*` is not contiguous
+		"a(.*c|d)", "a(b|.*c)", "pre(.*x|y)", "a(.*c|.*d)",
+		// non-ascii case folding must match the existing filters
+		"(?i)ünf.*", "(?i).*ÜNF", "(?i)Ünf", "(?i).*ünf.*",
 	} {
 		t.Run(re, func(t *testing.T) {
 			anchored := regexp.MustCompile("^(?:" + re + ")$")
@@ -424,6 +431,9 @@ func TestLabelFilterRegexIsAnchored(t *testing.T) {
 					"warn", "warning", "prewarn", "warnings",
 					"prod", "preprod", "nonprod", "production",
 					"GET", "GETALL", "TARGET", "400", "404", "4041", "foobar", "xfoobary",
+					"foobarX", "foobaz", "ac", "axc", "acb", "ad", "abd", "abdX",
+					"prex", "preXx", "prey", "abb", "abbX", "acc", "accX",
+					"ünf", "ÜNF", "Ünf", "ünfoo", "ÜNFOO", "xünf", "UNF",
 				} {
 					want := anchored.MatchString(v)
 					if matchType == labels.MatchNotRegexp {
@@ -443,13 +453,15 @@ func TestLabelFilterRegexIsAnchored(t *testing.T) {
 func TestLineFilterRegexStaysUnanchored(t *testing.T) {
 	for _, re := range []string{
 		"al.*", ".*al", "alpha", "warn|warning", "prod|preprod", "bar|buzz", "b(ar|uzz)",
+		"a(bb|cc).*", "a(.*c|d)", "a(b|.*c)", "(?i)ünf.*",
 	} {
 		t.Run(re, func(t *testing.T) {
 			unanchored := regexp.MustCompile(re)
 			f, err := NewFilter(re, LineMatchRegexp)
 			require.NoError(t, err)
 
-			for _, v := range []string{"alpha", "prealpha", "barbell", "rebar", "prewarn", "nonprod", "xfoobary"} {
+			for _, v := range []string{"alpha", "prealpha", "barbell", "rebar", "prewarn", "nonprod",
+				"xfoobary", "abbX", "axc", "acb", "zzaxczz", "ÜNFOO"} {
 				require.Equalf(t, unanchored.MatchString(v), f.Filter([]byte(v)),
 					"line filter %q on value %q", re, v)
 			}


### PR DESCRIPTION
Fixes #23892

## What

A label filter regex should match the whole label value, exactly like a stream selector matcher. Several shapes matched a substring instead, so `| name=~"al.*"` also returned `prealpha`.

`parseRegexpFilter` anchors with `^(?:...)$` only on the fallback path taken when simplification fails, so every simplified branch has to anchor itself. That is what the `isLabel` flag is for, and `Simplify`'s `OpConcat` branch dropped it.

## The issue undercounts the blast radius

The report covers one-sided stars. There is a second shape it lists as safe.

Go's parser factors an alternation with a shared leading literal into a concat, so it never reaches `simplifyAlternate` where `isLabel` is honoured:

| pattern | parsed as | filter built | correct |
|---|---|---|---|
| `al.*` | `(?-s:al.*)` | `containsFilter` | no |
| `.*al` | `(?-s:.*al)` | `containsFilter` | no |
| `warn\|warning` | `warn(?:(?:)\|ing)` | or of `containsFilter` | **no** |
| `prod\|preprod` | `pr(?:od\|eprod)` | or of `containsFilter` | **no** |
| `bar\|buzz` | `b(?:ar\|uzz)` | or of `containsFilter` | **no** |
| `400\|404` | `40[04]` | `regexpFilter` | yes, by luck |
| `foo\|bar` | alternate | or of `equalFilter` | yes |

So `| level=~"warn|warning"` matched `prewarn`, and `| env=~"prod|preprod"` matched `nonprod` and `production`. The issue says `foo|bar` is unaffected, which is true only because those two branches share no prefix. `400|404` escapes for a different reason again: the alternation collapses to a character class that `simplifyConcat` rejects, so it falls through to the anchored fallback.

## The fix

Anchored, the position of the `.*` decides the match, so one contains filter cannot serve all four cases:

| pattern | anchored meaning | filter |
|---|---|---|
| `foo` | equality | `equalFilter` (already correct) |
| `foo.*` | prefix | `prefixFilter` (new) |
| `.*foo` | suffix | `suffixFilter` (new) |
| `.*foo.*` | contains | `containsFilter` (unchanged) |

`simplifyConcat` now tracks whether a `.*` appeared before or after the literal and picks accordingly, and `isLabel` is threaded into `simplifyConcatAlternate` so alternation branches that resolve to a literal produce an equality rather than a contains.

Line filters are unanchored and share the simplifier, so `isLabel` is threaded through rather than changing the shared path. There is a test asserting line filters keep substring semantics.

`Matches(Checker)` on the two new filters passes `equal=false`, the same as `containsFilter`. A prefix is not an exact value, so an exact index lookup would be wrong and could skip chunks.

`NewRegexSimplifier` keeps its signature. The two new constructors are struct fields defaulted in it, so nothing outside the package breaks.

## Performance

Better, not worse. `equalFilter` short-circuits on length and prefix/suffix compare a bounded window, where `bytes.Contains` scans the value.

```
                  before     after
al.*              27.2ns  ->  16.8ns
.*al              26.6ns  ->  14.8ns
warn|warning      50.0ns  ->  25.6ns
prod|preprod      51.0ns  ->  25.7ns
.*al.*            26.3ns  ->  26.7ns   (unchanged, still contains)
alpha              8.5ns  ->   8.9ns   (unchanged path, noise)
```

`-benchtime=500000x -count=3`, five values per iteration, on darwin/arm64.

## Testing

`TestLabelFilterRegexIsAnchored` runs 23 patterns against 31 values and compares every result to `^(?:pattern)$`, for both `=~` and `!~`. `TestLineFilterRegexStaysUnanchored` does the mirror check for line filters.

Both halves are load-bearing and independent. Reverting the star-position choice fails `al.*`, `.*al`, both `(?i)` forms and `al.*|be.*`. Reverting the alternation branch fails `warn|warning`, `prod|preprod`, `bar|buzz`, `b(ar|uzz)`, `GET|GETALL` and `a|ab|abc`. Disjoint sets, which is the clearest evidence these are two bugs rather than one.

`go test ./pkg/logql/...` is green. `gofmt` and `go vet` clean on the touched package.

## Upgrade note

Added, since results change: queries using the affected patterns return fewer rows and `!~` returns more. Anyone relying on the substring behaviour should write `.*foo.*` explicitly.

## Open question

For alternation branches I emit an equality per branch, which keeps the fast path. The alternative is to bail out for labels and let the anchored `regexpFilter` fallback handle them, which is a smaller diff but gives up the simplification and, per the numbers above, is roughly twice as slow. Happy to switch if you would rather keep the change minimal.
