### PR TITLE
chore(distributor): Add per-tenant active stream count metric to rateStore

### DIFF
--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -119,12 +119,12 @@ func (s *rateStore) updateAllRates(ctx context.Context) error {
 
 	streamRates := s.getRates(ctx, clients)
 	updated := s.aggregateByShard(ctx, streamRates)
-	updateStats := s.updateRates(ctx, updated)
+	stats := s.updateRates(ctx, updated)
 
-	s.metrics.maxStreamRate.Set(float64(updateStats.maxRate))
-	s.metrics.maxStreamShardCount.Set(float64(updateStats.maxShards))
-	s.metrics.streamCount.Set(float64(updateStats.totalStreams))
-	s.metrics.expiredCount.Add(float64(updateStats.expiredCount))
+	s.metrics.maxStreamRate.Set(float64(stats.maxRate))
+	s.metrics.maxStreamShardCount.Set(float64(stats.maxShards))
+	s.metrics.streamCount.Set(float64(stats.totalStreams))
+	s.metrics.expiredCount.Add(float64(stats.expiredCount))
 
 	return nil
 }
@@ -136,7 +136,7 @@ type rateStats struct {
 	expiredCount int64
 }
 
-func (s *rateStore) updateRates(ctx context.Context, updated map[string]map[uint64]expiringRate) rateStats {
+func (s *rateStore) updateRates(ctx context.Context, updated perTenantExpiringRate) rateStats {
 	streamCnt := 0
 	if s.debug {
 		sp := trace.SpanFromContext(ctx)
@@ -178,7 +178,11 @@ func weightedMovingAverageF(next, last float64) float64 {
 	return (smoothingFactor * next) + ((1 - smoothingFactor) * last)
 }
 
-func (s *rateStore) cleanupExpired(updated map[string]map[uint64]expiringRate) rateStats {
+// cleanupExpired removes streams that have not been reported by any ingester
+// within rateKeepAlive and decays the rate of streams that were not part of the
+// most recent update. It must be called with rateLock held, because it mutates
+// s.rates.
+func (s *rateStore) cleanupExpired(updated perTenantExpiringRate) rateStats {
 	var rs rateStats
 
 	for tID, tenant := range s.rates {
@@ -186,10 +190,7 @@ func (s *rateStore) cleanupExpired(updated map[string]map[uint64]expiringRate) r
 		for stream, rate := range tenant {
 			if time.Since(rate.createdAt) > s.rateKeepAlive {
 				rs.expiredCount++
-				delete(s.rates[tID], stream)
-				if len(s.rates[tID]) == 0 {
-					delete(s.rates, tID)
-				}
+				delete(tenant, stream)
 				continue
 			}
 
@@ -205,12 +206,19 @@ func (s *rateStore) cleanupExpired(updated map[string]map[uint64]expiringRate) r
 			s.metrics.streamShardCount.Observe(float64(rate.shards))
 			s.metrics.streamRate.Observe(float64(rate.rate))
 		}
+
+		if len(tenant) == 0 {
+			delete(s.rates, tID)
+			s.metrics.activeCount.DeleteLabelValues(tID)
+			continue
+		}
+		s.metrics.activeCount.WithLabelValues(tID).Set(float64(len(tenant)))
 	}
 
 	return rs
 }
 
-func (s *rateStore) wasUpdated(tenantID string, streamID uint64, lastUpdated map[string]map[uint64]expiringRate) bool {
+func (s *rateStore) wasUpdated(tenantID string, streamID uint64, lastUpdated perTenantExpiringRate) bool {
 	if _, ok := lastUpdated[tenantID]; !ok {
 		return false
 	}
@@ -238,14 +246,21 @@ func (s *rateStore) anyShardingEnabled() bool {
 	return false
 }
 
-func (s *rateStore) aggregateByShard(ctx context.Context, streamRates map[string]map[uint64]*logproto.StreamRate) map[string]map[uint64]expiringRate {
+type (
+	// perTenantStreamRate maps tenant id -> stream hash -> rate as reported by ingesters.
+	perTenantStreamRate map[string]map[uint64]*logproto.StreamRate
+	// perTenantExpiringRate maps tenant id -> stream hash without shard -> aggregated rate.
+	perTenantExpiringRate map[string]map[uint64]expiringRate
+)
+
+func (s *rateStore) aggregateByShard(ctx context.Context, streamRates perTenantStreamRate) perTenantExpiringRate {
 	if s.debug {
 		sp := trace.SpanFromContext(ctx)
 		sp.AddEvent("started to aggregate by shard")
 		defer sp.AddEvent("finished to aggregate by shard")
 
 	}
-	rates := map[string]map[uint64]expiringRate{}
+	rates := perTenantExpiringRate{}
 	now := time.Now()
 
 	for tID, tenant := range streamRates {
@@ -267,7 +282,7 @@ func (s *rateStore) aggregateByShard(ctx context.Context, streamRates map[string
 	return rates
 }
 
-func (s *rateStore) getRates(ctx context.Context, clients []ingesterClient) map[string]map[uint64]*logproto.StreamRate {
+func (s *rateStore) getRates(ctx context.Context, clients []ingesterClient) perTenantStreamRate {
 	if s.debug {
 		sp := trace.SpanFromContext(ctx)
 		sp.AddEvent("started to get rates from ingesters")
@@ -313,9 +328,9 @@ func (s *rateStore) getRatesFromIngesters(ctx context.Context, clients chan inge
 	}
 }
 
-func (s *rateStore) ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses int) map[string]map[uint64]*logproto.StreamRate {
+func (s *rateStore) ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses int) perTenantStreamRate {
 	var maxRate int64
-	streamRates := map[string]map[uint64]*logproto.StreamRate{}
+	streamRates := perTenantStreamRate{}
 	for i := 0; i < totalResponses; i++ {
 		resp := <-responses
 		if resp == nil {

--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -12,6 +12,7 @@ type ratestoreMetrics struct {
 	rateRefreshFailures *prometheus.CounterVec
 	streamCount         prometheus.Gauge
 	expiredCount        prometheus.Counter
+	activeCount         *prometheus.GaugeVec
 	maxStreamShardCount prometheus.Gauge
 	streamShardCount    prometheus.Histogram
 	maxStreamRate       prometheus.Gauge
@@ -37,6 +38,11 @@ func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
 			Name:      "rate_store_expired_streams_total",
 			Help:      "The number of streams that have been expired by the ratestore",
 		}),
+		activeCount: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: constants.Loki,
+			Name:      "rate_store_active_streams",
+			Help:      "The number of non-expired streams per tenant known to the rate store. Sharded streams are combined",
+		}, []string{"tenant"}),
 		maxStreamShardCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
 			Name:      "rate_store_max_stream_shards",

--- a/pkg/distributor/ratestore_test.go
+++ b/pkg/distributor/ratestore_test.go
@@ -4,22 +4,21 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
-	"github.com/grafana/loki/v3/pkg/validation"
-
-	"github.com/stretchr/testify/require"
-
-	client2 "github.com/grafana/loki/v3/pkg/ingester/client"
-
-	"google.golang.org/grpc"
-
-	"github.com/grafana/loki/v3/pkg/logproto"
-
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/ring/client"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
+	client2 "github.com/grafana/loki/v3/pkg/ingester/client"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/validation"
 )
 
 func TestRateStore(t *testing.T) {
@@ -251,6 +250,41 @@ func TestRateStore(t *testing.T) {
 		_, afterNewPushRate := tc.rateStore.RateFor("tenant 1", 0)
 		require.EqualValues(t, weightedMovingAverageF(0, 1), afterNewPushRate)
 	})
+
+	t.Run("it reports the number of active streams per tenant", func(t *testing.T) {
+		tc := setup(true)
+		tc.ring.replicationSet = ring.ReplicationSet{
+			Instances: []ring.InstanceDesc{
+				{Addr: "ingester0"},
+			},
+		}
+
+		tc.clientPool.clients = map[string]client.PoolClient{
+			"ingester0": newRateClient([]*logproto.StreamRate{
+				// Two shards of the same stream count as one stream.
+				{Tenant: "tenant 1", StreamHash: 1, StreamHashNoShard: 0, Rate: 25},
+				{Tenant: "tenant 1", StreamHash: 2, StreamHashNoShard: 0, Rate: 25},
+				{Tenant: "tenant 1", StreamHash: 3, StreamHashNoShard: 1, Rate: 25},
+				{Tenant: "tenant 2", StreamHash: 4, StreamHashNoShard: 2, Rate: 25},
+			}, 1),
+		}
+
+		require.NoError(t, tc.rateStore.instrumentedUpdateAllRates(context.Background()))
+		require.NoError(t, testutil.GatherAndCompare(tc.reg, strings.NewReader(`
+			# HELP loki_rate_store_active_streams The number of non-expired streams per tenant known to the rate store. Sharded streams are combined
+			# TYPE loki_rate_store_active_streams gauge
+			loki_rate_store_active_streams{tenant="tenant 1"} 2
+			loki_rate_store_active_streams{tenant="tenant 2"} 1
+		`), "loki_rate_store_active_streams"))
+
+		// Once every stream of a tenant expired, the tenant series is removed.
+		tc.rateStore.rateKeepAlive = 1 * time.Millisecond
+		tc.ring.replicationSet = ring.ReplicationSet{}
+		time.Sleep(10 * time.Millisecond)
+
+		require.NoError(t, tc.rateStore.instrumentedUpdateAllRates(context.Background()))
+		require.NoError(t, testutil.GatherAndCompare(tc.reg, strings.NewReader(``), "loki_rate_store_active_streams"))
+	})
 }
 
 var benchErr error
@@ -384,6 +418,7 @@ type testContext struct {
 	ring       *fakeRing
 	clientPool *fakeClientPool
 	rateStore  *rateStore
+	reg        *prometheus.Registry
 }
 
 func setup(shardingEnabled bool) *testContext {
@@ -394,10 +429,12 @@ func setupWithOverrides(overrides *fakeOverrides) *testContext {
 	ring := newFakeRing()
 	cp := newFakeClientPool()
 	cfg := RateStoreConfig{MaxParallelism: 5, IngesterReqTimeout: time.Second, StreamRateUpdateInterval: 10 * time.Millisecond}
+	reg := prometheus.NewPedanticRegistry()
 
 	return &testContext{
 		ring:       ring,
 		clientPool: cp,
-		rateStore:  NewRateStore(cfg, ring, cp, overrides, nil),
+		rateStore:  NewRateStore(cfg, ring, cp, overrides, reg),
+		reg:        reg,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The rateStore only exposed a global stream count, which made it impossible to attribute stream counts to a tenant when investigating stream sharding behaviour.

Expose `loki_rate_store_active_streams`, the number of non-expired streams per tenant after shards are combined. It is computed in `cleanupExpired`, which already walks every tenant and decides what is expired, so the gauge is consistent with the existing global stream and expiry counters by construction. The tenant series is removed when the last stream of a tenant expires, so tenants that stop writing do not leave stale series behind.