### PR TITLE
docs: Fix /config mode value from diffs to diff

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1252,7 +1252,7 @@ GET /config
 ```
 
 `/config` exposes the current configuration. The optional `mode` query parameter can be used to
-modify the output. If it has the value `diffs` only the differences between the default configuration
+modify the output. If it has the value `diff` only the differences between the default configuration
 and the current are returned. A value of `defaults` returns the default configuration.
 
 In microservices mode, the `/config` endpoint is exposed by all components.


### PR DESCRIPTION
**What this PR does / why we need it**:

The `/config` endpoint's `mode` query parameter only recognizes `diff`, but the docs said `diffs`, which could mislead API consumers into passing a value that silently falls through to the default (full config) behavior.

Flagged by a [Copilot review](https://github.com/grafana/loki/pull/24230#pullrequestreview-5154855135) on grafana/loki#24230.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

- Docs-only change, no code touched.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format
- [x] N/A — no upgrade-impacting change
- [x] N/A — no config option deprecated or removed
