### PR TITLE
perf: Parallelise integration tests

### DIFF
--- a/integration/bloom_building_test.go
+++ b/integration/bloom_building_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestBloomBuilding(t *testing.T) {
+	t.Parallel()
 	const (
 		nSeries        = 10 //1000
 		nLogsPerSeries = 50

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -126,7 +126,7 @@ ruler:
   wal:
     dir: {{.sharedDataPath}}/ruler-wal
   # local rule storage is set by common.storage.filesystem.rules_directory
-  # however, even if this is set, ruler_storage has precedence over ruler.storage 
+  # however, even if this is set, ruler_storage has precedence over ruler.storage
   # when storage.use_thanos_objstore is true, so keep it for testing purpose
   storage:
     type: local
@@ -135,10 +135,12 @@ ruler:
   rule_path: {{.sharedDataPath}}/prom-rule
 `))
 
-func resetMetricRegistry() {
-	registry := &wrappedRegisterer{Registry: prometheus.NewRegistry()}
-	prometheus.DefaultRegisterer = registry
-	prometheus.DefaultGatherer = registry
+func init() {
+	if reg, ok := prometheus.DefaultRegisterer.(*prometheus.Registry); ok {
+		wrapped := &wrappedRegisterer{Registry: reg}
+		prometheus.DefaultRegisterer = wrapped
+		prometheus.DefaultGatherer = wrapped
+	}
 }
 
 type wrappedRegisterer struct {
@@ -179,7 +181,6 @@ func New(logLevel level.Value, opts ...func(*Cluster)) *Cluster {
 		util_log.Logger = level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.Allow(logLevel))
 	}
 
-	resetMetricRegistry()
 	sharedPath, err := os.MkdirTemp("", "loki-shared-data-")
 	if err != nil {
 		panic(err.Error())

--- a/integration/explore_logs_test.go
+++ b/integration/explore_logs_test.go
@@ -29,6 +29,7 @@ type DetectedFieldResponse struct {
 }
 
 func Test_ExploreLogsApis(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDBAndTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})

--- a/integration/labelaccess_test.go
+++ b/integration/labelaccess_test.go
@@ -216,6 +216,7 @@ func clusterAllLBACAggregation(t *testing.T) *cluster.Component {
 // TestLabelAccessDefault starts a Loki cluster and verifies
 // the query results are as expected as per the testCase configuration
 func TestLabelAccessTestCases(t *testing.T) {
+	t.Parallel()
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if testCase.createCluster == nil {
@@ -238,6 +239,7 @@ func TestLabelAccessTestCases(t *testing.T) {
 }
 
 func TestAggregatedMetricsTestCases(t *testing.T) {
+	t.Parallel()
 	var aggregatedMetricsTestCases = []*testQueryAndLabelResults{
 		{
 			name:          "aggregated metrics",

--- a/integration/loki_flush_tenant_test.go
+++ b/integration/loki_flush_tenant_test.go
@@ -37,6 +37,7 @@ import (
 // through a ~1m per-table cache, only becomes queryable after an explicit
 // PUT /sync-indexes, which refreshes that cache and downloads the new index.
 func TestFlushTenant(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -28,6 +28,7 @@ type pushRequest struct {
 }
 
 func TestMicroServicesDeleteRequest(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDBAndTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestMicroServicesIngestQuery(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDBAndTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})
@@ -208,6 +209,7 @@ func TestMicroServicesIngestQuery(t *testing.T) {
 }
 
 func TestMicroServicesIngestQueryWithSchemaChange(t *testing.T) {
+	t.Parallel()
 	// init the cluster with a single tsdb period. Uses prefix index_tsdb_
 	clu := cluster.New(nil, cluster.SchemaWithTSDB)
 
@@ -402,6 +404,7 @@ func TestMicroServicesIngestQueryWithSchemaChange(t *testing.T) {
 }
 
 func TestMicroServicesIngestQueryOverMultipleBucketSingleProvider(t *testing.T) {
+	t.Parallel()
 	for name, opt := range map[string]func(c *cluster.Cluster){
 		"multiple-tsdb": cluster.SchemaWithTSDBAndTSDB,
 	} {
@@ -528,6 +531,7 @@ func TestMicroServicesIngestQueryOverMultipleBucketSingleProvider(t *testing.T) 
 }
 
 func TestSchedulerRing(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})
@@ -648,6 +652,7 @@ func TestSchedulerRing(t *testing.T) {
 }
 
 func TestOTLPLogsIngestQuery(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})
@@ -775,6 +780,7 @@ func TestOTLPLogsIngestQuery(t *testing.T) {
 }
 
 func TestProbabilisticQuery(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDBAndTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})
@@ -884,6 +890,7 @@ func TestProbabilisticQuery(t *testing.T) {
 }
 
 func TestApproxCountDistinctQuery(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDBAndTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})
@@ -990,6 +997,7 @@ func TestApproxCountDistinctQuery(t *testing.T) {
 }
 
 func TestCategorizedLabels(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})

--- a/integration/loki_query_deduplication_test.go
+++ b/integration/loki_query_deduplication_test.go
@@ -23,6 +23,7 @@ import (
 // data is served from the ingester (in-memory) or from the chunk store (after a
 // flush + TSDB index build + querier discovery).
 func TestDedupMicroServicesKafka(t *testing.T) {
+	t.Parallel()
 	// Fake Kafka broker with a single partition, so all records are consumed in a
 	// single total order (the sentinel barrier below relies on this).
 	kafkaCluster, _ := testkafka.CreateCluster(t, 1, "loki")

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -25,6 +25,7 @@ import (
 // mode=EvalModeRemote tests that rules are evaluated remotely against a configured query-frontend
 // and that the results are written to the backend correctly.
 func TestRuleEval(t *testing.T) {
+	t.Parallel()
 	for _, mode := range []string{ruler.EvalModeLocal, ruler.EvalModeRemote} {
 		for _, useThanosObjstore := range []bool{false, true} {
 			name := fmt.Sprintf("mode=%v/use_thanos_objstore=%v", mode, useThanosObjstore)

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestSingleBinaryIngestQuery(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestMultiTenantQuery(t *testing.T) {
+	t.Parallel()
 	t.Skip("This test is flaky on CI but it's hardly reproducible locally.")
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")

--- a/integration/parse_metrics_test.go
+++ b/integration/parse_metrics_test.go
@@ -27,6 +27,7 @@ loki_compactor_pending_delete_requests_count 0
 `
 
 func TestExtractCounterMetric(t *testing.T) {
+	t.Parallel()
 	val, labels, err := extractMetric("loki_compactor_oldest_pending_delete_request_age_seconds", exampleMetricOutput)
 	require.NoError(t, err)
 	require.NotNil(t, labels)

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestPerRequestLimits(t *testing.T) {
+	t.Parallel()
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})

--- a/integration/shared_test.go
+++ b/integration/shared_test.go
@@ -4,15 +4,21 @@ package integration
 
 import (
 	"math/rand"
+	"sync"
 	"time"
 )
 
-var randomGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
+var (
+	randomGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomMu        sync.Mutex
+)
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func randStringRunes() string {
 	b := make([]rune, 12)
+	randomMu.Lock()
+	defer randomMu.Unlock()
 	for i := range b {
 		b[i] = letterRunes[randomGenerator.Intn(len(letterRunes))]
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Experiment to parallelise the integration tests without introducing any flakes. 
Integration package has the longest running tests in CI, so this is intended to reduce the total CI time, or at least shift the bottleneck.