### PR TITLE
chore(ingester): Add metric for in-memory sharded streams

### DIFF
--- a/docs/sources/operations/meta-monitoring/metrics.md
+++ b/docs/sources/operations/meta-monitoring/metrics.md
@@ -132,6 +132,7 @@ Ingester pressure often appears as memory growth, poor chunk utilization, or flu
 Key metrics:
 
 - `loki_ingester_memory_streams`
+- `loki_ingester_memory_sharded_streams`
 - `loki_ingester_memory_chunks`
 - `loki_ingester_flush_queue_length`
 - `loki_ingester_chunk_utilization`
@@ -140,6 +141,14 @@ Key metrics:
 Example queries:
 
 ```promql
+sum(loki_ingester_memory_streams{cluster="$cluster", namespace="$namespace"})
+```
+
+The share of in-memory streams that were created by stream sharding in the distributors:
+
+```promql
+sum(loki_ingester_memory_sharded_streams{cluster="$cluster", namespace="$namespace"})
+/
 sum(loki_ingester_memory_streams{cluster="$cluster", namespace="$namespace"})
 ```
 

--- a/docs/sources/operations/meta-monitoring/metrics.md
+++ b/docs/sources/operations/meta-monitoring/metrics.md
@@ -132,7 +132,7 @@ Ingester pressure often appears as memory growth, poor chunk utilization, or flu
 Key metrics:
 
 - `loki_ingester_memory_streams`
-- `loki_ingester_memory_sharded_streams`
+- `loki_ingester_memory_stream_shards`
 - `loki_ingester_memory_chunks`
 - `loki_ingester_flush_queue_length`
 - `loki_ingester_chunk_utilization`
@@ -147,7 +147,7 @@ sum(loki_ingester_memory_streams{cluster="$cluster", namespace="$namespace"})
 The share of in-memory streams that were created by stream sharding in the distributors:
 
 ```promql
-sum(loki_ingester_memory_sharded_streams{cluster="$cluster", namespace="$namespace"})
+sum(loki_ingester_memory_stream_shards{cluster="$cluster", namespace="$namespace"})
 /
 sum(loki_ingester_memory_streams{cluster="$cluster", namespace="$namespace"})
 ```

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -3,6 +3,7 @@ package ingester
 import (
 	"context"
 	"errors"
+	"expvar"
 	"fmt"
 	"math"
 	"net/http"
@@ -62,35 +63,47 @@ const (
 	queryBatchSampleSize = 512
 )
 
-var (
-	memoryStreams = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: constants.Loki,
-		Name:      "ingester_memory_streams",
-		Help:      "The total number of streams in memory per tenant.",
-	}, []string{"tenant"})
-	memoryStreamShards = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: constants.Loki,
-		Name:      "ingester_memory_stream_shards",
-		Help:      "The total number of stream shards in memory per tenant, meaning streams that carry the " + ShardLbName + " label. This is a subset of " + constants.Loki + "_ingester_memory_streams.",
-	}, []string{"tenant"})
-	memoryStreamsLabelsBytes = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: constants.Loki,
-		Name:      "ingester_memory_streams_labels_bytes",
-		Help:      "Total bytes of labels of the streams in memory.",
-	})
-	streamsCreatedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: constants.Loki,
-		Name:      "ingester_streams_created_total",
-		Help:      "The total number of streams created per tenant.",
-	}, []string{"tenant"})
-	streamsRemovedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: constants.Loki,
-		Name:      "ingester_streams_removed_total",
-		Help:      "The total number of streams removed per tenant.",
-	}, []string{"tenant"})
+type instanceMetrics struct {
+	memoryStreams            *prometheus.GaugeVec
+	memoryStreamShards       *prometheus.GaugeVec
+	memoryStreamsLabelsBytes prometheus.Gauge
+	streamsCreatedTotal      *prometheus.CounterVec
+	streamsRemovedTotal      *prometheus.CounterVec
+	streamsCountStats        *expvar.Int
+}
 
