### PR TITLE
perf: Read the streaming index window with pread

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_series.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_series.go
@@ -53,17 +53,7 @@ func (sc *seriesScan) Close() error {
 }
 
 // seek positions the scan's reader at the given absolute file offset.
-//
-// A short forward step is served by discarding bytes, which will often come
-// straight out of the read-ahead buffer and cost nothing; anything else falls
-// back to repositioning the file.
-// Backwards steps are always a reposition, so out-of-order refs stay correct
-// and merely incur the cost of ResetAt.
 func (sc *seriesScan) seek(offset int) {
-	if distance := offset - sc.decbuf.Offset(); distance >= 0 && distance <= streamenc.ReaderBufferSize {
-		sc.decbuf.Skip(distance)
-		return
-	}
 	sc.decbuf.ResetAt(offset)
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
@@ -123,18 +123,12 @@ func (d *Decbuf) SkipUvarintBytes() {
 }
 
 // ResetAt sets the pointer of the underlying BufReader to the absolute
-// offset and discards any buffered data. If E is non-nil, this method has
-// no effect. ResetAt-ing beyond the end of the underlying BufReader will set
-// E to an error and not advance the pointer of BufReader.
+// offset.
+// If E is non-nil, this method has no effect.
+// ResetAt-ing beyond the end of the underlying BufReader will set E to an error and
+// not advance the pointer of BufReader.
 func (d *Decbuf) ResetAt(off int) {
 	if d.E != nil {
-		return
-	}
-
-	// If we are trying to reset at an offset which is already buffered,
-	// we can avoid resetting the BufReader and just discard some of the buffer instead.
-	if dist := off - d.Offset(); dist >= 0 && dist < d.r.Buffered() {
-		d.E = d.r.Skip(dist)
 		return
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
@@ -6,7 +6,6 @@
 package streamenc
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -20,10 +19,17 @@ import (
 // value is arbitrary and will likely change in the future based on profiling results.
 const ReaderBufferSize = 4096
 
+// FileReader reads a file through a fixed-size read-ahead window.
+// The window is filled with positioned reads (pread, via os.File.ReadAt).
+// Every method maintains an invariant:
+// - buf[0:n] holds the bytes [off-r, off-r+n) of the underlying file
 type FileReader struct {
 	file   *os.File
 	closer filepool.FilePoolCloser
-	buf    *bufio.Reader
+	buf    []byte  // read-ahead window
+	bufRef *[]byte // pointer to buf so putting it back in the pool doesn't allocate a slice header
+	r      int     // read cursor within buf
+	n      int     // number of valid bytes in buf
 	base   int
 	length int
 	off    int
@@ -31,17 +37,20 @@ type FileReader struct {
 
 var bufferPool = sync.Pool{
 	New: func() any {
-		return bufio.NewReaderSize(nil, ReaderBufferSize)
+		b := make([]byte, ReaderBufferSize)
+		return &b
 	},
 }
 
 // NewFileReader creates a new FileReader for the segment of file beginning at base bytes,
 // extending length bytes, and closing the handle with closer.
 func NewFileReader(file *os.File, base, length int, closer filepool.FilePoolCloser) (*FileReader, error) {
+	bufRef := bufferPool.Get().(*[]byte)
 	f := &FileReader{
 		file:   file,
 		closer: closer,
-		buf:    bufferPool.Get().(*bufio.Reader),
+		bufRef: bufRef,
+		buf:    *bufRef,
 		base:   base,
 		length: length,
 	}
@@ -58,18 +67,60 @@ func (f *FileReader) Reset() error {
 	return f.ResetAt(0)
 }
 
+// ResetAt moves the cursor to off, relative to the segment base.
+//
+// It never reads and never moves the file handle's offset. A target inside the
+// read-ahead window is a cursor move, in either direction, since the window
+// spans bytes on both sides of the cursor. Anything else drops the window, so
+// the next access preads at the right place.
 func (f *FileReader) ResetAt(off int) error {
 	if off > f.length {
 		return ErrInvalidSize
 	}
 
-	_, err := f.file.Seek(int64(f.base+off), io.SeekStart)
-	if err != nil {
-		return err
+	if windowStart := f.off - f.r; off >= windowStart && off <= windowStart+f.n {
+		f.r, f.off = off-windowStart, off
+		return nil
 	}
 
-	f.buf.Reset(f.file)
+	f.dropWindow()
 	f.off = off
+
+	return nil
+}
+
+// dropWindow marks the read-ahead window empty, so that the next fill preads at
+// the current cursor. It must be called by anything that moves off without
+// moving r by the same amount.
+func (f *FileReader) dropWindow() {
+	f.r, f.n = 0, 0
+}
+
+// fill ensures at least need bytes are in the window, or that the end of the
+// file has been reached, in which case it returns io.EOF. It always asks for as
+// much as the window can hold, so a single pread serves many small reads.
+func (f *FileReader) fill(need int) error {
+	if f.n-f.r >= need {
+		return nil
+	}
+
+	// Slide what is left to the front to make room for the read-ahead.
+	if f.r > 0 {
+		f.n = copy(f.buf, f.buf[f.r:f.n])
+		f.r = 0
+	}
+
+	if f.n < len(f.buf) {
+		m, err := f.file.ReadAt(f.buf[f.n:], int64(f.base+f.off+(f.n-f.r)))
+		f.n += m
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+	}
+
+	if f.n-f.r < need {
+		return io.EOF
+	}
 
 	return nil
 }
@@ -79,24 +130,35 @@ func (f *FileReader) Skip(l int) error {
 		return ErrInvalidSize
 	}
 
-	n, err := f.buf.Discard(l)
-	if n > 0 {
-		f.off += n
+	if l <= f.n-f.r {
+		f.r += l
+	} else {
+		f.dropWindow()
 	}
 
-	return err
+	f.off += l
+
+	return nil
 }
 
 func (f *FileReader) Peek(n int) ([]byte, error) {
-	b, err := f.buf.Peek(n)
-	// bufio.Reader still returns what it Read when it hits EOF and callers
-	// expect to be able to peek past the end of a file.
+	if n > len(f.buf) {
+		// Callers are expected to check Size() first and use Read for anything
+		// larger; this mirrors bufio.Reader.Peek refusing to peek past its own
+		// buffer.
+		return nil, fmt.Errorf("%w peeking %d bytes: window holds %d", ErrInvalidSize, n, len(f.buf))
+	}
+
+	err := f.fill(n)
+	// Still return a partial result when Peeking beyond the end of the file;
+	// this mirrors bufio.Reader.Peek.
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 
-	if len(b) > 0 {
-		return b, nil
+	avail := min(f.n-f.r, n)
+	if avail > 0 {
+		return f.buf[f.r : f.r+avail], nil
 	}
 
 	return nil, nil
@@ -114,15 +176,46 @@ func (f *FileReader) Read(n int) ([]byte, error) {
 }
 
 func (f *FileReader) ReadInto(b []byte) error {
-	r, err := io.ReadFull(f.buf, b)
-	if r > 0 {
-		f.off += r
+	read := 0
+
+	for read < len(b) {
+		// Serve from the window first, so a run of small reads shares one pread.
+		if f.n > f.r {
+			c := copy(b[read:], f.buf[f.r:f.n])
+			f.r += c
+			f.off += c
+			read += c
+			continue
+		}
+
+		// A read at least as large as the window would spend more time being
+		// copied than it saves, so it goes straight into the destination.
+		if len(b)-read >= len(f.buf) {
+			f.dropWindow()
+			m, err := f.file.ReadAt(b[read:], int64(f.base+f.off))
+			f.off += m
+			read += m
+			if err != nil && !errors.Is(err, io.EOF) {
+				return err
+			}
+			break
+		}
+
+		// Otherwise refill the window and go again
+		if err := f.fill(1); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
 	}
 
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		return fmt.Errorf("%w reading %d bytes: %s", ErrInvalidSize, len(b), err)
-	} else if err != nil {
-		return err
+	if read < len(b) {
+		cause := io.ErrUnexpectedEOF
+		if read == 0 {
+			cause = io.EOF
+		}
+		return fmt.Errorf("%w reading %d bytes: %s", ErrInvalidSize, len(b), cause)
 	}
 
 	return nil
@@ -137,18 +230,22 @@ func (f *FileReader) Len() int {
 }
 
 func (f *FileReader) Size() int {
-	return f.buf.Size()
+	return len(f.buf)
 }
 
 func (f *FileReader) Buffered() int {
-	return f.buf.Buffered()
+	return f.n - f.r
 }
 
 // Close cleans up the underlying resources used by this FileReader.
 func (f *FileReader) Close() error {
-	// Note that we don't do anything to clean up the buffer before returning it to the pool here:
-	// we reset the buffer when we retrieve it from the pool instead.
-	bufferPool.Put(f.buf)
+	// Note that we don't do anything to clean up the buffer's contents before
+	// returning it to the pool here: the window is marked empty on acquisition
+	// instead, so stale bytes are never readable.
+	if f.bufRef != nil {
+		bufferPool.Put(f.bufRef)
+		f.bufRef, f.buf = nil, nil
+	}
 	// File handles are pooled, so we don't actually close the handle here, just return it.
 	return f.closer.Put(f.file)
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader_test.go
@@ -6,6 +6,7 @@
 package streamenc
 
 import (
+	"math/rand"
 	"os"
 	"path"
 	"testing"
@@ -118,7 +119,9 @@ func TestReaders_ResetAt(t *testing.T) {
 		require.Equal(t, []byte("0"), readAfterResetToLastByte, "read after reset to last byte")
 
 		require.NoError(t, r.ResetAt(20))
+		require.Equal(t, 20, r.Offset())
 		require.ErrorIs(t, r.ResetAt(21), ErrInvalidSize)
+		require.Equal(t, 20, r.Offset())
 	})
 }
 
@@ -145,7 +148,7 @@ func TestReaders_Skip(t *testing.T) {
 		require.NoError(t, r.Skip(5))
 		require.Equal(t, 0, r.Len())
 		require.ErrorIs(t, r.Skip(1), ErrInvalidSize)
-
+		require.Equal(t, 20, r.Offset())
 	})
 }
 
@@ -207,18 +210,7 @@ func TestReaders_Position(t *testing.T) {
 
 func TestReaders_CreationWithEmptyContents(t *testing.T) {
 	t.Run("FileReader", func(t *testing.T) {
-		dir := t.TempDir()
-		filePath := path.Join(dir, "test-file")
-		require.NoError(t, os.WriteFile(filePath, nil, 0700))
-
-		f, err := os.Open(filePath)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, f.Close())
-		})
-
-		r, err := NewFileReader(f, 0, 0, &filepool.SingleFilePoolNoopCloser{})
-		require.NoError(t, err)
+		r := newTestFileReader(t, nil, 0, 0)
 		require.ErrorIs(t, r.Skip(1), ErrInvalidSize)
 		require.ErrorIs(t, r.ResetAt(1), ErrInvalidSize)
 	})
@@ -228,39 +220,154 @@ func testReaders(t *testing.T, test func(t *testing.T, r *FileReader)) {
 	testReaderContents := []byte("abcdefghij1234567890")
 
 	t.Run("FileReaderWithZeroOffset", func(t *testing.T) {
-		dir := t.TempDir()
-		filePath := path.Join(dir, "test-file")
-		require.NoError(t, os.WriteFile(filePath, testReaderContents, 0700))
-
-		f, err := os.Open(filePath)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, f.Close())
-		})
-
-		r, err := NewFileReader(f, 0, len(testReaderContents), &filepool.SingleFilePoolNoopCloser{})
-		require.NoError(t, err)
-
+		r := newTestFileReader(t, testReaderContents, 0, len(testReaderContents))
 		test(t, r)
 	})
 
 	t.Run("FileReaderWithNonZeroOffset", func(t *testing.T) {
 		offsetBytes := []byte("ABCDE")
 		fileBytes := append(offsetBytes, testReaderContents...)
-
-		dir := t.TempDir()
-		filePath := path.Join(dir, "test-file")
-		require.NoError(t, os.WriteFile(filePath, fileBytes, 0700))
-
-		f, err := os.Open(filePath)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, f.Close())
-		})
-
-		r, err := NewFileReader(f, len(offsetBytes), len(testReaderContents), &filepool.SingleFilePoolNoopCloser{})
-		require.NoError(t, err)
-
+		r := newTestFileReader(t, fileBytes, len(offsetBytes), len(testReaderContents))
 		test(t, r)
 	})
+}
+
+func newTestFileReader(t *testing.T, fileBytes []byte, base, length int) *FileReader {
+	t.Helper()
+
+	filePath := path.Join(t.TempDir(), "test-file")
+	require.NoError(t, os.WriteFile(filePath, fileBytes, 0600))
+	f, err := os.Open(filePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
+	r, err := NewFileReader(f, base, length, &filepool.SingleFilePoolNoopCloser{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if r.buf != nil {
+			require.NoError(t, r.Close())
+		}
+	})
+	return r
+}
+
+func generateTestData(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i*7 + i/251)
+	}
+	return b
+}
+
+func newTestFileReaderWithGeneratedData(t *testing.T, base, length int) (*FileReader, []byte) {
+	t.Helper()
+
+	content := generateTestData(length)
+	fileBytes := make([]byte, base+length+64)
+	for i := range fileBytes[:base] {
+		fileBytes[i] = 0xaa
+	}
+	copy(fileBytes[base:], content)
+	for i := base + length; i < len(fileBytes); i++ {
+		fileBytes[i] = 0xbb
+	}
+
+	return newTestFileReader(t, fileBytes, base, length), content
+}
+
+func requireBufferInvariant(t *testing.T, r *FileReader, content []byte) {
+	t.Helper()
+
+	require.GreaterOrEqual(t, r.r, 0)
+	require.LessOrEqual(t, r.r, r.n)
+	require.LessOrEqual(t, r.n, len(r.buf))
+	require.GreaterOrEqual(t, r.off, r.r)
+
+	bufferStart := r.off - r.r
+	require.Equal(t, content[bufferStart:r.off], r.buf[:r.r])
+	end := min(r.off+r.Buffered(), len(content))
+	if end > r.off {
+		require.Equal(t, content[r.off:end], r.buf[r.r:r.r+end-r.off])
+	}
+}
+
+func TestFileReader_BufferInvariant(t *testing.T) {
+	const length = 10*ReaderBufferSize + 613
+	r, content := newTestFileReaderWithGeneratedData(t, 17, length)
+	rng := rand.New(rand.NewSource(20260826))
+
+	pickOffset := func() int {
+		if rng.Intn(2) != 0 {
+			return rng.Intn(length + 1)
+		}
+		edge := rng.Intn(length/ReaderBufferSize+1)*ReaderBufferSize + rng.Intn(5) - 2
+		return max(0, min(edge, length))
+	}
+
+	// Take random actions, asserting that the invariant holds after each action
+	for i := range 20000 {
+		switch rng.Intn(5) {
+		case 0:
+			// ResetAt to a random offset
+			off := pickOffset()
+			require.NoError(t, r.ResetAt(off), "iteration %d", i)
+			require.Equal(t, off, r.Offset(), "iteration %d", i)
+		case 1:
+			// Skip a random number of bytes forwards
+			before := r.Offset()
+			l := rng.Intn(r.Len() + 1)
+			require.NoError(t, r.Skip(l), "iteration %d", i)
+			require.Equal(t, before+l, r.Offset(), "iteration %d", i)
+		case 2:
+			// Peek a random number of bytes ahead
+			n := 1 + rng.Intn(ReaderBufferSize)
+			off := r.Offset()
+			got, err := r.Peek(n)
+			require.NoError(t, err, "iteration %d", i)
+			require.Equal(t, off, r.Offset(), "iteration %d", i)
+			want := min(n, len(content)-off)
+			require.GreaterOrEqual(t, len(got), want, "iteration %d", i)
+			require.Equal(t, content[off:off+want], got[:want], "iteration %d", i)
+		case 3:
+			// ReadInto a random number of bytes into a byte buffer
+			if r.Len() == 0 {
+				continue
+			}
+			n := 1 + rng.Intn(min(r.Len(), 2*ReaderBufferSize))
+			off := r.Offset()
+			buf := make([]byte, n)
+			require.NoError(t, r.ReadInto(buf), "iteration %d", i)
+			require.Equal(t, content[off:off+n], buf, "iteration %d", i)
+			require.Equal(t, off+n, r.Offset(), "iteration %d", i)
+		case 4:
+			// Reset the reader
+			require.NoError(t, r.Reset(), "iteration %d", i)
+			require.Zero(t, r.Offset(), "iteration %d", i)
+		}
+		requireBufferInvariant(t, r, content)
+	}
+}
+
+func TestFileReader_PeekBeyondBufferSize(t *testing.T) {
+	r, content := newTestFileReaderWithGeneratedData(t, 0, 4*ReaderBufferSize)
+	_, err := r.Peek(r.Size() + 1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Zero(t, r.Offset())
+
+	got, err := r.Peek(r.Size())
+	require.NoError(t, err)
+	require.Equal(t, content[:r.Size()], got)
+}
+
+func TestFileReader_ReadIntoPastEOF(t *testing.T) {
+	const length = 3*ReaderBufferSize + 137
+	content := generateTestData(length)
+	r := newTestFileReader(t, content, 0, length)
+	require.NoError(t, r.Skip(5))
+
+	buf := make([]byte, length)
+	err := r.ReadInto(buf)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Equal(t, content[5:], buf[:length-5])
+	require.Equal(t, length, r.Offset())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This was expected to be faster because it saves syscalls - rather than a `seek` then a `read`, we can do a `pread` instead. The approach taken is to read ahead by the same amount that the buffered reader was previously so that we don't miss out on a single syscall serving multiple small reads.

In existing benchmarks, we see a significant improvement in time taken, at the cost of an increase in bytes read:
```
                   │ before.txt  │              after.txt              │
                   │   sec/op    │   sec/op     vs base                │
Postings_Stats-12    5.143m ± 2%   5.205m ± 4%   +1.21% (p=0.035 n=10)
Postings-12          200.4µ ± 1%   198.5µ ± 1%        ~ (p=0.063 n=10)
SeriesIteration-12   44.73m ± 2%   27.16m ± 2%  -39.26% (p=0.000 n=10)
geomean              3.586m        3.039m       -15.25%

                   │  before.txt   │               after.txt               │
                   │     B/op      │     B/op       vs base                │
Postings_Stats-12    6.179Mi ±  0%   6.179Mi ±  0%        ~ (p=0.721 n=10)
Postings-12            506.0 ± 36%     568.5 ± 31%        ~ (p=0.469 n=10)
SeriesIteration-12   2.888Mi ±  0%   3.616Mi ±  0%  +25.19% (p=0.000 n=10)
geomean              209.9Ki         235.2Ki        +12.04%

                   │ before.txt  │              after.txt               │
                   │  allocs/op  │  allocs/op   vs base                 │
Postings_Stats-12    200.8k ± 0%   200.8k ± 0%       ~ (p=1.000 n=10) ¹
Postings-12           5.000 ± 0%    5.000 ± 0%       ~ (p=1.000 n=10) ¹
SeriesIteration-12   70.85k ± 0%   70.85k ± 0%  +0.00% (p=0.000 n=10)
geomean              4.144k        4.144k       +0.00%
¹ all samples are equal
```

**Which issue(s) this PR fixes**: N/A. 

**Special notes for your reviewer** N/A. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
