### PR TITLE
test(compactor): drain the in-flight log phase before asserting

### DIFF
--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -1832,19 +1832,22 @@ func TestRunTenantLoop_DisablingLogMidRunStopsLogMerge(t *testing.T) {
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(phases) >= cutoff+4 // several more cycles after disabling
+		// Drain the in-flight log phase. The first subsequent index dispatch
+		// marks a new phase; configuration is re-read between phases.
+		for cutoff < len(phases) && phases[cutoff] == "log-merge" {
+			cutoff++
+		}
+		return len(phases) >= cutoff+4
 	}, 2*time.Second, 5*time.Millisecond)
 	cancel()
 	<-done
 
 	mu.Lock()
 	defer mu.Unlock()
-	// The mid-run disable is not instantaneous: an in-flight log-merge cycle
-	// may still complete. Assert that dispatches eventually settle to
-	// index-merge only — i.e. the tail after the cutoff contains no log-merge.
+	// Every dispatch after the in-flight log phase must be index-merge.
 	tail := phases[cutoff:]
 	require.NotEmpty(t, tail)
-	for _, p := range tail[len(tail)-4:] {
+	for _, p := range tail {
 		require.Equal(t, "index-merge", p, "no log-merge after log compaction is disabled")
 	}
 }


### PR DESCRIPTION
Task dispatches are not phase boundaries. After disabling log compaction, wait for the next index dispatch before checking continued index-only progress. The coordinator drains each phase before starting the next one. Check every dispatch after that boundary, not just the last four. No production changes.

**What this PR does / why we need it**:

This fixes a 1 / 200 test failure we see in CI. Or at-least so it seems.

My analysis seems to suggest its simply a need to handle an incorrect state that hasnt moved forward yet. So not a bug.

**Which issue(s) this PR fixes**:


**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