-	streamsCountStats = analytics.NewInt("ingester_streams_count")
-)
+func newInstanceMetrics(reg prometheus.Registerer) *instanceMetrics {
+	return &instanceMetrics{
+		memoryStreams: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_memory_streams",
+			Help:      "The total number of streams in memory per tenant.",
+		}, []string{"tenant"}),
+		memoryStreamShards: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_memory_stream_shards",
+			Help:      "The total number of stream shards in memory per tenant, meaning streams that carry the __stream_shard__ label. This is a subset of loki_ingester_memory_streams.",
+		}, []string{"tenant"}),
+		memoryStreamsLabelsBytes: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_memory_streams_labels_bytes",
+			Help:      "Total bytes of labels of the streams in memory.",
+		}),
+		streamsCreatedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_streams_created_total",
+			Help:      "The total number of streams created per tenant.",
+		}, []string{"tenant"}),
+		streamsRemovedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_streams_removed_total",
+			Help:      "The total number of streams removed per tenant.",
+		}, []string{"tenant"}),
+
+		// analytics.NewInt() call is idempotent so it's safe to call it multiple times
+		streamsCountStats: analytics.NewInt("ingester_streams_count"),
+	}
+}
 
 type instance struct {
 	cfg *Config
@@ -103,8 +116,13 @@ type instance struct {
 
 	instanceID string
 
+	// global ingester metrics
+	metrics *ingesterMetrics
+	// per-tenant ingester metrics that are initialized at construction time
 	streamsCreatedTotal prometheus.Counter
 	streamsRemovedTotal prometheus.Counter
+	memoryStreams       prometheus.Gauge
+	memoryStreamShards  prometheus.Gauge
 
 	tailers   map[uint32]*tailer
 	tailerMtx sync.RWMutex
@@ -120,8 +138,6 @@ type instance struct {
 	// Denotes whether the ingester should flush on shutdown.
 	// Currently only used by the WAL to signal when the disk is full.
 	flushOnShutdownSwitch *OnceSwitch
-
-	metrics *ingesterMetrics
 
 	chunkFilter          chunk.RequestChunkFilterer
 	pipelineWrapper      log.PipelineWrapper
@@ -168,8 +184,11 @@ func newInstance(
 		index:      invertedIndex,
 		instanceID: instanceID,
 
-		streamsCreatedTotal: streamsCreatedTotal.WithLabelValues(instanceID),
-		streamsRemovedTotal: streamsRemovedTotal.WithLabelValues(instanceID),
+		metrics:             metrics,
+		streamsCreatedTotal: metrics.instance.streamsCreatedTotal.WithLabelValues(instanceID),
+		streamsRemovedTotal: metrics.instance.streamsRemovedTotal.WithLabelValues(instanceID),
+		memoryStreams:       metrics.instance.memoryStreams.WithLabelValues(instanceID),
+		memoryStreamShards:  metrics.instance.memoryStreamShards.WithLabelValues(instanceID),
 
 		tailers:            map[uint32]*tailer{},
 		limiter:            limiter,
@@ -178,7 +197,6 @@ func newInstance(
 		configs:            configs,
 
 		wal:                   wal,
-		metrics:               metrics,
 		flushOnShutdownSwitch: flushOnShutdownSwitch,
 
 		chunkFilter:      chunkFilter,
@@ -360,14 +378,14 @@ func (i *instance) onStreamCreationError(ctx context.Context, pushReqStream logp
 }
 
 func (i *instance) onStreamCreated(s *stream) {
-	memoryStreams.WithLabelValues(i.instanceID).Inc()
+	i.memoryStreams.Inc()
 	if s.labels.Has(ShardLbName) {
-		memoryStreamShards.WithLabelValues(i.instanceID).Inc()
+		i.memoryStreamShards.Inc()
 	}
-	memoryStreamsLabelsBytes.Add(float64(len(s.labels.String())))
+	i.metrics.instance.memoryStreamsLabelsBytes.Add(float64(len(s.labels.String())))
 	i.streamsCreatedTotal.Inc()
 	i.addTailersToNewStream(s)
-	streamsCountStats.Add(1)
+	i.metrics.instance.streamsCountStats.Add(1)
 	// we count newly created stream as owned
 	i.ownedStreamsSvc.trackStreamOwnership(s.fp, true, s.policy)
 	if i.configs.LogStreamCreation(i.instanceID) {
@@ -434,12 +452,12 @@ func (i *instance) removeStream(s *stream) {
 	if i.streams.Delete(s) {
 		i.index.Delete(s.labels, s.fp)
 		i.streamsRemovedTotal.Inc()
-		memoryStreams.WithLabelValues(i.instanceID).Dec()
+		i.memoryStreams.Dec()
 		if s.labels.Has(ShardLbName) {
-			memoryStreamShards.WithLabelValues(i.instanceID).Dec()
+			i.memoryStreamShards.Dec()
 		}
-		memoryStreamsLabelsBytes.Sub(float64(len(s.labels.String())))
-		streamsCountStats.Add(-1)
+		i.metrics.instance.memoryStreamsLabelsBytes.Sub(float64(len(s.labels.String())))
+		i.metrics.instance.streamsCountStats.Add(-1)
 		i.ownedStreamsSvc.trackRemovedStream(s.fp, s.policy)
 	}
 }

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -68,6 +68,11 @@ var (
 		Name:      "ingester_memory_streams",
 		Help:      "The total number of streams in memory per tenant.",
 	}, []string{"tenant"})
+	memoryShardedStreams = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: constants.Loki,
+		Name:      "ingester_memory_sharded_streams",
+		Help:      "The total number of streams in memory per tenant that are shards of a stream, meaning they carry the " + ShardLbName + " label. This is a subset of " + constants.Loki + "_ingester_memory_streams.",
+	}, []string{"tenant"})
 	memoryStreamsLabelsBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: constants.Loki,
 		Name:      "ingester_memory_streams_labels_bytes",
@@ -356,6 +361,9 @@ func (i *instance) onStreamCreationError(ctx context.Context, pushReqStream logp
 
 func (i *instance) onStreamCreated(s *stream) {
 	memoryStreams.WithLabelValues(i.instanceID).Inc()
+	if s.labels.Has(ShardLbName) {
+		memoryShardedStreams.WithLabelValues(i.instanceID).Inc()
+	}
 	memoryStreamsLabelsBytes.Add(float64(len(s.labels.String())))
 	i.streamsCreatedTotal.Inc()
 	i.addTailersToNewStream(s)
@@ -427,6 +435,9 @@ func (i *instance) removeStream(s *stream) {
 		i.index.Delete(s.labels, s.fp)
 		i.streamsRemovedTotal.Inc()
 		memoryStreams.WithLabelValues(i.instanceID).Dec()
+		if s.labels.Has(ShardLbName) {
+			memoryShardedStreams.WithLabelValues(i.instanceID).Dec()
+		}
 		memoryStreamsLabelsBytes.Sub(float64(len(s.labels.String())))
 		streamsCountStats.Add(-1)
 		i.ownedStreamsSvc.trackRemovedStream(s.fp, s.policy)

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -68,10 +68,10 @@ var (
 		Name:      "ingester_memory_streams",
 		Help:      "The total number of streams in memory per tenant.",
 	}, []string{"tenant"})
-	memoryShardedStreams = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	memoryStreamShards = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: constants.Loki,
-		Name:      "ingester_memory_sharded_streams",
-		Help:      "The total number of streams in memory per tenant that are shards of a stream, meaning they carry the " + ShardLbName + " label. This is a subset of " + constants.Loki + "_ingester_memory_streams.",
+		Name:      "ingester_memory_stream_shards",
+		Help:      "The total number of stream shards in memory per tenant, meaning streams that carry the " + ShardLbName + " label. This is a subset of " + constants.Loki + "_ingester_memory_streams.",
 	}, []string{"tenant"})
 	memoryStreamsLabelsBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: constants.Loki,
@@ -362,7 +362,7 @@ func (i *instance) onStreamCreationError(ctx context.Context, pushReqStream logp
 func (i *instance) onStreamCreated(s *stream) {
 	memoryStreams.WithLabelValues(i.instanceID).Inc()
 	if s.labels.Has(ShardLbName) {
-		memoryShardedStreams.WithLabelValues(i.instanceID).Inc()
+		memoryStreamShards.WithLabelValues(i.instanceID).Inc()
 	}
 	memoryStreamsLabelsBytes.Add(float64(len(s.labels.String())))
 	i.streamsCreatedTotal.Inc()
@@ -436,7 +436,7 @@ func (i *instance) removeStream(s *stream) {
 		i.streamsRemovedTotal.Inc()
 		memoryStreams.WithLabelValues(i.instanceID).Dec()
 		if s.labels.Has(ShardLbName) {
-			memoryShardedStreams.WithLabelValues(i.instanceID).Dec()
+			memoryStreamShards.WithLabelValues(i.instanceID).Dec()
 		}
 		memoryStreamsLabelsBytes.Sub(float64(len(s.labels.String())))
 		streamsCountStats.Add(-1)

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -1585,6 +1586,42 @@ func TestInstance_LabelsWithValues(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, map[string]UniqueValues{}, res)
 	})
+}
+
+func TestMemoryShardedStreamsMetric(t *testing.T) {
+	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	require.NoError(t, err)
+	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(&ringCountMock{count: 1}, 1), &TenantBasedStrategy{limits: limits})
+	tenantsRetention := retention.NewTenantsRetention(limits)
+
+	tenantID := "memory-sharded-streams"
+	inst, err := newInstance(defaultConfig(), defaultPeriodConfigs, tenantID, limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil, nil, nil, NewStreamRateCalculator(), nil, nil, tenantsRetention)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		memoryStreams.DeleteLabelValues(tenantID)
+		memoryShardedStreams.DeleteLabelValues(tenantID)
+	})
+
+	now := time.Now().Add(-5 * time.Minute)
+	require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{
+		{Labels: `{app="foo"}`, Entries: entries(1, now)},
+		{Labels: `{__stream_shard__="0", app="bar"}`, Entries: entries(1, now)},
+		{Labels: `{__stream_shard__="1", app="bar"}`, Entries: entries(1, now)},
+	}}))
+
+	require.Equal(t, 3.0, promtestutil.ToFloat64(memoryStreams.WithLabelValues(tenantID)))
+	require.Equal(t, 2.0, promtestutil.ToFloat64(memoryShardedStreams.WithLabelValues(tenantID)))
+
+	require.NoError(t, inst.streams.ForEach(func(s *stream) (bool, error) {
+		if s.labels.Has(ShardLbName) {
+			inst.removeStream(s)
+		}
+		return true, nil
+	}))
+
+	require.Equal(t, 1.0, promtestutil.ToFloat64(memoryStreams.WithLabelValues(tenantID)))
+	require.Equal(t, 0.0, promtestutil.ToFloat64(memoryShardedStreams.WithLabelValues(tenantID)))
 }
 
 type fakeQueryServer func(*logproto.QueryResponse) error

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -1591,17 +1592,19 @@ func TestInstance_LabelsWithValues(t *testing.T) {
 func TestMemoryStreamShardsMetric(t *testing.T) {
 	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
+
+	reg := prometheus.NewPedanticRegistry()
+	metrics := newIngesterMetrics(reg, constants.Loki)
+
 	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(&ringCountMock{count: 1}, 1), &TenantBasedStrategy{limits: limits})
 	tenantsRetention := retention.NewTenantsRetention(limits)
 
-	tenantID := "memory-sharded-streams"
-	inst, err := newInstance(defaultConfig(), defaultPeriodConfigs, tenantID, limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil, nil, nil, NewStreamRateCalculator(), nil, nil, tenantsRetention)
+	tenantID := "loki"
+	inst, err := newInstance(defaultConfig(), defaultPeriodConfigs, tenantID, limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, metrics, &OnceSwitch{}, nil, nil, nil, NewStreamRateCalculator(), nil, nil, tenantsRetention)
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		memoryStreams.DeleteLabelValues(tenantID)
-		memoryStreamShards.DeleteLabelValues(tenantID)
-	})
+	require.Equal(t, 0.0, promtestutil.ToFloat64(inst.memoryStreams), "metric needs to be instatiated with zero value")
+	require.Equal(t, 0.0, promtestutil.ToFloat64(inst.memoryStreamShards), "metric needs to be instantiated with zero value")
 
 	now := time.Now().Add(-5 * time.Minute)
 	require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{
@@ -1610,8 +1613,11 @@ func TestMemoryStreamShardsMetric(t *testing.T) {
 		{Labels: `{__stream_shard__="1", app="bar"}`, Entries: entries(1, now)},
 	}}))
 
