### PR TITLE
fix(distributor): Announce OTLP error bodies as protobuf

### DIFF
--- a/pkg/compactor/deletion/request_handler.go
+++ b/pkg/compactor/deletion/request_handler.go
@@ -322,6 +322,7 @@ func (dm *DeleteRequestHandler) GetCacheGenerationNumberHandler(w http.ResponseW
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(cacheGenNumber); err != nil {
 		level.Error(util_log.Logger).Log("msg", "error marshalling response", "err", err)
 		http.Error(w, fmt.Sprintf("Error marshalling response: %v", err), http.StatusInternalServerError)

--- a/pkg/compactor/deletion/request_handler_test.go
+++ b/pkg/compactor/deletion/request_handler_test.go
@@ -376,6 +376,21 @@ func TestGetAllDeleteRequestsHandler(t *testing.T) {
 	})
 }
 
+func TestGetCacheGenerationNumberHandler(t *testing.T) {
+	store := &mockDeleteRequestsStore{genNumber: "42"}
+	h := NewDeleteRequestHandler(store, 0, 0, nil)
+
+	w := httptest.NewRecorder()
+	h.GetCacheGenerationNumberHandler(w, buildRequest("org-id", ``, "", "", false))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var result string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.Equal(t, "42", result)
+}
+
 func TestUpdateCacheGenerationNumberHandler(t *testing.T) {
 	for _, tc := range []struct {
 		name               string

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -893,7 +893,12 @@ func TestOtlpError(t *testing.T) {
 			OTLPError(r, tc.msg, tc.inCode, logger)
 
 			require.Equal(t, tc.expectedCode, r.Code)
-			require.Equal(t, "application/octet-stream", r.Header().Get("Content-Type"))
+			// Result holds the headers as they were when WriteHeader committed
+			// them, which is what the client sees. Header() also reflects
+			// assignments made too late to be sent.
+			resp := r.Result()
+			defer resp.Body.Close()
+			require.Equal(t, pbContentType, resp.Header.Get("Content-Type"))
 
 			respStatus := &status.Status{}
 			require.NoError(t, proto.Unmarshal(r.Body.Bytes(), respStatus))

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -647,23 +647,24 @@ func OTLPError(w http.ResponseWriter, errorStr string, code int, logger log.Logg
 		code = http.StatusServiceUnavailable
 	}
 
-	// As per the OTLP spec, we send the status code on the http header.
-	w.WriteHeader(code)
-
 	// Status 0 because we omit the Status.code field.
 	status := grpcstatus.New(0, errorStr).Proto()
 	respBytes, err := proto.Marshal(status)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to marshal error response", "error", err)
-		writeResponseFailedBody, _ := proto.Marshal(grpcstatus.New(
+		respBytes, _ = proto.Marshal(grpcstatus.New(
 			codes.Internal,
 			fmt.Sprintf("failed to marshal error response: %s", err.Error()),
 		).Proto())
-		_, _ = w.Write(writeResponseFailedBody)
-		return
 	}
 
-	w.Header().Set(contentType, "application/octet-stream")
+	// The body is a Protobuf-encoded Status, so it must be announced as such.
+	// Headers have to be set before WriteHeader, which commits them.
+	w.Header().Set(contentType, pbContentType)
+
+	// As per the OTLP spec, we send the status code on the http header.
+	w.WriteHeader(code)
+
 	if _, err = w.Write(respBytes); err != nil {
 		level.Error(logger).Log("msg", "failed to write error response", "error", err)
 		writeResponseFailedBody, _ := proto.Marshal(grpcstatus.New(

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -579,7 +579,6 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		serverutil.RecoveryHTTPMiddleware,
 		t.HTTPAuthMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
-		serverutil.ResponseJSONMiddleware(),
 	}
 
 	var (
@@ -1234,7 +1233,6 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 		t.HTTPAuthMiddleware,
 		queryrange.StatsHTTPMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
-		serverutil.ResponseJSONMiddleware(),
 	}
 
 	if t.Cfg.Querier.PerRequestLimitsEnabled {
@@ -1378,7 +1376,6 @@ func (t *Loki) initV2QueryEngine() (services.Service, error) {
 			serverutil.RecoveryHTTPMiddleware,
 			t.HTTPAuthMiddleware,
 			serverutil.NewPrepopulateMiddleware(),
-			serverutil.ResponseJSONMiddleware(),
 		}
 
 		httpMiddleware := middleware.Merge(toMerge...)

--- a/pkg/querier/queryrange/serialize.go
+++ b/pkg/querier/queryrange/serialize.go
@@ -1,11 +1,16 @@
 package queryrange
 
 import (
+	"context"
+	"io"
 	"net/http"
+
+	"github.com/go-kit/log/level"
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	serverutil "github.com/grafana/loki/v3/pkg/util/server"
 )
 
@@ -75,17 +80,49 @@ func (rt *serializeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	// TODO(karsten): use rt.codec.EncodeResponse(ctx, r, response) which is the central encoding logic instead.
+	tracked := &trackedWriter{w: w}
 	if r.Header.Get("Accept") == ParquetType {
-		w.Header().Add("Content-Type", ParquetType)
-		if err := encodeResponseParquetTo(ctx, response, w); err != nil {
-			serverutil.WriteError(err, w)
-		}
+		w.Header().Set("Content-Type", ParquetType)
+		writeEncodeError(ctx, w, tracked, encodeResponseParquetTo(ctx, response, tracked))
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	version := loghttp.GetVersion(r.RequestURI)
 	encodingFlags := httpreq.ExtractEncodingFlags(r)
-	if err := encodeResponseJSONTo(version, response, w, encodingFlags); err != nil {
-		serverutil.WriteError(err, w)
+	writeEncodeError(ctx, w, tracked, encodeResponseJSONTo(version, response, tracked, encodingFlags))
+}
+
+// writeEncodeError reports an encoding failure to the client, but only while the
+// encoder has not written anything yet. Once the first byte is out, the status
+// code and the Content-Type of the successful response are already committed,
+// so appending a plain-text error would produce a truncated body that
+// contradicts both headers. In that case the error is only logged.
+func writeEncodeError(ctx context.Context, w http.ResponseWriter, tracked *trackedWriter, err error) {
+	if err == nil {
+		return
 	}
+	if !tracked.written {
+		serverutil.WriteError(err, w)
+		return
+	}
+	level.Error(util_log.WithContext(ctx, util_log.Logger)).Log(
+		"msg", "failed encoding response after the first byte was written, response body is truncated",
+		"err", err,
+	)
+}
+
+// trackedWriter records whether any byte reached the underlying writer, which
+// tells the caller whether the response headers are already committed.
+type trackedWriter struct {
+	w       io.Writer
+	written bool
+}
+
+func (t *trackedWriter) Write(p []byte) (int, error) {
+	n, err := t.w.Write(p)
+	if n > 0 {
+		t.written = true
+	}
+	return n, err
 }

--- a/pkg/querier/queryrange/serialize_test.go
+++ b/pkg/querier/queryrange/serialize_test.go
@@ -2,6 +2,7 @@ package queryrange
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,36 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 )
+
+func TestWriteEncodeError(t *testing.T) {
+	encodeErr := errors.New("encoding failed")
+
+	t.Run("nothing written yet", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+		writeEncodeError(context.Background(), w, &trackedWriter{w: w}, encodeErr)
+
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		require.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+		require.Equal(t, encodeErr.Error(), w.Body.String())
+	})
+
+	t.Run("headers already committed", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+		tracked := &trackedWriter{w: w}
+		_, err := tracked.Write([]byte(`{"status":`))
+		require.NoError(t, err)
+
+		writeEncodeError(context.Background(), w, tracked, encodeErr)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "application/json; charset=UTF-8", w.Header().Get("Content-Type"))
+		require.Equal(t, `{"status":`, w.Body.String())
+	})
+}
 
 func TestResponseFormat(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -22,15 +22,3 @@ func NewPrepopulateMiddleware() middleware.Interface {
 		})
 	})
 }
-
-// ResponseJSONMiddleware sets the Content-Type header to JSON if it's not set.
-func ResponseJSONMiddleware() middleware.Interface {
-	return middleware.Func(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			next.ServeHTTP(w, req)
-			if w.Header().Get("Content-Type") == "" {
-				w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-			}
-		})
-	})
-}


### PR DESCRIPTION
OTLPError set the Content-Type after WriteHeader, which commits the headers, so the assignment was dropped and Go's content sniffer picked application/octet-stream. The value was also wrong: the body is a Protobuf-encoded Status, so it is application/x-protobuf.

Move the assignment before WriteHeader and use pbContentType. The marshal-failure path now falls through to the same write instead of sending its fallback body with no Content-Type at all.

The existing test read ResponseRecorder.Header(), which reflects late assignments the client never sees, so it passed against the broken behaviour. It now reads the committed headers via Result().

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
