### PR TITLE
fix(deletion): Keep symbol positions stable when rewriting a chunk

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -367,9 +367,13 @@ func panicIfInvalidFormat(chunkFmt byte, head HeadBlockFmt) {
 
 // NewMemChunk returns a new in-mem chunk.
 func newMemChunkWithFormat(format byte, enc compression.Codec, head HeadBlockFmt, blockSize, targetSize int) *MemChunk {
+	return newMemChunkWithSymbolizer(format, enc, head, blockSize, targetSize, newSymbolizer())
+}
+
+// newMemChunkWithSymbolizer builds a chunk around an existing symbolizer.
+func newMemChunkWithSymbolizer(format byte, enc compression.Codec, head HeadBlockFmt, blockSize, targetSize int, symbolizer *symbolizer) *MemChunk {
 	panicIfInvalidFormat(format, head)
 
-	symbolizer := newSymbolizer()
 	return &MemChunk{
 		blockSize:  blockSize,  // The blockSize in bytes.
 		targetSize: targetSize, // Desired chunk size in compressed bytes
@@ -1157,7 +1161,16 @@ func (c *MemChunk) Blocks(mintT, maxtT time.Time) []Block {
 // Filter.Func would be called for each log entry, and the ones for which it returns true would be removed.
 // The new chunk would have data in the same order as the original chunk.
 func (c *MemChunk) Rewrite(filter filter.Func) (Chunk, error) {
-	newChunk := NewMemChunk(c.format, c.Encoding(), c.headFmt, math.MaxInt, math.MaxInt)
+	// Blocks cite symbols by position and unchanged ones are copied over as they
+	// are, so the new table has to number those strings identically. Symbols the
+	// removed entries leave behind are blanked below, not dropped, which would
+	// renumber everything after them.
+	cloned := c.symbolizer.clone()
+	newChunk := newMemChunkWithSymbolizer(c.format, c.Encoding(), c.headFmt, math.MaxInt, math.MaxInt, cloned)
+
+	// Positions any surviving entry still cites, in any block.
+	usedSymbols := make([]bool, len(cloned.labels))
+	var rewritten []logproto.LabelAdapter
 
 	// iterate through the entries block-by-block to avoid re-encoding unchanged blocks
 	for _, b := range c.blocks {
@@ -1171,10 +1184,13 @@ func (c *MemChunk) Rewrite(filter filter.Func) (Chunk, error) {
 				entriesRemoved = true
 				continue
 			}
+
+			rewritten = c.retainSymbols(itr.currSymbols(), usedSymbols, rewritten[:0])
+
 			entry := logproto.Entry{
 				Timestamp:          timestamp,
 				Line:               line,
-				StructuredMetadata: logproto.FromLabelsToLabelAdapters(itr.currStructuredMetadata),
+				StructuredMetadata: rewritten,
 			}
 			if _, err := newChunk.Append(&entry); err != nil {
 				return nil, err
@@ -1202,11 +1218,52 @@ func (c *MemChunk) Rewrite(filter filter.Func) (Chunk, error) {
 		return nil, chunk.ErrRewriteNoDataLeft
 	}
 
+	// One of the side effects of the bug, which copied unmodified blocks as is
+	// without accounting for updates in symbol tables due to the removal of symbols,
+	// is that it could leave entries pointing to non-existent symbols.
+	// Re-encoding a position the table does not hold resolves it to the empty
+	// string, which add() files as a new symbol.
+	// Only a position past the end can be that symbol: every other
+	// string re-encoded already had one. Growth beyond it stays unaccounted for
+	// so retainOnly rejects it rather than blank something still cited.
+	if pos, ok := newChunk.symbolizer.positionOf(""); ok && int(pos) == len(usedSymbols) {
+		usedSymbols = append(usedSymbols, true)
+	}
+
+	// Erase(set to empty string) what only the removed entries cited.
+	if err := newChunk.symbolizer.retainOnly(usedSymbols); err != nil {
+		return nil, err
+	}
+
 	if err := newChunk.Close(); err != nil {
 		return nil, err
 	}
 
 	return newChunk, nil
+}
+
+// retainSymbols marks the positions an entry cites and appends its metadata to
+// dst, resolved from the strings as stored -- not as reads return them, since
+// reads normalize names and re-encoding those would file a second copy of each
+// while the copied blocks carry on citing the stored one. A position the table
+// does not hold resolves to the empty string, and has nothing to mark.
+func (c *MemChunk) retainSymbols(syms symbols, usedSymbols []bool, dst []logproto.LabelAdapter) []logproto.LabelAdapter {
+	for _, sym := range syms {
+		// uint32 because int() turns a position past 2^31 negative on 32 bit.
+		if sym.Name < uint32(len(usedSymbols)) {
+			usedSymbols[sym.Name] = true
+		}
+		if sym.Value < uint32(len(usedSymbols)) {
+			usedSymbols[sym.Value] = true
+		}
+
+		dst = append(dst, logproto.LabelAdapter{
+			Name:  c.symbolizer.lookup(sym.Name),
+			Value: c.symbolizer.lookup(sym.Value),
+		})
+	}
+
+	return dst
 }
 
 // encBlock is an internal wrapper for a block, mainly to avoid binding an encoding in a block itself.
@@ -1471,6 +1528,17 @@ func (si *bufferedIterator) Next() bool {
 	si.currLine = line
 	si.currStructuredMetadata = structuredMetadata
 	return true
+}
+
+// currSymbols returns the symbol positions the current entry was encoded with,
+// as opposed to the strings they resolve to. Only valid until the next call to
+// Next, which reuses the buffer, and empty for formats without structured
+// metadata.
+func (si *bufferedIterator) currSymbols() symbols {
+	if si.format < ChunkFormatV4 {
+		return nil
+	}
+	return si.symbolsBuf
 }
 
 // moveNext moves the buffer to the next entry

--- a/pkg/chunkenc/memchunk_fuzz_test.go
+++ b/pkg/chunkenc/memchunk_fuzz_test.go
@@ -1,0 +1,272 @@
+package chunkenc
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/compression"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+)
+
+// Label names that all survive normalization, so reading the chunk the rewrite
+// starts from always works. Several change shape on the way out ("a.b" ->
+// "a_b", "9lives" -> "key_9lives"), which is what tells the form a block was
+// encoded with apart from the form reads hand back. "a.b" and "a__b" normalize
+// to the same name, so entries can collide on it.
+var fuzzSymbolNames = []string{"app", "a.b", "a__b", "trace.id", "__reserved__", "level", "9lives", "x"}
+
+// Values are stored and read back untouched, so these deliberately include
+// strings that are not valid label names.
+var fuzzSymbolValues = []string{"/", "-", "1", "", "value", "a/b/c", "alice@example.com"}
+
+var fuzzBlockSizes = []int{1, 20, 60, 200, 1024}
+
+// fuzzGen turns the fuzzer's bytes into a chunk layout: how big its blocks are,
+// what structured metadata each entry carries and which entries the rewrite
+// removes. It runs off the end of short inputs rather than failing, so every
+// input describes some chunk.
+type fuzzGen struct {
+	data []byte
+	pos  int
+}
+
+func (g *fuzzGen) next() byte {
+	if g.pos >= len(g.data) {
+		return 0
+	}
+	b := g.data[g.pos]
+	g.pos++
+	return b
+}
+
+func (g *fuzzGen) intn(n int) int {
+	if n <= 1 {
+		return 0
+	}
+	return int(g.next()) % n
+}
+
+func readEntriesErr(chk Chunk) ([]logproto.Entry, error) {
+	itr, err := chk.Iterator(context.Background(), time.Unix(0, 0), time.Unix(0, math.MaxInt64), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.EmptyLabels()))
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []logproto.Entry
+	for itr.Next() {
+		entries = append(entries, itr.At())
+	}
+
+	return entries, itr.Err()
+}
+
+func blankSymbols(c *MemChunk) int {
+	n := 0
+	for _, lbl := range c.symbolizer.labels {
+		if lbl == "" {
+			n++
+		}
+	}
+	return n
+}
+
+func liveSymbols(c *MemChunk) []string {
+	var live []string
+	for _, lbl := range c.symbolizer.labels {
+		if lbl != "" {
+			live = append(live, lbl)
+		}
+	}
+	return live
+}
+
+// FuzzMemChunkRewrite checks that rewriting a chunk to drop some of its entries
+// leaves the rest exactly as they were.
+//
+// Blocks reference symbols by their position in the chunk's symbol table, and
+// Rewrite copies the blocks it did not have to change straight over, so the
+// table it builds has to keep those positions pointing at the same strings
+// while still dropping what only the removed entries referenced. Which symbols
+// that leaves live depends entirely on how the entries share metadata and where
+// the removals land, which is what makes it worth fuzzing rather than enumerating.
+//
+// Run the seed corpus with the rest of the package, and explore with:
+//
+//	go test ./pkg/chunkenc/ -run=Fuzz -fuzz=FuzzMemChunkRewrite -fuzztime=5m
+func FuzzMemChunkRewrite(f *testing.F) {
+	// The generator reads the input as a script, so a seed is only as
+	// interesting as the layout it decodes to. These were built backwards from
+	// the layout wanted -- see the byte order in fuzzGen -- and cover removals
+	// at the front, in the middle, at the end and adjacent, one entry per block
+	// and several, both source shapes, and the metadata that makes the symbol
+	// table interesting. Note that running off the end of the input yields
+	// zeroes, which reads as "drop, with no metadata", so a seed that stops
+	// early silently drops everything after that point.
+	// Removals in the middle, one entry per block, source built in memory.
+	f.Add([]byte{4, 0, 1, 0, 4, 1, 1, 0, 5, 1, 1, 0, 6, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1})
+	// Scattered removals, one entry per block, source read back from storage.
+	f.Add([]byte{7, 0, 1, 3, 4, 1, 1, 3, 5, 0, 1, 3, 6, 1, 1, 3, 0, 1, 1, 3, 1, 0, 1, 3, 2, 1, 1, 3, 3, 0, 1, 3, 4, 1, 0})
+	// A single removal from a chunk of three blocks, so one block is re-encoded
+	// while both its neighbours are copied verbatim.
+	f.Add([]byte{11, 2, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 2, 1, 1, 1, 3, 1, 1, 1, 4, 1, 1, 1, 5, 1, 1, 1, 6, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 3, 1, 1, 1, 4, 1, 0})
+	// Adjacent removals.
+	f.Add([]byte{5, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 2, 0, 1, 1, 3, 0, 1, 1, 4, 1, 1, 1, 5, 1, 1})
+	// Two pairs in one entry whose names normalize to the same thing, which the
+	// read view collapses into one.
+	f.Add([]byte{3, 2, 2, 1, 4, 2, 6, 1, 2, 1, 4, 2, 6, 0, 2, 1, 4, 2, 6, 1, 2, 1, 4, 2, 6, 1, 0})
+	// Values that are not valid label names, including the empty one.
+	f.Add([]byte{5, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 1, 1, 3, 3, 0, 1, 4, 0, 1, 1, 5, 1, 1, 1})
+	// Removing every entry, and an input that runs out immediately.
+	f.Add([]byte{2, 0, 1, 0, 4, 0, 1, 0, 5, 0, 1, 0, 6, 0, 1})
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		g := &fuzzGen{data: data}
+
+		numEntries := 1 + g.intn(20)
+		blockSize := fuzzBlockSizes[g.intn(len(fuzzBlockSizes))]
+
+		originalChunk := NewMemChunk(ChunkFormatV4, compression.None, UnorderedWithStructuredMetadataHeadBlockFmt, blockSize, testTargetSize)
+
+		dropped := make(map[string]bool, numEntries)
+		for i := 0; i < numEntries; i++ {
+			line := fmt.Sprintf("line-%03d", i)
+
+			var sm []logproto.LabelAdapter
+			for pairs := g.intn(4); pairs > 0; pairs-- {
+				sm = append(sm, logproto.LabelAdapter{
+					Name:  fuzzSymbolNames[g.intn(len(fuzzSymbolNames))],
+					Value: fuzzSymbolValues[g.intn(len(fuzzSymbolValues))],
+				})
+			}
+
+			// Timestamps stay strictly increasing: iteration order is not what
+			// this target is about.
+			_, err := originalChunk.Append(&logproto.Entry{
+				Timestamp:          time.Unix(0, int64(i+1)),
+				Line:               line,
+				StructuredMetadata: sm,
+			})
+			require.NoError(t, err)
+
+			dropped[line] = g.intn(2) == 0
+		}
+		// Entries left in the head block are not part of any block yet, and
+		// Rewrite only walks the cut ones.
+		require.NoError(t, originalChunk.Close())
+
+		// Half the time, rewrite the chunk the way the compactor gets it: read
+		// back from storage, so its symbolizer is read-only and carries no
+		// symbolsMap.
+		if g.intn(2) == 0 {
+			b, err := originalChunk.Bytes()
+			require.NoError(t, err)
+			originalChunk, err = NewByteChunk(b, blockSize, testTargetSize)
+			require.NoError(t, err)
+		}
+
+		// Take what the chunk actually holds as the baseline rather than the
+		// metadata handed to Append, so that whatever the write path did to it is
+		// already accounted for and this only measures what the rewrite changed.
+		original, err := readEntriesErr(originalChunk)
+		require.NoError(t, err)
+
+		var expected []logproto.Entry
+		for _, e := range original {
+			if !dropped[e.Line] {
+				expected = append(expected, e)
+			}
+		}
+
+		// Account for what each entry refers to by its stored symbols rather than
+		// by the metadata a read returns: reads normalize label names, and two
+		// pairs whose names normalize to the same thing collapse into one, so the
+		// read view understates what an entry still holds.
+		survivingValues := map[string]struct{}{}
+		removedValues := map[string]struct{}{}
+		for _, b := range originalChunk.blocks {
+			itr := newBufferedIterator(context.Background(), compression.GetReaderPool(originalChunk.encoding), b.b, originalChunk.format, originalChunk.symbolizer)
+			for itr.Next() {
+				into := survivingValues
+				if dropped[string(itr.currLine)] {
+					into = removedValues
+				}
+				for _, sym := range itr.currSymbols() {
+					into[originalChunk.symbolizer.lookup(sym.Value)] = struct{}{}
+				}
+			}
+			require.NoError(t, itr.Err())
+		}
+
+		filterFunc := func(_ time.Time, s string, _ labels.Labels) bool { return dropped[s] }
+
+		rewritten, err := originalChunk.Rewrite(filterFunc)
+		if len(expected) == 0 {
+			require.Equal(t, chunk.ErrRewriteNoDataLeft, err)
+			return
+		}
+		require.NoError(t, err)
+		newChunk := rewritten.(*MemChunk)
+
+		// The entries that survived kept every byte of their metadata.
+		actual, err := readEntriesErr(newChunk)
+		require.NoError(t, err)
+		requireEntriesEqual(t, expected, actual)
+
+		// The rewritten chunk is what gets uploaded, so it has to survive the
+		// encoding too.
+		b, err := newChunk.Bytes()
+		require.NoError(t, err)
+		roundTripped, err := NewByteChunk(b, blockSize, testTargetSize)
+		require.NoError(t, err)
+		actual, err = readEntriesErr(roundTripped)
+		require.NoError(t, err)
+		requireEntriesEqual(t, expected, actual)
+
+		// No surviving entry resolves a name to a blanked or out of range symbol.
+		for _, e := range actual {
+			for _, lbl := range e.StructuredMetadata {
+				require.NotEmpty(t, lbl.Name, "entry %q resolved a name to a blanked symbol", e.Line)
+			}
+		}
+
+		// The generator never damages the table and no name in its alphabet is
+		// empty, so nothing here resolves a position the table does not hold and
+		// the rewrite files no symbol of its own. Adding either would make this a
+		// misleading failure rather than a real one.
+		//
+		// Keeping the positions stable must not grow the table or file a second
+		// copy of a symbol: reads normalize label names, so re-encoding from what
+		// a read returns rather than from what is stored would do both.
+		require.Len(t, newChunk.symbolizer.labels, len(originalChunk.symbolizer.labels), "rewrite changed the size of the symbol table")
+
+		live := liveSymbols(newChunk)
+		seen := make(map[string]struct{}, len(live))
+		for _, lbl := range live {
+			_, dup := seen[lbl]
+			require.False(t, dup, "symbol %q stored twice", lbl)
+			seen[lbl] = struct{}{}
+		}
+
+		// Deleting an entry deletes its metadata: a value nothing surviving
+		// refers to is gone from the chunk, not just unreferenced. The empty
+		// string is what a blanked symbol holds, so it is not a value to chase.
+		for value := range removedValues {
+			if value == "" {
+				continue
+			}
+			if _, ok := survivingValues[value]; ok {
+				continue
+			}
+			require.NotContains(t, seen, value, "value %q of a removed entry is still in the chunk", value)
+		}
+	})
+}

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -1799,6 +1799,493 @@ func TestMemChunk_Rewrite_WithFilter(t *testing.T) {
 	}
 }
 
+// lineFor names the entry at index i. Fixed width so no line is a prefix of
+// another and the removal sets below stay readable.
+func lineFor(i int) string { return fmt.Sprintf("line-%02d", i) }
+
+// distinctMetadata gives an entry metadata no other entry shares. Shared
+// metadata resolves to the same symbols and hides any renumbering.
+func distinctMetadata(i int) []logproto.LabelAdapter {
+	return []logproto.LabelAdapter{{Name: fmt.Sprintf("name_%02d", i), Value: fmt.Sprintf("value_%02d", i)}}
+}
+
+// unnormalizedMetadata uses names normalization rewrites, so the stored form
+// differs from what reads return.
+func unnormalizedMetadata(i int) []logproto.LabelAdapter {
+	return []logproto.LabelAdapter{{Name: fmt.Sprintf("name.%02d", i), Value: fmt.Sprintf("value_%02d", i)}}
+}
+
+// collidingMetadata uses two names that normalize alike, so one entry holds two
+// symbols that read back under a single name.
+func collidingMetadata(i int) []logproto.LabelAdapter {
+	return []logproto.LabelAdapter{
+		{Name: "a.b", Value: fmt.Sprintf("value_%02d", i)},
+		{Name: "a__b", Value: fmt.Sprintf("other_%02d", i)},
+	}
+}
+
+// valueNotALabelNameMetadata stores values that are not valid label names, so a
+// name symbol pointed at one fails the read outright rather than return the
+// wrong string.
+func valueNotALabelNameMetadata(i int) []logproto.LabelAdapter {
+	values := []string{"/", "-", "1", "", "a/b/c"}
+	return []logproto.LabelAdapter{{Name: fmt.Sprintf("name_%02d", i), Value: values[i%len(values)]}}
+}
+
+func buildMetadataChunk(t *testing.T, blockSize, numEntries int, metadata func(int) []logproto.LabelAdapter) *MemChunk {
+	t.Helper()
+
+	chk := NewMemChunk(ChunkFormatV4, compression.Snappy, UnorderedWithStructuredMetadataHeadBlockFmt, blockSize, testTargetSize)
+	for i := 0; i < numEntries; i++ {
+		_, err := chk.Append(&logproto.Entry{
+			Timestamp:          time.Unix(0, int64(i+1)),
+			Line:               lineFor(i),
+			StructuredMetadata: metadata(i),
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, chk.Close())
+
+	return chk
+}
+
+// reloadFromStorage round-trips a chunk the way the compactor receives one: the
+// symbolizer comes back read-only and without the symbolsMap add() dedupes
+// through, which is a different half of clone() than an in-memory chunk.
+func reloadFromStorage(t *testing.T, chk *MemChunk, blockSize int) *MemChunk {
+	t.Helper()
+
+	b, err := chk.Bytes()
+	require.NoError(t, err)
+
+	reloaded, err := NewByteChunk(b, blockSize, testTargetSize)
+	require.NoError(t, err)
+
+	// Pin the shape this is here to cover.
+	require.True(t, reloaded.symbolizer.readOnly, "a chunk read back from storage should have a read-only symbolizer")
+	require.Empty(t, reloaded.symbolizer.symbolsMap, "a chunk read back from storage should have no symbolsMap")
+
+	return reloaded
+}
+
+func readEntries(t *testing.T, chk Chunk) []logproto.Entry {
+	t.Helper()
+
+	entries, err := readEntriesErr(chk)
+	require.NoError(t, err)
+
+	return entries
+}
+
+// A chunk the buggy rewrite already touched cites positions past the end of its
+// own shrunken table. Rewriting one has to keep working -- those are the chunks
+// this fix exists for, and an error fails the delete request and the table's
+// retention pass, which no retry clears. A missing position resolves to the
+// empty string, which is what it already read back as.
+func TestMemChunk_Rewrite_SourceCitesPositionsPastItsTable(t *testing.T) {
+	// distinctMetadata puts entry i's name at position 2i and its value at 2i+1,
+	// so trimming an even number of positions loses whole pairs and an odd
+	// number leaves the last entry's name addressable but not its value.
+	for _, tc := range []struct {
+		name      string
+		blockSize int
+		metadata  func(int) []logproto.LabelAdapter
+		trim      int
+		// symbols the rewrite files for the empty string.
+		filed int
+	}{
+		{
+			// One block, so removing an entry re-encodes the rest.
+			name:      "whole pair lost, nothing interns the empty string",
+			blockSize: 1 << 20,
+			metadata:  distinctMetadata,
+			trim:      2,
+			filed:     1,
+		},
+		{
+			name:      "whole pair lost, empty string already interned",
+			blockSize: 1 << 20,
+			metadata: func(i int) []logproto.LabelAdapter {
+				if i == 0 {
+					return []logproto.LabelAdapter{{Name: "empty_valued", Value: ""}}
+				}
+				return distinctMetadata(i)
+			},
+			trim:  2,
+			filed: 0,
+		},
+		{
+			// One entry per block, so the damaged entry's block is copied over
+			// untouched and keeps citing the name. Blanking it would lose a name
+			// that still read back. The filed empty string lands exactly on the
+			// position that block cites for the lost value, so it reads the same.
+			name:      "half a pair lost, block copied verbatim",
+			blockSize: 1,
+			metadata:  distinctMetadata,
+			trim:      1,
+			filed:     1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			originalChunk := buildMetadataChunk(t, tc.blockSize, 5, tc.metadata)
+
+			// Stand in for the renumbering the old code did: drop the tail of the
+			// table while the blocks carry on citing it.
+			symbols := originalChunk.symbolizer.labels
+			require.Equal(t, []string{"name_04", "value_04"}, symbols[len(symbols)-2:])
+			originalChunk.symbolizer.labels = symbols[:len(symbols)-tc.trim]
+
+			originalChunk = reloadFromStorage(t, originalChunk, tc.blockSize)
+
+			var expected []logproto.Entry
+			for _, e := range readEntries(t, originalChunk) {
+				if e.Line != lineFor(0) {
+					expected = append(expected, e)
+				}
+			}
+			require.Len(t, expected, 4)
+
+			rewritten, err := originalChunk.Rewrite(func(_ time.Time, s string, _ labels.Labels) bool {
+				return s == lineFor(0)
+			})
+			require.NoError(t, err, "a chunk damaged by the old rewrite must still be rewritable")
+
+			requireEntriesEqual(t, expected, readEntries(t, rewritten))
+
+			// One symbol at most, and only ever the empty string.
+			rewrittenSymbols := rewritten.(*MemChunk).symbolizer.labels
+			require.Len(t, rewrittenSymbols, len(originalChunk.symbolizer.labels)+tc.filed)
+			if tc.filed == 1 {
+				require.Empty(t, rewrittenSymbols[len(rewrittenSymbols)-1])
+			}
+
+			// The result carries a blank per erased symbol plus, where one was
+			// filed, the empty string itself. Rewriting a table holding several
+			// has to work and leave the rest alone.
+			second := rewritten.(*MemChunk)
+			require.Greater(t, blankSymbols(second), 1, "expected the first rewrite to leave several empty symbols")
+
+			var expectedAgain []logproto.Entry
+			for _, e := range readEntries(t, second) {
+				if e.Line != lineFor(1) {
+					expectedAgain = append(expectedAgain, e)
+				}
+			}
+
+			rewrittenAgain, err := second.Rewrite(func(_ time.Time, s string, _ labels.Labels) bool {
+				return s == lineFor(1)
+			})
+			require.NoError(t, err)
+			requireEntriesEqual(t, expectedAgain, readEntries(t, rewrittenAgain))
+		})
+	}
+}
+
+// Rewriting again starts from a table holding blanks, where clone() maps the
+// empty string to the first of them. An undamaged chunk must not grow, and the
+// table has to survive each trip through storage.
+func TestMemChunk_Rewrite_RepeatedRewritesOfACleanChunk(t *testing.T) {
+	chk := reloadFromStorage(t, buildMetadataChunk(t, 1<<20, 8, distinctMetadata), 1<<20)
+	symbolCount := len(chk.symbolizer.labels)
+
+	for round := 1; round <= 4; round++ {
+		var expected []logproto.Entry
+		for _, e := range readEntries(t, chk) {
+			if e.Line != lineFor(round) {
+				expected = append(expected, e)
+			}
+		}
+
+		rewritten, err := chk.Rewrite(func(_ time.Time, s string, _ labels.Labels) bool {
+			return s == lineFor(round)
+		})
+		require.NoError(t, err)
+		next := rewritten.(*MemChunk)
+
+		require.Len(t, next.symbolizer.labels, symbolCount, "round %d changed the size of the symbol table", round)
+		requireEntriesEqual(t, expected, readEntries(t, next))
+
+		seen := map[string]struct{}{}
+		for _, lbl := range liveSymbols(next) {
+			_, dup := seen[lbl]
+			require.False(t, dup, "round %d stored %q twice", round, lbl)
+			seen[lbl] = struct{}{}
+		}
+
+		// Round-trip the way the compactor would get it next time.
+		b, err := next.Bytes()
+		require.NoError(t, err)
+		reloaded, err := NewByteChunk(b, 1<<20, testTargetSize)
+		require.NoError(t, err)
+		require.Equal(t, next.symbolizer.labels, reloaded.symbolizer.labels, "round %d: the table changed through storage", round)
+		requireEntriesEqual(t, expected, readEntries(t, reloaded))
+
+		chk = reloaded
+	}
+}
+
+// requireEntriesEqual compares entry by entry: comparing the slices wholesale
+// makes a failure render a diff of every entry in the chunk.
+func requireEntriesEqual(t *testing.T, expected, actual []logproto.Entry) {
+	t.Helper()
+
+	require.Len(t, actual, len(expected))
+	for i := range expected {
+		require.Equal(t, expected[i].Timestamp, actual[i].Timestamp, "entry %d", i)
+		require.Equal(t, expected[i].Line, actual[i].Line, "entry %d", i)
+		require.Equal(t, expected[i].StructuredMetadata, actual[i].StructuredMetadata, "entry %d (%q)", i, expected[i].Line)
+	}
+}
+
+// Blocks Rewrite did not change are copied over still citing the positions they
+// were encoded with, so the new chunk has to number its symbols the same way.
+// Removing an entry used to drop the symbols only it cited, shifting every later
+// position down: entries came back with another entry's metadata, or none.
+func TestMemChunk_Rewrite_PreservesSurvivingStructuredMetadata(t *testing.T) {
+	// A block size of 1 cuts a block after every entry, so each one is either
+	// copied over untouched or dropped. Larger sizes pack several entries per
+	// block, so a block loses some of its entries and is re-encoded while its
+	// neighbours are still copied verbatim.
+	const (
+		blockPerEntry   = 1
+		entriesPerBlock = 60
+	)
+
+	for _, tc := range []struct {
+		name       string
+		blockSize  int
+		numEntries int
+		metadata   func(int) []logproto.LabelAdapter
+		remove     []int
+		minBlocks  int
+	}{
+		{
+			name:       "no removals",
+			blockSize:  blockPerEntry,
+			numEntries: 5,
+			minBlocks:  5,
+		},
+		{
+			name:       "removal in the middle",
+			blockSize:  blockPerEntry,
+			numEntries: 5,
+			remove:     []int{2},
+			minBlocks:  5,
+		},
+		{
+			name:       "removal at the front",
+			blockSize:  blockPerEntry,
+			numEntries: 5,
+			remove:     []int{0},
+			minBlocks:  5,
+		},
+		{
+			name:       "removal at the end",
+			blockSize:  blockPerEntry,
+			numEntries: 5,
+			remove:     []int{4},
+			minBlocks:  5,
+		},
+		{
+			name:       "adjacent removals",
+			blockSize:  blockPerEntry,
+			numEntries: 6,
+			remove:     []int{2, 3},
+			minBlocks:  6,
+		},
+		{
+			name:       "scattered removals",
+			blockSize:  blockPerEntry,
+			numEntries: 12,
+			remove:     []int{1, 4, 5, 9},
+			minBlocks:  12,
+		},
+		{
+			name:       "all but one removed",
+			blockSize:  blockPerEntry,
+			numEntries: 5,
+			remove:     []int{0, 1, 2, 4},
+			minBlocks:  5,
+		},
+		{
+			name:       "everything removed",
+			blockSize:  blockPerEntry,
+			numEntries: 5,
+			remove:     []int{0, 1, 2, 3, 4},
+			minBlocks:  5,
+		},
+		{
+			name:       "partial removal from a block of several entries",
+			blockSize:  entriesPerBlock,
+			numEntries: 12,
+			remove:     []int{1},
+			minBlocks:  3,
+		},
+		{
+			name:       "partial removal from several blocks",
+			blockSize:  entriesPerBlock,
+			numEntries: 12,
+			remove:     []int{1, 8},
+			minBlocks:  3,
+		},
+		{
+			name:       "names that do not survive normalization untouched",
+			blockSize:  blockPerEntry,
+			numEntries: 12,
+			metadata:   unnormalizedMetadata,
+			remove:     []int{1, 4, 9},
+			minBlocks:  12,
+		},
+		{
+			name:       "names that normalize onto each other",
+			blockSize:  blockPerEntry,
+			numEntries: 8,
+			metadata:   collidingMetadata,
+			remove:     []int{1, 4},
+			minBlocks:  8,
+		},
+		{
+			name:       "values that are not valid label names",
+			blockSize:  blockPerEntry,
+			numEntries: 10,
+			metadata:   valueNotALabelNameMetadata,
+			remove:     []int{1, 3, 6},
+			minBlocks:  10,
+		},
+		{
+			name:       "values that are not valid label names, re-encoded blocks",
+			blockSize:  entriesPerBlock,
+			numEntries: 12,
+			metadata:   valueNotALabelNameMetadata,
+			remove:     []int{2, 7},
+			minBlocks:  3,
+		},
+	} {
+		for _, fromStorage := range []bool{false, true} {
+			name := tc.name
+			if fromStorage {
+				name += ", read back from storage"
+			}
+
+			t.Run(name, func(t *testing.T) {
+				metadata := tc.metadata
+				if metadata == nil {
+					metadata = distinctMetadata
+				}
+
+				originalChunk := buildMetadataChunk(t, tc.blockSize, tc.numEntries, metadata)
+				if fromStorage {
+					originalChunk = reloadFromStorage(t, originalChunk, tc.blockSize)
+				}
+				require.GreaterOrEqual(t, originalChunk.BlockCount(), tc.minBlocks, "chunk is not laid out the way this case assumes")
+
+				removed := make(map[string]bool, len(tc.remove))
+				for _, i := range tc.remove {
+					removed[lineFor(i)] = true
+				}
+
+				// Take what the chunk holds as the baseline rather than the metadata
+				// handed to Append, so whatever the write path did to it is already
+				// accounted for and this only measures what the rewrite changed.
+				var expected []logproto.Entry
+				for _, e := range readEntries(t, originalChunk) {
+					if !removed[e.Line] {
+						expected = append(expected, e)
+					}
+				}
+				require.Len(t, expected, tc.numEntries-len(tc.remove))
+
+				rewritten, err := originalChunk.Rewrite(func(_ time.Time, s string, _ labels.Labels) bool {
+					return removed[s]
+				})
+				if len(expected) == 0 {
+					require.Equal(t, chunk.ErrRewriteNoDataLeft, err)
+					return
+				}
+				require.NoError(t, err)
+				newChunk := rewritten.(*MemChunk)
+
+				requireEntriesEqual(t, expected, readEntries(t, newChunk))
+
+				// The rewritten chunk is what gets uploaded, so it has to survive the
+				// encoding too.
+				b, err := newChunk.Bytes()
+				require.NoError(t, err)
+				roundTripped, err := NewByteChunk(b, tc.blockSize, testTargetSize)
+				require.NoError(t, err)
+
+				actual := readEntries(t, roundTripped)
+				requireEntriesEqual(t, expected, actual)
+
+				// No surviving entry resolves a name to a blanked or out of range symbol.
+				for _, e := range actual {
+					for _, lbl := range e.StructuredMetadata {
+						require.NotEmpty(t, lbl.Name, "entry %q resolved a name to a blanked symbol", e.Line)
+					}
+				}
+
+				// Keeping the positions stable must not grow the table or file a second
+				// copy of a symbol: reads normalize label names, so re-encoding from
+				// what a read returns rather than from what is stored would do both.
+				require.Len(t, newChunk.symbolizer.labels, len(originalChunk.symbolizer.labels), "rewrite changed the size of the symbol table")
+
+				seen := map[string]struct{}{}
+				for _, lbl := range liveSymbols(newChunk) {
+					_, dup := seen[lbl]
+					require.False(t, dup, "symbol %q stored twice", lbl)
+					seen[lbl] = struct{}{}
+				}
+			})
+		}
+	}
+}
+
+// Keeping positions stable must not keep the removed entries' names and values
+// with them: a delete request has to erase those.
+func TestMemChunk_Rewrite_DropsStructuredMetadataOfRemovedEntries(t *testing.T) {
+	const secret = "alice@example.com"
+
+	// Uncompressed so the assertions below can look for the value in the bytes
+	// the compactor would upload.
+	originalChunk := NewMemChunk(ChunkFormatV4, compression.None, UnorderedWithStructuredMetadataHeadBlockFmt, 1, testTargetSize)
+	for i, sm := range [][]logproto.LabelAdapter{
+		{{Name: "aaa", Value: "0"}},
+		{{Name: "user_email", Value: secret}},
+		{{Name: "ccc", Value: "2"}},
+	} {
+		_, err := originalChunk.Append(&logproto.Entry{
+			Timestamp:          time.Unix(0, int64(i+1)),
+			Line:               lineFor(i),
+			StructuredMetadata: sm,
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, originalChunk.Close())
+	require.Greater(t, originalChunk.BlockCount(), 1)
+
+	originalBytes, err := originalChunk.Bytes()
+	require.NoError(t, err)
+	require.Contains(t, string(originalBytes), secret, "test needs the value to be findable before the rewrite")
+
+	rewritten, err := originalChunk.Rewrite(func(_ time.Time, s string, _ labels.Labels) bool {
+		return s == lineFor(1)
+	})
+	require.NoError(t, err)
+	newChunk := rewritten.(*MemChunk)
+
+	require.NotContains(t, liveSymbols(newChunk), secret, "removed entry's value is still in the symbol table")
+	require.NotContains(t, liveSymbols(newChunk), "user_email", "removed entry's name is still in the symbol table")
+
+	newBytes, err := newChunk.Bytes()
+	require.NoError(t, err)
+	require.NotContains(t, string(newBytes), secret, "removed entry's value is still in the chunk")
+	require.NotContains(t, string(newBytes), "user_email", "removed entry's name is still in the chunk")
+
+	// Symbols an entry that survived still refers to are left alone.
+	require.Contains(t, string(newBytes), "aaa")
+	require.Contains(t, string(newBytes), "ccc")
+}
+
 func buildFilterableTestMemChunk(t *testing.T, from, through time.Time, matchingFrom, matchingTo *time.Time, withStructuredMetadata bool) *MemChunk {
 	chk := NewMemChunk(ChunkFormatV4, compression.GZIP, DefaultTestHeadBlockFmt, testBlockSize, 0)
 	t.Logf("from   : %v", from.String())

--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -104,6 +104,76 @@ func (s *symbolizer) add(lbl string) uint32 {
 	return idx
 }
 
+// clone returns a writable copy that keeps every symbol at its position, so a
+// chunk reusing an already encoded block still resolves it correctly.
+func (s *symbolizer) clone() *symbolizer {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	c := &symbolizer{
+		symbolsMap:      make(map[string]uint32, len(s.labels)),
+		labels:          make([]string, len(s.labels)),
+		size:            s.size,
+		normalizedNames: make(map[uint32]string, len(s.labels)/2),
+	}
+	copy(c.labels, s.labels)
+
+	for i, lbl := range c.labels {
+		if _, ok := c.symbolsMap[lbl]; !ok {
+			c.symbolsMap[lbl] = uint32(i)
+		}
+	}
+
+	return c
+}
+
+// positionOf returns the position add() would resolve lbl to, without filing it
+// as a side effect of asking.
+func (s *symbolizer) positionOf(lbl string) (uint32, bool) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	pos, ok := s.symbolsMap[lbl]
+	return pos, ok
+}
+
+// retainOnly every unused symbol to an empty string, leaving the rest at
+// their positions. used is indexed by position and must cover the whole table,
+// so a caller filing a symbol without accounting for it fails loudly instead of
+// having it blanked out from under whatever cites it.
+func (s *symbolizer) retainOnly(used []bool) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.readOnly {
+		return errSymbolizerReadOnly
+	}
+	if len(used) != len(s.labels) {
+		return fmt.Errorf("symbolizer: used covers %d symbols, table holds %d", len(used), len(s.labels))
+	}
+
+	size := 0
+	for i, lbl := range s.labels {
+		if lbl == "" {
+			continue
+		}
+		if used[i] {
+			size += len(lbl)
+			continue
+		}
+
+		delete(s.symbolsMap, lbl)
+		s.labels[i] = ""
+	}
+
+	s.size = size
+	// Nothing has looked a name up on this symbolizer yet, but a blanked position
+	// must never keep serving a name normalized from the string it used to hold.
+	clear(s.normalizedNames)
+
+	return nil
+}
+
 // Lookup coverts and returns labels pairs for the given symbols
 func (s *symbolizer) Lookup(syms symbols, buf *labels.ScratchBuilder) (labels.Labels, error) {
 	if len(syms) == 0 {

--- a/pkg/chunkenc/symbols_test.go
+++ b/pkg/chunkenc/symbols_test.go
@@ -332,3 +332,35 @@ func TestSymbolizerLabelNormalizationSameNameValue(t *testing.T) {
 	require.False(t, result.Has("foo-bar"), "metric should not contain unnormalized label")
 	require.False(t, result.Has("test-label"), "metric should not contain unnormalized label")
 }
+
+// used is indexed by symbol position, so a caller filing a symbol without
+// accounting for it has to fail loudly rather than have it blanked out from
+// under whatever cites it.
+func TestSymbolizerRetainOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		used     int
+		readOnly bool
+		err      string
+	}{
+		{name: "covers the table", used: 2},
+		{name: "shorter than the table", used: 1, err: "used covers 1 symbols, table holds 2"},
+		{name: "longer than the table", used: 3, err: "used covers 3 symbols, table holds 2"},
+		{name: "table read back from a flushed chunk", used: 2, readOnly: true, err: errSymbolizerReadOnly.Error()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newSymbolizer()
+			_, err := s.Add(labels.FromStrings("foo", "bar"))
+			require.NoError(t, err)
+			require.Len(t, s.labels, 2)
+			s.readOnly = tc.readOnly
+
+			err = s.retainOnly(make([]bool, tc.used))
+			if tc.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.err)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`MemChunk.Rewrite` is the compactor's per-line delete path. Blocks encode structured metadata as positions into the chunk's symbol table, and since #19140 a block that loses no entries is copied into the new chunk as it is still citing the positions it was originally encoded with. `Rewrite` built the new chunk on an empty symbol table, so symbols referenced only by deleted entries disappeared, shifting every later position down and silently repointing those copied blocks at the wrong strings.

Entries came back carrying another entry's structured metadata, or none at all where a position ran off the end of the table. Where a name position landed on a value that is not a valid label name (`/`, for instance), `symbolizer.Lookup` returned an error, which failed the deletion job for that chunk.

This builds the rewritten chunk on a copy of the source symbol table so the positions line up, and erases the symbols no surviving entry cites by blanking them in place rather than removing them. Blanking keeps the numbering stable while still deleting the removed entries' names and values, which a delete request has to do.

I have added a fuzz test `FuzzMemChunkRewrite` target with 8 seeds, and unit tests for the symbolizer's preconditions. Replaying the pre-fix code fails 28 of 30 subtests and 6 of 8 seeds; the rest are the degenerate cases. Roughly 4M fuzz executions with no failures with the fix.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)