-	require.Equal(t, 3.0, promtestutil.ToFloat64(memoryStreams.WithLabelValues(tenantID)))
-	require.Equal(t, 2.0, promtestutil.ToFloat64(memoryStreamShards.WithLabelValues(tenantID)))
+	require.Equal(t, 3.0, promtestutil.ToFloat64(metrics.instance.memoryStreams.WithLabelValues(tenantID)))
+	require.Equal(t, 2.0, promtestutil.ToFloat64(metrics.instance.memoryStreamShards.WithLabelValues(tenantID)))
+
+	require.Equal(t, 3.0, promtestutil.ToFloat64(inst.memoryStreams))
+	require.Equal(t, 2.0, promtestutil.ToFloat64(inst.memoryStreamShards))
 
 	require.NoError(t, inst.streams.ForEach(func(s *stream) (bool, error) {
 		if s.labels.Has(ShardLbName) {
@@ -1620,8 +1626,11 @@ func TestMemoryStreamShardsMetric(t *testing.T) {
 		return true, nil
 	}))
 
-	require.Equal(t, 1.0, promtestutil.ToFloat64(memoryStreams.WithLabelValues(tenantID)))
-	require.Equal(t, 0.0, promtestutil.ToFloat64(memoryStreamShards.WithLabelValues(tenantID)))
+	require.Equal(t, 1.0, promtestutil.ToFloat64(metrics.instance.memoryStreams.WithLabelValues(tenantID)))
+	require.Equal(t, 0.0, promtestutil.ToFloat64(metrics.instance.memoryStreamShards.WithLabelValues(tenantID)))
+
+	require.Equal(t, 1.0, promtestutil.ToFloat64(inst.memoryStreams))
+	require.Equal(t, 0.0, promtestutil.ToFloat64(inst.memoryStreamShards))
 }
 
 type fakeQueryServer func(*logproto.QueryResponse) error

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -1588,7 +1588,7 @@ func TestInstance_LabelsWithValues(t *testing.T) {
 	})
 }
 
-func TestMemoryShardedStreamsMetric(t *testing.T) {
+func TestMemoryStreamShardsMetric(t *testing.T) {
 	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(&ringCountMock{count: 1}, 1), &TenantBasedStrategy{limits: limits})
@@ -1600,7 +1600,7 @@ func TestMemoryShardedStreamsMetric(t *testing.T) {
 
 	t.Cleanup(func() {
 		memoryStreams.DeleteLabelValues(tenantID)
-		memoryShardedStreams.DeleteLabelValues(tenantID)
+		memoryStreamShards.DeleteLabelValues(tenantID)
 	})
 
 	now := time.Now().Add(-5 * time.Minute)
@@ -1611,7 +1611,7 @@ func TestMemoryShardedStreamsMetric(t *testing.T) {
 	}}))
 
 	require.Equal(t, 3.0, promtestutil.ToFloat64(memoryStreams.WithLabelValues(tenantID)))
-	require.Equal(t, 2.0, promtestutil.ToFloat64(memoryShardedStreams.WithLabelValues(tenantID)))
+	require.Equal(t, 2.0, promtestutil.ToFloat64(memoryStreamShards.WithLabelValues(tenantID)))
 
 	require.NoError(t, inst.streams.ForEach(func(s *stream) (bool, error) {
 		if s.labels.Has(ShardLbName) {
@@ -1621,7 +1621,7 @@ func TestMemoryShardedStreamsMetric(t *testing.T) {
 	}))
 
 	require.Equal(t, 1.0, promtestutil.ToFloat64(memoryStreams.WithLabelValues(tenantID)))
-	require.Equal(t, 0.0, promtestutil.ToFloat64(memoryShardedStreams.WithLabelValues(tenantID)))
+	require.Equal(t, 0.0, promtestutil.ToFloat64(memoryStreamShards.WithLabelValues(tenantID)))
 }
 
 type fakeQueryServer func(*logproto.QueryResponse) error

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -72,6 +72,8 @@ type ingesterMetrics struct {
 	flushQueueLength       prometheus.Gauge
 	duplicateLogBytesTotal *prometheus.CounterVec
 	streamsOwnershipCheck  prometheus.Histogram
+
+	instance *instanceMetrics
 }
 
 // setRecoveryBytesInUse bounds the bytes reports to >= 0.
@@ -339,5 +341,7 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 			Name:      "duplicate_log_bytes_total",
 			Help:      "The total number of bytes that were discarded for duplicate log lines.",
 		}, []string{"tenant"}),
+
+		instance: newInstanceMetrics(r),
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`loki_ingester_memory_streams` counts all in-memory streams, including the ones the distributors created by stream sharding. That makes it impossible to tell how much of the stream count comes from sharding.

`loki_ingester_memory_stream_shards` counts only streams carrying the `__stream_shard__` label, so the ratio between sharded and unsharded streams can be tracked per tenant.

**Special notes for your reviewer**:

This is a follow up on https://github.com/grafana/loki/pull/24451 to observe correctness during migration from rateStore to limits service for stream sharding.

This PR moves the package-global ingester instance metrics into a dedicated struct, which is created when the ingester metrics are constructed. Refer to the 3rd commit of this PR to understand the changes better.