### PR TITLE
feat: Move logline query-frontend and limits to Loki

### DIFF
--- a/pkg/logline/limits/AGENTS.md
+++ b/pkg/logline/limits/AGENTS.md
@@ -1,0 +1,28 @@
+# pkg/limits/
+
+Per-tenant settings interface, construction, and runtime reloading for logline components.
+
+## Invariants
+
+- The Limits interface contains only the methods each component actually needs.
+  Do not add methods here unless a logline component requires them.
+- RetentionPeriod() == 0 → retention is disabled (keep forever)
+- The Limits returned by NewOverrides computes the **maximum** across all
+  configured tenants. Logline indexes are shared across tenants, so the most
+  permissive (longest) value must apply. A zero from any tenant means "no override,
+  use default" and is skipped by computeMax().
+- Value resolution priority (highest to lowest):
+  1. Per-tenant runtime overrides (max across all tenants)
+  2. Loki config `limits_config` defaults (retention_period)
+- `NewOverrides` consumes whatever defaults are already present in
+  `loki.ConfigWrapper`. It does not apply ad-hoc per-field backfills; defaults
+  are expected to be initialized by config loading (`flagext.DefaultValues` in
+  `cmd/logline`).
+- NewOverrides accepts a loki.ConfigWrapper. It handles:
+  1. SetDefaultLimitsForYAMLUnmarshalling (so per-tenant YAML inherits global defaults)
+  2. runtimeconfig.Manager creation for periodic file polling
+  3. *validation.Overrides construction (with or without TenantLimits)
+- The returned services.Service (runtime config manager) may be nil when no override
+  file is configured. When non-nil the caller must add it to the service manager.
+- The returned *validation.Overrides is the raw Loki type for components that need
+  per-tenant behavior (e.g., queryfrontend tripperware).

--- a/pkg/logline/limits/AGENTS.md
+++ b/pkg/logline/limits/AGENTS.md
@@ -1,4 +1,4 @@
-# pkg/limits/
+# pkg/logline/limits/
 
 Per-tenant settings interface, construction, and runtime reloading for logline components.
 
@@ -16,8 +16,8 @@ Per-tenant settings interface, construction, and runtime reloading for logline c
   2. Loki config `limits_config` defaults (retention_period)
 - `NewOverrides` consumes whatever defaults are already present in
   `loki.ConfigWrapper`. It does not apply ad-hoc per-field backfills; defaults
-  are expected to be initialized by config loading (`flagext.DefaultValues` in
-  `cmd/logline`).
+  are expected to have been initialized by the caller's config loading, normally
+  via `flagext.DefaultValues`.
 - NewOverrides accepts a loki.ConfigWrapper. It handles:
   1. SetDefaultLimitsForYAMLUnmarshalling (so per-tenant YAML inherits global defaults)
   2. runtimeconfig.Manager creation for periodic file polling

--- a/pkg/logline/limits/CLAUDE.md
+++ b/pkg/logline/limits/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/logline/limits/limits.go
+++ b/pkg/logline/limits/limits.go
@@ -1,0 +1,12 @@
+package limits
+
+import "time"
+
+// Limits defines global settings needed by logline components. Values are
+// the maximum across all configured tenants because logline indexes are
+// shared (not per-tenant).
+type Limits interface {
+	// RetentionPeriod returns the retention period for indexes.
+	// A zero duration means retention is disabled (keep forever).
+	RetentionPeriod() time.Duration
+}

--- a/pkg/logline/limits/limits_test.go
+++ b/pkg/logline/limits/limits_test.go
@@ -1,0 +1,17 @@
+package limits_test
+
+import (
+	"time"
+
+	"github.com/grafana/loki-logline-index-private/pkg/limits"
+)
+
+// stubLimits is a test helper that satisfies limits.Limits.
+type stubLimits struct {
+	retentionPeriod time.Duration
+}
+
+func (s stubLimits) RetentionPeriod() time.Duration { return s.retentionPeriod }
+
+// Compile-time assertion: stubLimits satisfies limits.Limits.
+var _ limits.Limits = stubLimits{}

--- a/pkg/logline/limits/limits_test.go
+++ b/pkg/logline/limits/limits_test.go
@@ -3,7 +3,7 @@ package limits_test
 import (
 	"time"
 
-	"github.com/grafana/loki-logline-index-private/pkg/limits"
+	"github.com/grafana/loki/v3/pkg/logline/limits"
 )
 
 // stubLimits is a test helper that satisfies limits.Limits.

--- a/pkg/logline/limits/overrides.go
+++ b/pkg/logline/limits/overrides.go
@@ -1,0 +1,185 @@
+package limits
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/runtimeconfig"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/v3/pkg/loki"
+	"github.com/grafana/loki/v3/pkg/validation"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
+	"go.yaml.in/yaml/v4"
+)
+
+// runtimeConfigValues mirrors Loki's runtime config YAML structure.
+// Only the overrides key is relevant to logline.
+type runtimeConfigValues struct {
+	TenantLimits map[string]*validation.Limits `yaml:"overrides"`
+}
+
+func (r runtimeConfigValues) validate(logger log.Logger) error {
+	for t, c := range r.TenantLimits {
+		if c == nil {
+			level.Warn(logger).Log("msg", "skipping empty tenant limit definition", "tenant", t)
+		}
+	}
+	return nil
+}
+
+// tenantLimitsFromRuntimeConfig implements validation.TenantLimits by
+// reading from a live runtimeconfig.Manager. Same pattern as Loki.
+type tenantLimitsFromRuntimeConfig struct {
+	manager *runtimeconfig.Manager
+}
+
+func (t *tenantLimitsFromRuntimeConfig) TenantLimits(userID string) *validation.Limits {
+	all := t.AllByUserID()
+	if all == nil {
+		return nil
+	}
+	return all[userID]
+}
+
+func (t *tenantLimitsFromRuntimeConfig) AllByUserID() map[string]*validation.Limits {
+	if t.manager == nil {
+		return nil
+	}
+	cfg, ok := t.manager.GetConfig().(*runtimeConfigValues)
+	if cfg != nil && ok {
+		return cfg.TenantLimits
+	}
+	return nil
+}
+
+// maxLimits precomputes the maximum of each limit across all tenants.
+// Values are recomputed on every runtime config reload via a listener
+// goroutine and served from atomics, so callers pay no iteration cost.
+type maxLimits struct {
+	inner *validation.Overrides
+
+	retention atomic.Int64 // time.Duration stored as int64
+
+	retentionGauge prometheus.Gauge
+}
+
+func (m *maxLimits) RetentionPeriod() time.Duration {
+	return time.Duration(m.retention.Load())
+}
+
+// recompute iterates all tenant limits and updates the cached max values.
+// The default comes from the Loki config's limits_config; per-tenant
+// overrides can only increase it (or set zero to disable).
+func (m *maxLimits) recompute() {
+	rp := m.computeMax(
+		func(l *validation.Limits) time.Duration { return time.Duration(l.RetentionPeriod) },
+		m.inner.RetentionPeriod(""),
+	)
+	m.retention.Store(int64(rp))
+	m.retentionGauge.Set(rp.Seconds())
+}
+
+// computeMax returns the maximum of defaultVal and the field extracted by fn
+// from every tenant's limits. Per-tenant zero values are skipped (treated as
+// "use the default"). The result is always at least defaultVal.
+func (m *maxLimits) computeMax(fn func(*validation.Limits) time.Duration, defaultVal time.Duration) time.Duration {
+	max := defaultVal
+	for _, l := range m.inner.AllByUserID() {
+		if l == nil {
+			continue
+		}
+		if v := fn(l); v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+// listenForReloads blocks until the channel is closed (manager stopped),
+// recomputing max limits on every runtime config reload.
+func (m *maxLimits) listenForReloads(ch <-chan interface{}) {
+	for range ch {
+		m.recompute()
+	}
+}
+
+// NewOverrides creates a Limits implementation and the underlying
+// *validation.Overrides from the given Loki config. If the Loki config
+// specifies a runtime config file (runtime_config.file), a
+// runtimeconfig.Manager service is returned that polls the file for changes.
+// The caller must start this service. If no file is configured the returned
+// service is nil.
+//
+// The returned Limits precomputes the maximum RetentionPeriod across all
+// tenants because logline indexes are shared across tenants. Values are
+// recomputed on each config reload.
+func NewOverrides(
+	lokiCfg loki.ConfigWrapper,
+	logger log.Logger,
+	reg prometheus.Registerer,
+) (Limits, *validation.Overrides, services.Service, error) {
+	runtimeCfg := lokiCfg.RuntimeConfig
+
+	var (
+		tl      validation.TenantLimits
+		manager *runtimeconfig.Manager
+		svc     services.Service
+	)
+
+	if len(runtimeCfg.LoadPath) > 0 {
+		// Set defaults so that YAML unmarshalling fills in unset fields
+		// with the Loki config values, not Go zero values.
+		validation.SetDefaultLimitsForYAMLUnmarshalling(lokiCfg.LimitsConfig)
+
+		runtimeCfg.Loader = loadRuntimeConfig(logger)
+
+		var err error
+		manager, err = runtimeconfig.New(runtimeCfg, "logline", reg, logger)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("create runtime config manager: %w", err)
+		}
+		svc = manager
+		tl = &tenantLimitsFromRuntimeConfig{manager: manager}
+	}
+
+	ov, err := validation.NewOverrides(lokiCfg.LimitsConfig, tl)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("create validation overrides: %w", err)
+	}
+
+	lim := &maxLimits{
+		inner: ov,
+		retentionGauge: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "logline_limits_retention_period_seconds",
+			Help: "Maximum retention_period across all tenants, in seconds. Zero means unlimited.",
+		}),
+	}
+	lim.recompute()
+
+	if manager != nil {
+		ch := manager.CreateListenerChannel(1)
+		go lim.listenForReloads(ch)
+	}
+
+	return lim, ov, svc, nil
+}
+
+// loadRuntimeConfig returns a Loader that parses the runtime config YAML.
+func loadRuntimeConfig(logger log.Logger) runtimeconfig.Loader {
+	return func(r io.Reader) (interface{}, error) {
+		var cfg runtimeConfigValues
+		decoder := yaml.NewDecoder(r)
+		if err := decoder.Decode(&cfg); err != nil {
+			return nil, err
+		}
+		if err := cfg.validate(logger); err != nil {
+			return nil, err
+		}
+		return &cfg, nil
+	}
+}

--- a/pkg/logline/limits/overrides.go
+++ b/pkg/logline/limits/overrides.go
@@ -9,12 +9,13 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/loki/v3/pkg/loki"
-	"github.com/grafana/loki/v3/pkg/validation"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v4"
+
+	"github.com/grafana/loki/v3/pkg/loki"
+	"github.com/grafana/loki/v3/pkg/validation"
 )
 
 // runtimeConfigValues mirrors Loki's runtime config YAML structure.
@@ -88,21 +89,21 @@ func (m *maxLimits) recompute() {
 // from every tenant's limits. Per-tenant zero values are skipped (treated as
 // "use the default"). The result is always at least defaultVal.
 func (m *maxLimits) computeMax(fn func(*validation.Limits) time.Duration, defaultVal time.Duration) time.Duration {
-	max := defaultVal
+	maxVal := defaultVal
 	for _, l := range m.inner.AllByUserID() {
 		if l == nil {
 			continue
 		}
-		if v := fn(l); v > max {
-			max = v
+		if v := fn(l); v > maxVal {
+			maxVal = v
 		}
 	}
-	return max
+	return maxVal
 }
 
 // listenForReloads blocks until the channel is closed (manager stopped),
 // recomputing max limits on every runtime config reload.
-func (m *maxLimits) listenForReloads(ch <-chan interface{}) {
+func (m *maxLimits) listenForReloads(ch <-chan any) {
 	for range ch {
 		m.recompute()
 	}
@@ -171,7 +172,7 @@ func NewOverrides(
 
 // loadRuntimeConfig returns a Loader that parses the runtime config YAML.
 func loadRuntimeConfig(logger log.Logger) runtimeconfig.Loader {
-	return func(r io.Reader) (interface{}, error) {
+	return func(r io.Reader) (any, error) {
 		var cfg runtimeConfigValues
 		decoder := yaml.NewDecoder(r)
 		if err := decoder.Decode(&cfg); err != nil {

--- a/pkg/logline/limits/overrides_integration_test.go
+++ b/pkg/logline/limits/overrides_integration_test.go
@@ -1,0 +1,124 @@
+package limits_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/runtimeconfig"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/v3/pkg/loki"
+	"github.com/grafana/loki/v3/pkg/validation"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki-logline-index-private/pkg/limits"
+)
+
+// validDefaults returns a validation.Limits with all fields populated to
+// valid defaults (via RegisterFlags) so that per-tenant overrides inherit
+// valid values for fields like DeletionMode that Validate() checks.
+func validDefaults() validation.Limits {
+	var l validation.Limits
+	l.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+	return l
+}
+
+func writeRuntimeConfig(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func TestNewOverrides_RuntimeConfigReload(t *testing.T) {
+	// Write initial runtime config with two tenants.
+	configFile := t.TempDir() + "/runtime.yaml"
+	writeRuntimeConfig(t, configFile, `
+overrides:
+  tenant-a:
+    retention_period: 14d
+  tenant-b:
+    retention_period: 30d
+`)
+
+	// Global defaults: 7d retention.
+	defaults := validDefaults()
+	defaults.RetentionPeriod = model.Duration(7 * 24 * time.Hour)
+
+	lokiCfg := loki.ConfigWrapper{}
+	lokiCfg.LimitsConfig = defaults
+	lokiCfg.RuntimeConfig = runtimeconfig.Config{
+		ReloadPeriod: 100 * time.Millisecond,
+		LoadPath:     []string{configFile},
+	}
+
+	reg := prometheus.NewRegistry()
+	lim, ov, svc, err := limits.NewOverrides(lokiCfg, log.NewNopLogger(), reg)
+	require.NoError(t, err)
+	require.NotNil(t, svc, "runtime config service should be non-nil when file is configured")
+	require.NotNil(t, ov)
+
+	// Before the manager starts, limits reflect only the global defaults
+	// because the runtime config file hasn't been loaded yet.
+	require.Equal(t, 7*24*time.Hour, lim.RetentionPeriod())
+
+	// Start the runtime config manager. starting() loads the file
+	// synchronously and notifies the listener goroutine.
+	ctx := context.Background()
+	require.NoError(t, services.StartAndAwaitRunning(ctx, svc))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, svc))
+	})
+
+	// The listener goroutine recomputes asynchronously after the manager
+	// notifies it. Poll briefly for the updated values.
+	require.Eventually(t, func() bool {
+		return lim.RetentionPeriod() == 30*24*time.Hour
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected max retention=30d (tenant-b) after initial load")
+
+	// --- Reload: change tenant-b to shorter values, add tenant-c with the longest. ---
+	writeRuntimeConfig(t, configFile, `
+overrides:
+  tenant-a:
+    retention_period: 14d
+  tenant-b:
+    retention_period: 20d
+  tenant-c:
+    retention_period: 60d
+`)
+
+	require.Eventually(t, func() bool {
+		return lim.RetentionPeriod() == 60*24*time.Hour
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected max retention=60d (tenant-c) after reload")
+
+	// --- Reload: remove all tenant overrides. Limits should fall back to defaults. ---
+	writeRuntimeConfig(t, configFile, `
+overrides: {}
+`)
+
+	require.Eventually(t, func() bool {
+		return lim.RetentionPeriod() == 7*24*time.Hour
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected defaults (retention=7d) after removing all tenant overrides")
+}
+
+func TestNewOverrides_NoRuntimeConfig(t *testing.T) {
+	defaults := validDefaults()
+	defaults.RetentionPeriod = model.Duration(14 * 24 * time.Hour)
+
+	lokiCfg := loki.ConfigWrapper{}
+	lokiCfg.LimitsConfig = defaults
+	// No RuntimeConfig.LoadPath set — no file polling.
+
+	lim, ov, svc, err := limits.NewOverrides(lokiCfg, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	require.Nil(t, svc, "no service when no runtime config file")
+	require.NotNil(t, ov)
+
+	require.Equal(t, 14*24*time.Hour, lim.RetentionPeriod())
+}

--- a/pkg/logline/limits/overrides_integration_test.go
+++ b/pkg/logline/limits/overrides_integration_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/loki/v3/pkg/loki"
-	"github.com/grafana/loki/v3/pkg/validation"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki-logline-index-private/pkg/limits"
+	"github.com/grafana/loki/v3/pkg/loki"
+	"github.com/grafana/loki/v3/pkg/validation"
+
+	"github.com/grafana/loki/v3/pkg/logline/limits"
 )
 
 // validDefaults returns a validation.Limits with all fields populated to

--- a/pkg/logline/limits/overrides_test.go
+++ b/pkg/logline/limits/overrides_test.go
@@ -1,0 +1,128 @@
+package limits
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/loki/v3/pkg/validation"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTenantLimits implements validation.TenantLimits for tests.
+type fakeTenantLimits struct {
+	tenants map[string]*validation.Limits
+}
+
+func (f *fakeTenantLimits) TenantLimits(userID string) *validation.Limits {
+	return f.tenants[userID]
+}
+
+func (f *fakeTenantLimits) AllByUserID() map[string]*validation.Limits {
+	return f.tenants
+}
+
+func newTestMaxLimits(defaults validation.Limits, tenants map[string]*validation.Limits) *maxLimits {
+	tl := &fakeTenantLimits{tenants: tenants}
+	ov, err := validation.NewOverrides(defaults, tl)
+	if err != nil {
+		panic(err)
+	}
+	m := &maxLimits{
+		inner:          ov,
+		retentionGauge: prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_retention"}),
+	}
+	m.recompute()
+	return m
+}
+
+func TestLoadRuntimeConfig_LenientLimitOverrides(t *testing.T) {
+	validation.SetDefaultLimitsForYAMLUnmarshalling(validation.Limits{})
+
+	actual, err := loadRuntimeConfig(log.NewNopLogger())(strings.NewReader(`
+overrides:
+  tenant-a:
+    tsdb_max_bytes_per_shard: 256MB
+    split_queries_by_interval: 30m
+    logline_mode: live
+`))
+	require.NoError(t, err)
+
+	cfg := actual.(*runtimeConfigValues)
+	require.Equal(t, 256<<20, cfg.TenantLimits["tenant-a"].TSDBMaxBytesPerShard.Val())
+	require.Equal(t, 30*time.Minute, time.Duration(cfg.TenantLimits["tenant-a"].QuerySplitDuration))
+}
+
+func TestMaxLimits_RetentionPeriod_MaxAcrossTenants(t *testing.T) {
+	defaults := validation.Limits{}
+	defaults.RetentionPeriod = model.Duration(7 * 24 * time.Hour)
+
+	tenants := map[string]*validation.Limits{
+		"short": {RetentionPeriod: model.Duration(3 * 24 * time.Hour)},
+		"long":  {RetentionPeriod: model.Duration(30 * 24 * time.Hour)},
+	}
+
+	m := newTestMaxLimits(defaults, tenants)
+
+	// Should return the longest tenant retention (30d), not the default (7d).
+	got := m.RetentionPeriod()
+	require.Equal(t, 30*24*time.Hour, got)
+}
+
+func TestMaxLimits_RetentionPeriod_ZeroTenantSkipped(t *testing.T) {
+	defaults := validation.Limits{}
+	defaults.RetentionPeriod = model.Duration(7 * 24 * time.Hour)
+
+	tenants := map[string]*validation.Limits{
+		"limited":   {RetentionPeriod: model.Duration(30 * 24 * time.Hour)},
+		"unlimited": {RetentionPeriod: 0}, // zero = "use default", not "keep forever"
+	}
+
+	m := newTestMaxLimits(defaults, tenants)
+
+	// Zero tenant is skipped; max of default (7d) and limited (30d) = 30d.
+	got := m.RetentionPeriod()
+	require.Equal(t, 30*24*time.Hour, got)
+}
+
+func TestMaxLimits_RetentionPeriod_DefaultZero(t *testing.T) {
+	defaults := validation.Limits{}
+	// Zero default = 0 (no retention configured).
+
+	tenants := map[string]*validation.Limits{
+		"a": {RetentionPeriod: model.Duration(30 * 24 * time.Hour)},
+	}
+
+	m := newTestMaxLimits(defaults, tenants)
+	// Tenant overrides the zero default.
+	got := m.RetentionPeriod()
+	require.Equal(t, 30*24*time.Hour, got)
+}
+
+func TestMaxLimits_RetentionPeriod_NoTenants(t *testing.T) {
+	defaults := validation.Limits{}
+	defaults.RetentionPeriod = model.Duration(14 * 24 * time.Hour)
+
+	m := newTestMaxLimits(defaults, nil)
+	got := m.RetentionPeriod()
+	require.Equal(t, 14*24*time.Hour, got)
+}
+
+func TestMaxLimits_NilTenantLimits(t *testing.T) {
+	defaults := validation.Limits{}
+	defaults.RetentionPeriod = model.Duration(14 * 24 * time.Hour)
+
+	ov, err := validation.NewOverrides(defaults, nil)
+	require.NoError(t, err)
+
+	m := &maxLimits{
+		inner:          ov,
+		retentionGauge: prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_retention"}),
+	}
+	m.recompute()
+
+	require.Equal(t, 14*24*time.Hour, m.RetentionPeriod())
+}

--- a/pkg/logline/limits/overrides_test.go
+++ b/pkg/logline/limits/overrides_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/loki/v3/pkg/validation"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/validation"
 )
 
 // fakeTenantLimits implements validation.TenantLimits for tests.

--- a/pkg/logline/queryfrontend/AGENTS.md
+++ b/pkg/logline/queryfrontend/AGENTS.md
@@ -1,0 +1,65 @@
+# pkg/queryfrontend
+
+## What this package does
+
+This package integrates the **logline index** into **Loki's query-range pipeline** for
+Grafana Enterprise Logs (GEL). It injects two middlewares around Loki's existing
+`queryrangebase` middleware stack to skip or narrow time intervals that the logline
+index proves contain no matching log lines.
+
+## Architecture: Two-layer middleware
+
+```
+  Prefetch MW → [Loki: limits → SplitByInterval → cache → shard → ...] → Filter MW → queriers
+```
+
+1. **Prefetch middleware** (`loglinePrefetchHandler`): Sits *above* `SplitByInterval`.
+   Parses the query, kicks off an async logline index lookup, and stores the result
+   (hint time ranges + ingester cutoff) in context. Opt-in via `X-Logline-Index` header.
+
+2. **Filter middleware** (`loglineFilterHandler`): Sits *below* `SplitByInterval` and
+   below the results cache. For each interval sub-request, it consults the prefetched
+   hints to either:
+   - **Skip** the interval entirely (return empty response) if no hint ranges overlap
+   - **Narrow** to only the matching time ranges within the interval
+   - **Pass through** if the interval is in the ingester window, or on error/timeout
+
+## Key integration points
+
+- **Wiring**: `WrapMiddleware` / `WrapMiddlewareWithStore` in `integration.go` create the
+  store, hint provider, optional cache, and compose the middleware stack. Called from
+  `pkg/enterprise/loki/init/logline.go` in the `enterprise-logs` repo.
+- **Hint provider**: `pkg/hintprovider` does the actual index lookups.
+- **Store**: `pkg/store` manages the logline index data (object storage, polling).
+- **Loki codec**: `mergeLokiResponse` in Loki's `pkg/querier/queryrange/codec.go` merges
+  sub-interval responses. It inherits `Direction`, `Limit`, and `Version` from
+  `responses[0]`, so any empty response returned by the filter middleware **must**
+  faithfully copy these fields from the original `LokiRequest`.
+
+## Common pitfalls
+
+### Ingester window
+
+The logline index only covers data in object storage. Recent data still in ingesters
+is always passed through. The `ingesterCutoff` is computed from
+`QueryIngestersWithin` (from Loki's querier config).
+
+### Hint timeout
+
+If the async hint lookup doesn't complete within `HintTimeout` (default 15s), the
+filter middleware falls back to passthrough — it does not block or fail the query.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `middleware.go` | Prefetch + filter middleware handlers, `emptyLokiResponse`, `rangesOverlapping` |
+| `integration.go` | `WrapMiddleware` / `WrapMiddlewareWithStore` — builds and composes the full stack |
+| `config.go` | `MiddlewareConfig` and `Config` — ngram length, parallelism, timeouts, cache settings |
+| `metrics.go` | Prometheus metrics for hint provider duration, ranges returned, passthrough/skip/narrow counts |
+
+## Running tests
+
+```sh
+cd pkg/queryfrontend && go test -v ./...
+```

--- a/pkg/logline/queryfrontend/AGENTS.md
+++ b/pkg/logline/queryfrontend/AGENTS.md
@@ -1,11 +1,10 @@
-# pkg/queryfrontend
+# pkg/logline/queryfrontend/
 
 ## What this package does
 
-This package integrates the **logline index** into **Loki's query-range pipeline** for
-Grafana Enterprise Logs (GEL). It injects two middlewares around Loki's existing
-`queryrangebase` middleware stack to skip or narrow time intervals that the logline
-index proves contain no matching log lines.
+This package integrates the **logline index** into **Loki's query-range pipeline**. It
+injects two middlewares around Loki's existing `queryrangebase` middleware stack to skip
+or narrow time intervals that the logline index proves contain no matching log lines.
 
 ## Architecture: Two-layer middleware
 
@@ -27,10 +26,11 @@ index proves contain no matching log lines.
 ## Key integration points
 
 - **Wiring**: `WrapMiddleware` / `WrapMiddlewareWithStore` in `integration.go` create the
-  store, hint provider, optional cache, and compose the middleware stack. Called from
-  `pkg/enterprise/loki/init/logline.go` in the `enterprise-logs` repo.
-- **Hint provider**: `pkg/hintprovider` does the actual index lookups.
-- **Store**: `pkg/store` manages the logline index data (object storage, polling).
+  store, hint provider, optional cache, and compose the middleware stack. The caller owns
+  the returned `services.Service` and prepends the wrapped middleware to
+  `Loki.QueryFrontEndMiddleware`.
+- **Hint provider**: `pkg/logline/hintprovider` does the actual index lookups.
+- **Store**: `pkg/logline/store` manages the logline index data (object storage, polling).
 - **Loki codec**: `mergeLokiResponse` in Loki's `pkg/querier/queryrange/codec.go` merges
   sub-interval responses. It inherits `Direction`, `Limit`, and `Version` from
   `responses[0]`, so any empty response returned by the filter middleware **must**
@@ -61,5 +61,5 @@ filter middleware falls back to passthrough — it does not block or fail the qu
 ## Running tests
 
 ```sh
-cd pkg/queryfrontend && go test -v ./...
+cd pkg/logline/queryfrontend && go test -v ./...
 ```

--- a/pkg/logline/queryfrontend/CLAUDE.md
+++ b/pkg/logline/queryfrontend/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/logline/queryfrontend/config.go
+++ b/pkg/logline/queryfrontend/config.go
@@ -1,0 +1,191 @@
+package queryfrontend
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logline/store"
+)
+
+const (
+	defaultNgramLength                    = 6
+	defaultMaxHintParallel                = 64
+	defaultHintTimeout                    = 15 * time.Second
+	defaultMinQueryBytes                  = int64(500 * 1024 * 1024 * 1024) // 500 GB
+	defaultShardPlanningEnabled           = true
+	defaultShardPlanningMinReductionRatio = 0.75
+
+	shardPlanningStrategyPowerOfTwo = "power_of_two"
+)
+
+// ShardPlanningConfig controls cancel-then-rerun behavior: when logline hints
+// finish before the provisional query and show sufficient narrowing, the
+// in-flight query is cancelled and restarted with power_of_two TSDB sharding.
+type ShardPlanningConfig struct {
+	Enabled               bool    `yaml:"enabled"`
+	MinTimeReductionRatio float64 `yaml:"min_time_reduction_ratio"`
+}
+
+func (c *ShardPlanningConfig) applyDefaults() {
+	if c.MinTimeReductionRatio == 0 {
+		c.MinTimeReductionRatio = defaultShardPlanningMinReductionRatio
+	}
+}
+
+func (c *ShardPlanningConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	type plain ShardPlanningConfig
+	defaults := ShardPlanningConfig{Enabled: defaultShardPlanningEnabled}
+	defaults.applyDefaults()
+	*c = defaults
+	return unmarshal((*plain)(c))
+}
+
+// MiddlewareConfig controls logline query narrowing behavior.
+type MiddlewareConfig struct {
+	// DryRun performs passive hint lookups for verification without modifying
+	// query execution.
+	DryRun bool `yaml:"dry_run"`
+	// RequireOptInHeader requires X-Logline-Index header to activate logline
+	// behavior. Applies to both active narrowing and dry-run mode.
+	RequireOptInHeader bool `yaml:"require_opt_in_header"`
+	// NgramLength is the n-gram size used for hint lookups against the logline index.
+	// Defaults to 6 when zero.
+	NgramLength int `yaml:"ngram_length"`
+	// MaxHintParallel is the maximum number of concurrent hint index workers
+	// dispatched per query. Defaults to 64 when zero.
+	MaxHintParallel int `yaml:"max_hint_parallel"`
+	// QueryIngestersWithin is the window of recent data that lives only in
+	// ingesters (not yet flushed to object storage). The logline index cannot
+	// cover this window, so it is always passed through to the Loki pipeline.
+	// Populated from Loki's querier.query_ingesters_within at assembly time.
+	QueryIngestersWithin time.Duration `yaml:"query_ingesters_within"`
+	// HintTimeout is the maximum time to wait for the logline index hint
+	// lookup before falling back to passthrough. Defaults to 15s when zero.
+	HintTimeout time.Duration `yaml:"hint_timeout"`
+	// HintCacheTTL is the TTL for cached hint results. When no external cache
+	// backend (memcached/redis) is available from Loki's results cache config,
+	// an in-process embedded cache is used automatically.
+	// Set to 0 to disable hint caching.
+	HintCacheTTL time.Duration `yaml:"hint_cache_ttl"`
+	// HintCacheMaxSizeMB is the maximum size in megabytes for the embedded
+	// hint cache. Only used when no external cache backend is configured.
+	// Defaults to 100 when zero.
+	HintCacheMaxSizeMB int64 `yaml:"hint_cache_max_size_mb"`
+	// MinQueryBytesForIndex is the minimum query size (from index stats bytes)
+	// required before running logline index hint lookup.
+	// Set to 0 to disable stats-based gating.
+	MinQueryBytesForIndex int64 `yaml:"min_query_bytes_for_index"`
+	// ShardPlanning controls optional live-query reruns that force Loki's TSDB
+	// shard planner to use a configured strategy when hints prove the request is narrow.
+	ShardPlanning ShardPlanningConfig `yaml:"shard_planning"`
+}
+
+// RegisterFlags registers configuration flags with the given FlagSet.
+func (c *MiddlewareConfig) RegisterFlags(f *flag.FlagSet) {
+	c.RegisterFlagsWithPrefix("query-frontend", f)
+}
+
+// RegisterFlagsWithPrefix registers middleware flags under a custom prefix.
+func (c *MiddlewareConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	if f == nil {
+		f = flag.CommandLine
+	}
+	if prefix == "" {
+		prefix = "query-frontend"
+	}
+
+	f.IntVar(&c.NgramLength, prefix+".ngram-length", 0,
+		"N-gram size for hint lookups against the logline index (default 6)")
+	f.BoolVar(&c.DryRun, prefix+".dry-run", false,
+		"Run logline hint lookups passively for verification without modifying query execution")
+	f.BoolVar(&c.RequireOptInHeader, prefix+".require-opt-in-header", true,
+		"Require X-Logline-Index header to activate hint narrowing")
+	f.IntVar(&c.MaxHintParallel, prefix+".max-hint-parallel", 0,
+		"Maximum concurrent hint index workers per query (default 64)")
+	f.DurationVar(&c.HintTimeout, prefix+".hint-timeout", 0,
+		"Maximum time to wait for logline index hint lookup (default 15s)")
+	f.DurationVar(&c.HintCacheTTL, prefix+".hint-cache-ttl", 2*time.Minute,
+		"TTL for cached hint results. Uses Loki results cache backend; set to 0 to disable.")
+	f.Int64Var(&c.HintCacheMaxSizeMB, prefix+".hint-cache-max-size-mb", 0,
+		"Max size in MB for embedded hint cache when no external backend is configured (default 100)")
+	f.Int64Var(&c.MinQueryBytesForIndex, prefix+".min-query-bytes-for-index", defaultMinQueryBytes,
+		"Minimum index-stats bytes required before performing logline hint lookup; set to 0 to disable (default 500 GB)")
+	f.BoolVar(&c.ShardPlanning.Enabled, prefix+".shard-planning.enabled", defaultShardPlanningEnabled,
+		"Enable logline shard-planning reruns for narrow live queries")
+	f.Float64Var(&c.ShardPlanning.MinTimeReductionRatio, prefix+".shard-planning.min-time-reduction-ratio", defaultShardPlanningMinReductionRatio,
+		"Minimum hinted time reduction ratio required for a shard-planning rerun (default 0.75)")
+}
+
+// Validate checks constraints and applies defaults for zero-valued fields.
+func (c *MiddlewareConfig) Validate() error {
+	if c.NgramLength <= 0 {
+		c.NgramLength = defaultNgramLength
+	}
+	if c.MaxHintParallel <= 0 {
+		c.MaxHintParallel = defaultMaxHintParallel
+	}
+	if c.HintTimeout <= 0 {
+		c.HintTimeout = defaultHintTimeout
+	}
+	if c.HintCacheTTL < 0 {
+		return fmt.Errorf("hint_cache_ttl must be >= 0")
+	}
+	if c.HintCacheMaxSizeMB < 0 {
+		return fmt.Errorf("hint_cache_max_size_mb must be >= 0")
+	}
+	if c.HintCacheMaxSizeMB == 0 {
+		c.HintCacheMaxSizeMB = 100
+	}
+	if c.MinQueryBytesForIndex < 0 {
+		return fmt.Errorf("min_query_bytes_for_index must be >= 0")
+	}
+	if err := c.ShardPlanning.Validate(); err != nil {
+		return fmt.Errorf("invalid shard_planning config: %w", err)
+	}
+	return nil
+}
+
+func (c *ShardPlanningConfig) Validate() error {
+	zero := *c == ShardPlanningConfig{}
+	if c.MinTimeReductionRatio < 0 {
+		return fmt.Errorf("min_time_reduction_ratio must be >= 0")
+	}
+	if zero {
+		c.Enabled = defaultShardPlanningEnabled
+	}
+	if !c.Enabled {
+		return nil
+	}
+	c.applyDefaults()
+	return nil
+}
+
+// Config controls logline query frontend middleware injection in GEL.
+type Config struct {
+	Enabled       bool             `yaml:"enabled"`
+	Store         store.Config     `yaml:"store"`
+	QueryFrontend MiddlewareConfig `yaml:"query_frontend"`
+}
+
+// RegisterFlags registers GEL integration flags for logline middleware.
+func (c *Config) RegisterFlags(f *flag.FlagSet) {
+	if f == nil {
+		f = flag.CommandLine
+	}
+
+	f.BoolVar(&c.Enabled, "logline.enabled", false, "Enable logline query frontend middleware injection")
+	c.Store.RegisterFlags(f)
+	c.QueryFrontend.RegisterFlagsWithPrefix("logline-query-frontend", f)
+}
+
+// Validate checks constraints and applies defaults.
+func (c *Config) Validate() error {
+	if err := c.Store.Validate(); err != nil {
+		return fmt.Errorf("invalid store config: %w", err)
+	}
+	if err := c.QueryFrontend.Validate(); err != nil {
+		return fmt.Errorf("invalid query frontend config: %w", err)
+	}
+	return nil
+}

--- a/pkg/logline/queryfrontend/config.go
+++ b/pkg/logline/queryfrontend/config.go
@@ -161,14 +161,14 @@ func (c *ShardPlanningConfig) Validate() error {
 	return nil
 }
 
-// Config controls logline query frontend middleware injection in GEL.
+// Config controls logline query frontend middleware injection.
 type Config struct {
 	Enabled       bool             `yaml:"enabled"`
 	Store         store.Config     `yaml:"store"`
 	QueryFrontend MiddlewareConfig `yaml:"query_frontend"`
 }
 
-// RegisterFlags registers GEL integration flags for logline middleware.
+// RegisterFlags registers the integration flags for the logline middleware.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	if f == nil {
 		f = flag.CommandLine

--- a/pkg/logline/queryfrontend/integration.go
+++ b/pkg/logline/queryfrontend/integration.go
@@ -1,0 +1,213 @@
+package queryfrontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/v3/pkg/loki"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
+	"github.com/grafana/loki/v3/pkg/logline/store"
+)
+
+// lenientRegisterer wraps a prometheus.Registerer to swallow duplicate
+// registration errors instead of panicking. Loki's middleware stack creates
+// multiple caches that each initialise a DNS provider registering the same
+// metrics; in the full Loki binary these are de-duped, but this integration
+// can initialize additional cache clients.
+type lenientRegisterer struct {
+	prometheus.Registerer
+}
+
+func (r lenientRegisterer) Register(c prometheus.Collector) error {
+	err := r.Registerer.Register(c)
+	if err == nil {
+		return nil
+	}
+	var are prometheus.AlreadyRegisteredError
+	if errors.As(err, &are) {
+		return nil
+	}
+	return err
+}
+
+func (r lenientRegisterer) MustRegister(cs ...prometheus.Collector) {
+	for _, c := range cs {
+		if err := r.Register(c); err != nil {
+			panic(err)
+		}
+	}
+}
+
+type identityMiddleware struct{}
+
+func (identityMiddleware) Wrap(next queryrangebase.Handler) queryrangebase.Handler { return next }
+
+// WrapMiddleware builds and injects logline query middlewares around an
+// existing Loki queryrange middleware stack. It creates and owns a store
+// service lifecycle for index polling.
+//
+// Returns:
+//   - wrapped middleware
+//   - store polling service (start/stop managed by caller)
+//   - cleanup function (idempotent; stops hint cache)
+func WrapMiddleware(
+	lokiCfg loki.ConfigWrapper,
+	cfg Config,
+	tenantSettings TenantSettings,
+	existing queryrangebase.Middleware,
+	logger log.Logger,
+	reg prometheus.Registerer,
+) (queryrangebase.Middleware, services.Service, func(), error) {
+	if !cfg.Enabled {
+		if existing == nil {
+			existing = identityMiddleware{}
+		}
+		return existing, nil, func() {}, nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, nil, nil, fmt.Errorf("invalid logline config: %w", err)
+	}
+
+	lokiQIW := lokiCfg.Querier.QueryIngestersWithin
+	if lokiQIW == 0 {
+		lokiQIW = store.DefaultQueryIngestersWithin
+	}
+	cfg.Store.QueryIngestersWithin = lokiQIW
+	indexStore, err := store.New(
+		context.Background(),
+		lokiCfg.SchemaConfig,
+		lokiCfg.StorageConfig.ObjectStore,
+		cfg.Store,
+		logger,
+		reg,
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("create logline index store: %w", err)
+	}
+
+	wrapped, hintCache, err := WrapMiddlewareWithStore(
+		lokiCfg,
+		cfg.QueryFrontend,
+		tenantSettings,
+		indexStore,
+		existing,
+		logger,
+		reg,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() {
+			if hintCache != nil {
+				hintCache.Stop()
+			}
+		})
+	}
+
+	storeSvc := services.NewBasicService(
+		func(ctx context.Context) error {
+			return indexStore.StartPolling(ctx)
+		},
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			return nil
+		},
+		func(_ error) error {
+			cleanup()
+			return nil
+		},
+	)
+
+	return wrapped, storeSvc, cleanup, nil
+}
+
+// WrapMiddlewareWithStore injects logline middlewares around an existing
+// middleware stack using a caller-provided index store.
+func WrapMiddlewareWithStore(
+	lokiCfg loki.ConfigWrapper,
+	cfg MiddlewareConfig,
+	tenantSettings TenantSettings,
+	indexStore *store.Store,
+	existing queryrangebase.Middleware,
+	logger log.Logger,
+	reg prometheus.Registerer,
+) (queryrangebase.Middleware, cache.Cache, error) {
+	if indexStore == nil {
+		return nil, nil, fmt.Errorf("index store cannot be nil")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("invalid query frontend config: %w", err)
+	}
+
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+	reg = lenientRegisterer{reg}
+
+	metrics := NewMetrics(reg)
+	baseHintProvider, err := hintprovider.NewLoglineHintProvider(
+		indexStore,
+		cfg.NgramLength,
+		cfg.MaxHintParallel,
+		metrics.ObserveQueryMultipleTermBatches,
+		logger,
+		reg,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create hint provider: %w", err)
+	}
+
+	var hintCache cache.Cache
+	if cfg.HintCacheTTL > 0 {
+		hintCacheCfg := lokiCfg.QueryRange.ResultsCacheConfig.CacheConfig
+		hintCacheCfg.Prefix = "logline-hint-cache."
+		hintCacheCfg.DefaultValidity = cfg.HintCacheTTL
+		hintCacheCfg.Memcache.Expiration = cfg.HintCacheTTL
+		hintCacheCfg.Redis.Expiration = cfg.HintCacheTTL
+		hintCacheCfg.EmbeddedCache.TTL = cfg.HintCacheTTL
+
+		// Fall back to an in-process embedded cache when the Loki config
+		// doesn't provide an external cache backend (memcached/redis).
+		if !cache.IsMemcacheSet(hintCacheCfg) && !cache.IsRedisSet(hintCacheCfg) {
+			hintCacheCfg.EmbeddedCache.Enabled = true
+			hintCacheCfg.EmbeddedCache.MaxSizeMB = cfg.HintCacheMaxSizeMB
+		}
+
+		if cache.IsCacheConfigured(hintCacheCfg) {
+			hintCache, err = cache.New(hintCacheCfg, reg, logger, stats.CacheType("logline-hints"), "logline")
+			if err != nil {
+				return nil, nil, fmt.Errorf("create hint cache: %w", err)
+			}
+		}
+	}
+
+	hp := hintprovider.NewCachingHintProvider(baseHintProvider, hintCache, reg)
+	if cfg.QueryIngestersWithin == 0 {
+		cfg.QueryIngestersWithin = lokiCfg.Querier.QueryIngestersWithin
+	}
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, tenantSettings, metrics, logger)
+	filterMW := NewLoglineFilterMiddleware(cfg.HintTimeout, metrics, logger)
+
+	if existing == nil {
+		existing = identityMiddleware{}
+	}
+
+	wrapped := queryrangebase.MergeMiddlewares(prefetchMW, existing, filterMW)
+	return wrapped, hintCache, nil
+}

--- a/pkg/logline/queryfrontend/integration.go
+++ b/pkg/logline/queryfrontend/integration.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/loki"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
 	"github.com/grafana/loki/v3/pkg/logline/store"

--- a/pkg/logline/queryfrontend/metrics.go
+++ b/pkg/logline/queryfrontend/metrics.go
@@ -1,0 +1,108 @@
+package queryfrontend
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics holds all Prometheus metrics for the logline query frontend.
+type Metrics struct {
+	// hintProviderDuration measures time spent in ProvideHints per query.
+	hintProviderDuration prometheus.Histogram
+	// hintRangesReturned measures the number of time ranges returned per query.
+	hintRangesReturned prometheus.Histogram
+	// hintPassthrough counts queries bypassed without hint narrowing.
+	// Labels: reason — "timeout", "unsupported", "error".
+	hintPassthrough *prometheus.CounterVec
+	// hintSubRequests counts sub-requests dispatched for hint-narrowed queries.
+	// Labels: status — "narrowed", "skipped".
+	hintSubRequests *prometheus.CounterVec
+	// passthroughSubRequests counts sub-requests dispatched for ingester-window
+	// time ranges that bypass the logline index entirely.
+	// Labels: reason — "ingester_window".
+	passthroughSubRequests *prometheus.CounterVec
+	// queryTermBatchesProcessed records QueryMultiple term-batch depth per index query.
+	// Labels: reason — "term_miss", "empty_and", "positive".
+	queryTermBatchesProcessed *prometheus.HistogramVec
+	// hintSkippedSmallQuery counts requests that skip hint prefetch because
+	// query index-stats bytes are below the configured threshold.
+	hintSkippedSmallQuery prometheus.Counter
+	// dryRunTotal counts dry-run requests that pass initial eligibility gates.
+	dryRunTotal prometheus.Counter
+	// dryRunSkippedInflight counts dry-run requests skipped because only one
+	// dry-run lookup is allowed in flight at a time.
+	dryRunSkippedInflight prometheus.Counter
+	// dryRunIncomplete counts dry-run requests where query execution completed
+	// before hint lookup finished, forcing hint cancellation.
+	dryRunIncomplete prometheus.Counter
+	// dryRunVerified counts dry-run verification outcomes.
+	// Labels: result — "correct", "false_negative".
+	dryRunVerified *prometheus.CounterVec
+	// shardPlanningTotal counts shard-planning cancel-then-rerun decisions and outcomes.
+	// Labels: result — "provisional_query", "cancel_then_rerun", "fallback"; reason is low cardinality.
+	shardPlanningTotal *prometheus.CounterVec
+}
+
+// NewMetrics creates a new Metrics instance registered with reg.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	return &Metrics{
+		hintProviderDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "logline_query_frontend_hint_provider_duration_seconds",
+			Help:    "Time spent in ProvideHints per query in seconds",
+			Buckets: prometheus.DefBuckets,
+		}),
+		hintRangesReturned: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "logline_query_frontend_hint_ranges_returned",
+			Help:    "Number of time ranges returned by ProvideHints per query",
+			Buckets: []float64{0, 1, 2, 5, 10, 20, 50, 100, 200, 500},
+		}),
+		hintPassthrough: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "logline_query_frontend_hint_passthrough_total",
+			Help: "Total queries passed through without hint narrowing",
+		}, []string{"reason"}),
+		hintSubRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "logline_query_frontend_hint_sub_requests_total",
+			Help: "Total hint-narrowed sub-requests dispatched",
+		}, []string{"status"}),
+		passthroughSubRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "logline_query_frontend_passthrough_sub_requests_total",
+			Help: "Total sub-requests dispatched for ingester-window time ranges",
+		}, []string{"reason"}),
+		queryTermBatchesProcessed: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "logline_query_frontend_query_term_batches_processed",
+			Help:    "Term batches processed by QueryMultiple per index query",
+			Buckets: []float64{1, 2, 3, 4, 5, 8, 10, 15, 20},
+		}, []string{"reason"}),
+		hintSkippedSmallQuery: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "logline_query_frontend_hint_skipped_small_query_total",
+			Help: "Total requests that skipped logline hint prefetch because query bytes were below threshold",
+		}),
+		dryRunTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "logline_query_frontend_dry_run_total",
+			Help: "Total dry-run requests that executed hint lookup verification",
+		}),
+		dryRunSkippedInflight: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "logline_query_frontend_dry_run_skipped_inflight_total",
+			Help: "Total dry-run requests skipped because another dry-run hint lookup was in flight",
+		}),
+		dryRunIncomplete: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "logline_query_frontend_dry_run_incomplete_total",
+			Help: "Total dry-run requests where hint lookup did not finish before query completion",
+		}),
+		dryRunVerified: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "logline_query_frontend_dry_run_verified_total",
+			Help: "Total dry-run verification outcomes",
+		}, []string{"result"}),
+		shardPlanningTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "logline_query_frontend_shard_planning_total",
+			Help: "Total shard-planning cancel-then-rerun decisions and outcomes",
+		}, []string{"result", "reason"}),
+	}
+}
+
+func (m *Metrics) ObserveQueryMultipleTermBatches(reason string, termBatchesProcessed int) {
+	if m == nil || termBatchesProcessed <= 0 {
+		return
+	}
+	m.queryTermBatchesProcessed.WithLabelValues(reason).Observe(float64(termBatchesProcessed))
+}

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/common/model"
+	"github.com/zeebo/xxh3"
+	"go.uber.org/atomic"
+
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -21,8 +24,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/querylimits"
-	"github.com/prometheus/common/model"
-	"github.com/zeebo/xxh3"
 
 	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
 	"github.com/grafana/loki/v3/pkg/logline/verification"
@@ -92,12 +93,12 @@ type hintPrefetchResult struct {
 
 	// Per-query impact counters, updated from the filter layer and logged once
 	// after the full query pipeline finishes.
-	totalIntervals        int64
-	skippedIntervals      int64
-	narrowedIntervals     int64
-	passthroughIntervals  int64
-	originalDurationNanos int64
-	queryDurationNanos    int64
+	totalIntervals        atomic.Int64
+	skippedIntervals      atomic.Int64
+	narrowedIntervals     atomic.Int64
+	passthroughIntervals  atomic.Int64
+	originalDurationNanos atomic.Int64
+	queryDurationNanos    atomic.Int64
 }
 
 type hintImpactSnapshot struct {
@@ -122,29 +123,29 @@ func (r *hintPrefetchResult) recordSkipped(intervalDuration time.Duration) {
 	if r == nil {
 		return
 	}
-	atomic.AddInt64(&r.totalIntervals, 1)
-	atomic.AddInt64(&r.skippedIntervals, 1)
-	atomic.AddInt64(&r.originalDurationNanos, intervalDuration.Nanoseconds())
+	r.totalIntervals.Add(1)
+	r.skippedIntervals.Add(1)
+	r.originalDurationNanos.Add(intervalDuration.Nanoseconds())
 }
 
 func (r *hintPrefetchResult) recordNarrowed(originalDuration, queriedDuration time.Duration) {
 	if r == nil {
 		return
 	}
-	atomic.AddInt64(&r.totalIntervals, 1)
-	atomic.AddInt64(&r.narrowedIntervals, 1)
-	atomic.AddInt64(&r.originalDurationNanos, originalDuration.Nanoseconds())
-	atomic.AddInt64(&r.queryDurationNanos, queriedDuration.Nanoseconds())
+	r.totalIntervals.Add(1)
+	r.narrowedIntervals.Add(1)
+	r.originalDurationNanos.Add(originalDuration.Nanoseconds())
+	r.queryDurationNanos.Add(queriedDuration.Nanoseconds())
 }
 
 func (r *hintPrefetchResult) recordPassthrough(intervalDuration time.Duration) {
 	if r == nil {
 		return
 	}
-	atomic.AddInt64(&r.totalIntervals, 1)
-	atomic.AddInt64(&r.passthroughIntervals, 1)
-	atomic.AddInt64(&r.originalDurationNanos, intervalDuration.Nanoseconds())
-	atomic.AddInt64(&r.queryDurationNanos, intervalDuration.Nanoseconds())
+	r.totalIntervals.Add(1)
+	r.passthroughIntervals.Add(1)
+	r.originalDurationNanos.Add(intervalDuration.Nanoseconds())
+	r.queryDurationNanos.Add(intervalDuration.Nanoseconds())
 }
 
 func (r *hintPrefetchResult) impactSnapshot() hintImpactSnapshot {
@@ -152,8 +153,8 @@ func (r *hintPrefetchResult) impactSnapshot() hintImpactSnapshot {
 		return hintImpactSnapshot{}
 	}
 
-	originalNanos := atomic.LoadInt64(&r.originalDurationNanos)
-	queryNanos := atomic.LoadInt64(&r.queryDurationNanos)
+	originalNanos := r.originalDurationNanos.Load()
+	queryNanos := r.queryDurationNanos.Load()
 	ratio := 0.0
 	if originalNanos > 0 {
 		ratio = float64(originalNanos-queryNanos) / float64(originalNanos)
@@ -163,10 +164,10 @@ func (r *hintPrefetchResult) impactSnapshot() hintImpactSnapshot {
 	}
 
 	return hintImpactSnapshot{
-		totalIntervals:       atomic.LoadInt64(&r.totalIntervals),
-		skippedIntervals:     atomic.LoadInt64(&r.skippedIntervals),
-		narrowedIntervals:    atomic.LoadInt64(&r.narrowedIntervals),
-		passthroughIntervals: atomic.LoadInt64(&r.passthroughIntervals),
+		totalIntervals:       r.totalIntervals.Load(),
+		skippedIntervals:     r.skippedIntervals.Load(),
+		narrowedIntervals:    r.narrowedIntervals.Load(),
+		passthroughIntervals: r.passthroughIntervals.Load(),
 		originalDuration:     time.Duration(originalNanos),
 		queryDuration:        time.Duration(queryNanos),
 		timeReductionRatio:   ratio,

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -1,0 +1,1216 @@
+package queryfrontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/loki/v3/pkg/loghttp"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
+	"github.com/prometheus/common/model"
+	"github.com/zeebo/xxh3"
+
+	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
+	"github.com/grafana/loki/v3/pkg/logline/verification"
+)
+
+// Two-layer logline index middleware:
+//
+// 1. Prefetch MW (above SplitByInterval): parses query, kicks off async
+//    logline index lookup, stores results + ingester cutoff in context.
+//
+// 2. Filter MW (below SplitByInterval, below cache): for each interval
+//    sub-request, consults the prefetched hints to skip empty intervals
+//    or narrow to matching time ranges within the interval.
+//
+// SplitByInterval handles direction ordering, LIMIT early-exit, and
+// interval-level caching. We just help it skip or narrow intervals.
+//
+//	Prefetch MW → [Loki: limits → SplitByInterval → cache → shard → ...] → Filter MW → queriers
+
+// LoglineIndexHeader enables logline index narrowing for a query.
+// Accepted values:
+//   - "dry_run" — opt in to logline dry-run verification
+//   - "live" — override dry-run config and perform live query acceleration
+//   - "off" — force-disable logline handling for this request
+const LoglineIndexHeader = "X-Logline-Index"
+
+// LoglineIndexHeaderValue is the string enum for X-Logline-Index values.
+type LoglineIndexHeaderValue string
+
+const (
+	// LoglineIndexDryRun enables dry-run verification for a single request.
+	LoglineIndexDryRun LoglineIndexHeaderValue = "dry_run"
+	// LoglineIndexLive enables live query acceleration for a single request.
+	LoglineIndexLive LoglineIndexHeaderValue = "live"
+	// LoglineIndexOff force-disables logline handling for a single request,
+	// overriding all other config and tenant settings.
+	LoglineIndexOff LoglineIndexHeaderValue = "off"
+)
+
+const LoglineSkipCacheHeader = "X-Logline-Skip-Cache"
+
+type hintPrefetchKeyType struct{}
+type shardPlanningRerunGuardKeyType struct{}
+
+type shardPlanningDecision struct {
+	eligible bool
+	reason   string
+	overlaps []hintprovider.HintTimeRange
+}
+
+type provisionalQueryResult struct {
+	resp queryrangebase.Response
+	err  error
+}
+
+// hintPrefetchResult holds pre-computed logline index lookup results, shared
+// between the prefetch and filter middleware layers via context.
+type hintPrefetchResult struct {
+	ranges         []hintprovider.HintTimeRange // normalized, sorted by start
+	err            error
+	stats          *hintprovider.QueryStats
+	queryBytes     uint64
+	queryStart     time.Time     // original query start
+	queryEnd       time.Time     // original query end
+	ingesterCutoff time.Time     // data after this is in ingester window only
+	done           chan struct{} // closed when lookup completes
+
+	// Per-query impact counters, updated from the filter layer and logged once
+	// after the full query pipeline finishes.
+	totalIntervals        int64
+	skippedIntervals      int64
+	narrowedIntervals     int64
+	passthroughIntervals  int64
+	originalDurationNanos int64
+	queryDurationNanos    int64
+}
+
+type hintImpactSnapshot struct {
+	totalIntervals       int64
+	skippedIntervals     int64
+	narrowedIntervals    int64
+	passthroughIntervals int64
+	originalDuration     time.Duration
+	queryDuration        time.Duration
+	timeReductionRatio   float64
+}
+
+type dryRunLookupResult struct {
+	ranges   []hintprovider.HintTimeRange
+	err      error
+	stats    *hintprovider.QueryStats
+	duration time.Duration
+	done     chan struct{}
+}
+
+func (r *hintPrefetchResult) recordSkipped(intervalDuration time.Duration) {
+	if r == nil {
+		return
+	}
+	atomic.AddInt64(&r.totalIntervals, 1)
+	atomic.AddInt64(&r.skippedIntervals, 1)
+	atomic.AddInt64(&r.originalDurationNanos, intervalDuration.Nanoseconds())
+}
+
+func (r *hintPrefetchResult) recordNarrowed(originalDuration, queriedDuration time.Duration) {
+	if r == nil {
+		return
+	}
+	atomic.AddInt64(&r.totalIntervals, 1)
+	atomic.AddInt64(&r.narrowedIntervals, 1)
+	atomic.AddInt64(&r.originalDurationNanos, originalDuration.Nanoseconds())
+	atomic.AddInt64(&r.queryDurationNanos, queriedDuration.Nanoseconds())
+}
+
+func (r *hintPrefetchResult) recordPassthrough(intervalDuration time.Duration) {
+	if r == nil {
+		return
+	}
+	atomic.AddInt64(&r.totalIntervals, 1)
+	atomic.AddInt64(&r.passthroughIntervals, 1)
+	atomic.AddInt64(&r.originalDurationNanos, intervalDuration.Nanoseconds())
+	atomic.AddInt64(&r.queryDurationNanos, intervalDuration.Nanoseconds())
+}
+
+func (r *hintPrefetchResult) impactSnapshot() hintImpactSnapshot {
+	if r == nil {
+		return hintImpactSnapshot{}
+	}
+
+	originalNanos := atomic.LoadInt64(&r.originalDurationNanos)
+	queryNanos := atomic.LoadInt64(&r.queryDurationNanos)
+	ratio := 0.0
+	if originalNanos > 0 {
+		ratio = float64(originalNanos-queryNanos) / float64(originalNanos)
+		if ratio < 0 {
+			ratio = 0
+		}
+	}
+
+	return hintImpactSnapshot{
+		totalIntervals:       atomic.LoadInt64(&r.totalIntervals),
+		skippedIntervals:     atomic.LoadInt64(&r.skippedIntervals),
+		narrowedIntervals:    atomic.LoadInt64(&r.narrowedIntervals),
+		passthroughIntervals: atomic.LoadInt64(&r.passthroughIntervals),
+		originalDuration:     time.Duration(originalNanos),
+		queryDuration:        time.Duration(queryNanos),
+		timeReductionRatio:   ratio,
+	}
+}
+
+func appendHintStats(logValues []any, stats *hintprovider.QueryStats) []any {
+	if stats == nil {
+		return logValues
+	}
+	snap := stats.Snapshot()
+	return append(logValues,
+		"object_requests", snap.ObjectStorageRequests,
+		"header_reads", snap.HeaderReads,
+		"metadata_reads", snap.MetadataReads,
+		"term_dict_reads", snap.TermDictReads,
+		"bitmap_reads", snap.BitmapReads,
+		"header_cache_misses", snap.HeaderCacheMisses,
+		"metadata_cache_misses", snap.MetadataCacheMisses,
+		"io_wait", snap.TotalIOWait,
+		"io_bytes", snap.TotalIOBytes,
+		"peak_concurrency", snap.PeakConcurrency,
+		"effective_concurrency", snap.EffectiveConcurrency,
+		"index_queries_total", snap.IndexQueriesTotal,
+		"index_queries_term_miss", snap.IndexQueriesTermMiss,
+		"index_queries_empty_and", snap.IndexQueriesEmptyAnd,
+		"index_queries_positive", snap.IndexQueriesPositive,
+		"term_batches_processed_total", snap.TotalTermBatchesProcessed,
+		"hint_cache_result", snap.HintCacheResult,
+		"hint_cache_days_fetched", snap.HintCacheDaysFetched,
+		"hint_cache_days_hit", snap.HintCacheDaysHit,
+	)
+}
+
+func withHintPrefetch(ctx context.Context, r *hintPrefetchResult) context.Context {
+	return context.WithValue(ctx, hintPrefetchKeyType{}, r)
+}
+
+func hintPrefetchFromContext(ctx context.Context) *hintPrefetchResult {
+	v, _ := ctx.Value(hintPrefetchKeyType{}).(*hintPrefetchResult)
+	return v
+}
+
+func withShardPlanningRerunGuard(ctx context.Context) context.Context {
+	return context.WithValue(ctx, shardPlanningRerunGuardKeyType{}, true)
+}
+
+func shardPlanningRerunGuardFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(shardPlanningRerunGuardKeyType{}).(bool)
+	return v
+}
+
+func withShardPlanningQueryLimits(ctx context.Context, strategy string) context.Context {
+	limits := querylimits.QueryLimits{}
+	if existing := querylimits.ExtractQueryLimitsFromContext(ctx); existing != nil {
+		limits = *existing
+	}
+	limits.TSDBShardingStrategy = strategy
+	return querylimits.InjectQueryLimitsIntoContext(ctx, limits)
+}
+
+func intervalDuration(start, end time.Time) time.Duration {
+	if !end.After(start) {
+		return 0
+	}
+	return end.Sub(start)
+}
+
+// NewLoglinePrefetchMiddleware starts an async logline index lookup before
+// SplitByInterval generates intervals.
+func NewLoglinePrefetchMiddleware(
+	hp hintprovider.QueryHintProvider,
+	cfg MiddlewareConfig,
+	tenantSettings TenantSettings,
+	metrics *Metrics,
+	logger log.Logger,
+) queryrangebase.Middleware {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	if tenantSettings == nil {
+		tenantSettings = staticTenantSettings{}
+	}
+	if cfg.ShardPlanning == (ShardPlanningConfig{}) {
+		cfg.ShardPlanning.Enabled = defaultShardPlanningEnabled
+	}
+	cfg.ShardPlanning.applyDefaults()
+	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
+		return &loglinePrefetchHandler{
+			next:                 next,
+			hintProvider:         hp,
+			defaultMode:          modeFromDryRun(cfg.DryRun),
+			requireOptInHeader:   cfg.RequireOptInHeader,
+			ngramLength:          cfg.NgramLength,
+			hintTimeout:          cfg.HintTimeout,
+			minQueryBytes:        cfg.MinQueryBytesForIndex,
+			queryIngestersWithin: cfg.QueryIngestersWithin,
+			shardPlanning:        cfg.ShardPlanning,
+			tenantSettings:       tenantSettings,
+			metrics:              metrics,
+			logger:               logger,
+		}
+	})
+}
+
+type loglinePrefetchHandler struct {
+	next                 queryrangebase.Handler
+	hintProvider         hintprovider.QueryHintProvider
+	defaultMode          Mode
+	requireOptInHeader   bool
+	ngramLength          int
+	hintTimeout          time.Duration
+	dryRunInflight       atomic.Int32
+	minQueryBytes        int64
+	queryIngestersWithin time.Duration
+	shardPlanning        ShardPlanningConfig
+	tenantSettings       TenantSettings
+	metrics              *Metrics
+	logger               log.Logger
+}
+
+func modeFromDryRun(dryRun bool) Mode {
+	if dryRun {
+		return ModeDryRun
+	}
+	return ModeLive
+}
+
+func resolveMode(header string, tenantMode, defaultMode Mode, requireOptInHeader bool) (Mode, bool) {
+	switch LoglineIndexHeaderValue(header) {
+	case LoglineIndexOff:
+		return ModeOff, true
+	case LoglineIndexLive:
+		return ModeLive, false
+	case LoglineIndexDryRun:
+		return ModeDryRun, false
+	}
+
+	mode := defaultMode
+	if tenantMode != ModeUnset {
+		mode = tenantMode
+	}
+
+	if mode == ModeOff {
+		return ModeOff, true
+	}
+
+	if tenantMode == ModeUnset && requireOptInHeader {
+		return mode, true
+	}
+
+	return mode, false
+}
+
+func (h *loglinePrefetchHandler) getQueryBytes(ctx context.Context, expr syntax.Expr, from, through time.Time) (uint64, error) {
+	matcherGroups, err := syntax.MatcherGroups(expr)
+	if err != nil {
+		return 0, err
+	}
+	// If there are zero matcher groups, query index stats for everything.
+	if len(matcherGroups) == 0 {
+		matcherGroups = append(matcherGroups, syntax.MatcherRange{})
+	}
+
+	start := model.Time(from.UnixMilli())
+	end := model.Time(through.UnixMilli())
+
+	var totalBytes uint64
+	for _, group := range matcherGroups {
+		diff := group.Interval + group.Offset
+		adjustedFrom := start.Add(-diff)
+		adjustedThrough := end.Add(-group.Offset)
+
+		resp, err := h.next.Do(ctx, &logproto.IndexStatsRequest{
+			From:     adjustedFrom,
+			Through:  adjustedThrough,
+			Matchers: syntax.MatchersString(group.Matchers),
+		})
+		if err != nil {
+			return 0, err
+		}
+
+		casted, ok := resp.(*queryrange.IndexStatsResponse)
+		if !ok {
+			return 0, fmt.Errorf("expected *queryrange.IndexStatsResponse while querying index, got %T", resp)
+		}
+
+		if casted.Response != nil {
+			totalBytes += casted.Response.Bytes
+		}
+	}
+
+	return totalBytes, nil
+}
+
+func (h *loglinePrefetchHandler) observeShardPlanning(result, reason string) {
+	if h == nil || h.metrics == nil || h.metrics.shardPlanningTotal == nil {
+		return
+	}
+	h.metrics.shardPlanningTotal.WithLabelValues(result, reason).Inc()
+}
+
+func (h *loglinePrefetchHandler) shardPlanningDecision(result *hintPrefetchResult, from, through time.Time) shardPlanningDecision {
+	if result == nil {
+		return shardPlanningDecision{reason: "hint_error"}
+	}
+	if result.err != nil {
+		if errors.Is(result.err, hintprovider.ErrUnsupported) {
+			return shardPlanningDecision{reason: "unsupported"}
+		}
+		return shardPlanningDecision{reason: "hint_error"}
+	}
+	if through.After(result.ingesterCutoff) {
+		return shardPlanningDecision{reason: "ingester_window"}
+	}
+	for _, hint := range result.ranges {
+		if hint.IsPassthrough() {
+			return shardPlanningDecision{reason: "passthrough_range"}
+		}
+	}
+
+	overlaps := rangesOverlapping(result.ranges, from, through)
+
+	var cumulative time.Duration
+	for _, hint := range overlaps {
+		start := maxTime(hint.Start, from)
+		end := minTime(hint.End, through)
+		cumulative += intervalDuration(start, end)
+	}
+
+	queryDuration := intervalDuration(from, through)
+	if queryDuration == 0 {
+		return shardPlanningDecision{reason: "time_reduction_too_small", overlaps: overlaps}
+	}
+	timeReductionRatio := float64(queryDuration-cumulative) / float64(queryDuration)
+	if timeReductionRatio < 0 {
+		timeReductionRatio = 0
+	}
+	if timeReductionRatio < h.shardPlanning.MinTimeReductionRatio {
+		return shardPlanningDecision{reason: "time_reduction_too_small", overlaps: overlaps}
+	}
+
+	return shardPlanningDecision{eligible: true, reason: "eligible", overlaps: overlaps}
+}
+
+func verifyDryRunHints(hintRanges []hintprovider.HintTimeRange, resp *queryrange.LokiResponse, eligibleEnd time.Time) verification.Report {
+	if resp == nil {
+		return verification.Report{HintRanges: len(hintRanges)}
+	}
+	var timestamps []time.Time
+	for _, stream := range resp.Data.Result {
+		for _, entry := range stream.Entries {
+			if !eligibleEnd.IsZero() && entry.Timestamp.After(eligibleEnd) {
+				continue
+			}
+			timestamps = append(timestamps, entry.Timestamp)
+		}
+	}
+	return verification.VerifyEntries(hintRanges, timestamps)
+}
+
+type dryRunHintSummary struct {
+	hintTotalSeconds   string
+	earliestHintTime   string
+	latestHintTime     string
+	initialSkipSeconds string
+	rangesChecksum     string
+}
+
+func summarizeDryRunHints(
+	hintRanges []hintprovider.HintTimeRange,
+	queryStart, queryEnd, eligibleEnd time.Time,
+	direction logproto.Direction,
+) dryRunHintSummary {
+	start := queryStart.UTC()
+	end := queryEnd.UTC()
+	if end.Before(start) {
+		end = start
+	}
+
+	if eligibleEnd.IsZero() {
+		eligibleEnd = end
+	}
+	verifyEnd := eligibleEnd.UTC()
+	if verifyEnd.Before(start) {
+		verifyEnd = start
+	}
+
+	hasPassthrough := false
+	for _, r := range hintRanges {
+		if r.IsPassthrough() {
+			hasPassthrough = true
+			break
+		}
+	}
+	if hasPassthrough {
+		total := roundTo1Decimal(intervalDuration(start, end).Seconds())
+		return dryRunHintSummary{
+			hintTotalSeconds:   fmt.Sprintf("%.1f", total),
+			earliestHintTime:   start.Format(time.RFC3339Nano),
+			latestHintTime:     end.Format(time.RFC3339Nano),
+			initialSkipSeconds: "0.0",
+			rangesChecksum:     "0",
+		}
+	}
+
+	hasher := xxh3.New()
+	var (
+		earliest   time.Time
+		latest     time.Time
+		total      float64
+		hasClipped bool
+	)
+	for _, r := range hintRanges {
+		rangeStart := r.Start.UTC()
+		rangeEnd := r.End.UTC()
+		if rangeEnd.Before(rangeStart) {
+			rangeEnd = rangeStart
+		}
+		fmt.Fprintf(hasher, "%d,%d;", rangeStart.UnixNano(), rangeEnd.UnixNano())
+
+		clippedStart := maxTime(rangeStart, start)
+		clippedEnd := minTime(rangeEnd, verifyEnd)
+		if clippedEnd.Before(clippedStart) {
+			continue
+		}
+		total += clippedEnd.Sub(clippedStart).Seconds()
+		if !hasClipped || clippedStart.Before(earliest) {
+			earliest = clippedStart
+		}
+		if !hasClipped || clippedEnd.After(latest) {
+			latest = clippedEnd
+		}
+		hasClipped = true
+	}
+
+	totalRounded := roundTo1Decimal(total)
+	initialSkip := 0.0
+	earliestStr := ""
+	latestStr := ""
+	if hasClipped {
+		earliestStr = earliest.Format(time.RFC3339Nano)
+		latestStr = latest.Format(time.RFC3339Nano)
+		switch direction {
+		case logproto.BACKWARD:
+			initialSkip = intervalDuration(latest, end).Seconds()
+		default:
+			initialSkip = intervalDuration(start, earliest).Seconds()
+		}
+		initialSkip = roundTo1Decimal(initialSkip)
+	}
+
+	return dryRunHintSummary{
+		hintTotalSeconds:   fmt.Sprintf("%.1f", totalRounded),
+		earliestHintTime:   earliestStr,
+		latestHintTime:     latestStr,
+		initialSkipSeconds: fmt.Sprintf("%.1f", initialSkip),
+		rangesChecksum:     fmt.Sprintf("%016x", hasher.Sum64()),
+	}
+}
+
+func roundTo1Decimal(v float64) float64 {
+	return math.Round(v*10) / 10
+}
+
+// hintRangesTotalSeconds returns the unclipped sum of non-passthrough hint
+// range durations, formatted to one decimal place for log output.
+func hintRangesTotalSeconds(ranges []hintprovider.HintTimeRange) string {
+	var total float64
+	for _, r := range ranges {
+		if r.IsPassthrough() {
+			continue
+		}
+		total += intervalDuration(r.Start.UTC(), r.End.UTC()).Seconds()
+	}
+	return fmt.Sprintf("%.1f", roundTo1Decimal(total))
+}
+
+func (h *loglinePrefetchHandler) doDryRun(
+	ctx context.Context,
+	req queryrangebase.Request,
+	lokiReq *queryrange.LokiRequest,
+	expr syntax.Expr,
+	from, through time.Time,
+	queryBytes uint64,
+) (queryrangebase.Response, error) {
+	logger := util_log.WithContext(ctx, h.logger)
+	eligibleEnd := through
+	if h.queryIngestersWithin > 0 {
+		cutoff := time.Now().Add(-h.queryIngestersWithin).UTC()
+		if cutoff.After(from) && cutoff.Before(through) {
+			eligibleEnd = cutoff
+		} else if !cutoff.After(from) {
+			// Entire query is in the ingester window — nothing to verify.
+			return h.next.Do(ctx, req)
+		}
+	}
+
+	if !h.dryRunInflight.CompareAndSwap(0, 1) {
+		if h.metrics != nil && h.metrics.dryRunSkippedInflight != nil {
+			h.metrics.dryRunSkippedInflight.Inc()
+		}
+		level.Warn(logger).Log(
+			"msg", "logline dry-run hint lookup skipped due to inflight limit",
+			"query_hash", util.HashedQuery(lokiReq.Query),
+			"limit", 1,
+		)
+		return h.next.Do(ctx, req)
+	}
+	defer h.dryRunInflight.Store(0)
+
+	if h.metrics != nil && h.metrics.dryRunTotal != nil {
+		h.metrics.dryRunTotal.Inc()
+	}
+
+	prefetchCtx, cancelPrefetch := context.WithTimeout(ctx, h.hintTimeout)
+	defer cancelPrefetch()
+	tenant, _ := user.ExtractOrgID(ctx)
+
+	lookup := &dryRunLookupResult{
+		stats: hintprovider.NewQueryStats(),
+		done:  make(chan struct{}),
+	}
+
+	go func() {
+		defer close(lookup.done)
+		start := time.Now()
+		hints, stats, hintErr := h.hintProvider.ProvideHints(
+			prefetchCtx,
+			tenant,
+			expr,
+			model.TimeFromUnixNano(from.UnixNano()),
+			model.TimeFromUnixNano(eligibleEnd.UnixNano()),
+		)
+		lookup.duration = time.Since(start)
+		if h.metrics != nil && h.metrics.hintProviderDuration != nil {
+			h.metrics.hintProviderDuration.Observe(lookup.duration.Seconds())
+		}
+		if lookup.stats != nil {
+			lookup.stats.SetWallTime(lookup.duration)
+		}
+		if stats != nil {
+			if lookup.stats == nil {
+				lookup.stats = hintprovider.NewQueryStats()
+			}
+			lookup.stats.Merge(stats)
+		}
+		if hintErr != nil {
+			lookup.err = hintErr
+			return
+		}
+		if hints != nil {
+			lookup.ranges = hints.TimeRanges
+			if h.metrics != nil && h.metrics.hintRangesReturned != nil {
+				h.metrics.hintRangesReturned.Observe(float64(len(lookup.ranges)))
+			}
+		}
+	}()
+
+	queryStart := time.Now()
+	resp, queryErr := h.next.Do(ctx, req)
+	queryDuration := time.Since(queryStart)
+	queryTimeout := ctx.Err() != nil
+
+	// Bind common fields once so every branch inherits them.
+	logger = log.With(logger,
+		"query_hash", util.HashedQuery(lokiReq.Query),
+		"query_timeout", queryTimeout,
+		"query_start", from.Format(time.RFC3339Nano),
+		"query_end", through.Format(time.RFC3339Nano),
+		"query_duration", queryDuration,
+		"query_bytes", queryBytes,
+	)
+
+	hintsDone := false
+	select {
+	case <-lookup.done:
+		hintsDone = true
+	default:
+		cancelPrefetch()
+	}
+
+	if !hintsDone {
+		if h.metrics != nil && h.metrics.dryRunIncomplete != nil {
+			h.metrics.dryRunIncomplete.Inc()
+		}
+		level.Error(logger).Log("msg", "logline dry-run hint lookup incomplete")
+		return resp, queryErr
+	}
+
+	// Hint lookup goroutine finished — but it may have been cancelled by
+	// the parent context (client timeout). Treat context errors on the hint
+	// lookup as incomplete when the query itself timed out.
+	if lookup.err != nil {
+		if queryTimeout && isCancel(lookup.err) {
+			if h.metrics != nil && h.metrics.dryRunIncomplete != nil {
+				h.metrics.dryRunIncomplete.Inc()
+			}
+			level.Info(logger).Log("msg", "logline dry-run hint lookup incomplete")
+			return resp, queryErr
+		}
+		level.Error(logger).Log("msg", "logline dry-run hint lookup failed", "err", lookup.err)
+		return resp, queryErr
+	}
+
+	hintSummary := summarizeDryRunHints(lookup.ranges, from, through, eligibleEnd, lokiReq.Direction)
+
+	// Hint lookup succeeded. If the query timed out we can still report
+	// the hint data — mark correct=true since the hints themselves were
+	// valid but we had no (complete) result set to verify against.
+	if queryTimeout {
+		if h.metrics != nil && h.metrics.dryRunVerified != nil {
+			h.metrics.dryRunVerified.WithLabelValues("correct").Inc()
+		}
+		logValues := []any{
+			"msg", "logline dry-run verification",
+			"eligible_end", eligibleEnd.Format(time.RFC3339Nano),
+			"hint_duration", lookup.duration,
+			"hint_ranges", len(lookup.ranges),
+			"hint_ranges_detail", hintprovider.FormatHintRanges(lookup.ranges),
+			"hint_total_seconds", hintSummary.hintTotalSeconds,
+			"earliest_hint_time", hintSummary.earliestHintTime,
+			"latest_hint_time", hintSummary.latestHintTime,
+			"initial_skip_seconds", hintSummary.initialSkipSeconds,
+			"hint_ranges_checksum", hintSummary.rangesChecksum,
+			"correct", true,
+		}
+		logValues = appendHintStats(logValues, lookup.stats)
+		level.Info(logger).Log(logValues...)
+		return resp, queryErr
+	}
+
+	if queryErr != nil {
+		level.Warn(logger).Log("msg", "logline dry-run verification skipped due query error", "err", queryErr)
+		return resp, queryErr
+	}
+
+	lokiResp, ok := resp.(*queryrange.LokiResponse)
+	if !ok {
+		level.Warn(logger).Log(
+			"msg", "logline dry-run verification skipped due non-Loki response",
+			"response_type", fmt.Sprintf("%T", resp),
+		)
+		return resp, queryErr
+	}
+
+	vr := verifyDryRunHints(lookup.ranges, lokiResp, eligibleEnd)
+	correct := vr.Correct()
+	label := "correct"
+	if !correct {
+		label = "false_negative"
+	}
+	if h.metrics != nil && h.metrics.dryRunVerified != nil {
+		h.metrics.dryRunVerified.WithLabelValues(label).Inc()
+	}
+
+	logValues := []any{
+		"msg", "logline dry-run verification",
+		"eligible_end", eligibleEnd.Format(time.RFC3339Nano),
+		"hint_duration", lookup.duration,
+		"hint_ranges", len(lookup.ranges),
+		"hint_ranges_detail", hintprovider.FormatHintRanges(lookup.ranges),
+		"hint_total_seconds", hintSummary.hintTotalSeconds,
+		"earliest_hint_time", hintSummary.earliestHintTime,
+		"latest_hint_time", hintSummary.latestHintTime,
+		"initial_skip_seconds", hintSummary.initialSkipSeconds,
+		"hint_ranges_checksum", hintSummary.rangesChecksum,
+		"total_entries", vr.TotalEntries,
+		"covered_entries", vr.CoveredEntries,
+		"false_negatives", vr.FalseNegatives,
+		"correct", correct,
+	}
+	logValues = appendHintStats(logValues, lookup.stats)
+	level.Info(logger).Log(logValues...)
+
+	return resp, queryErr
+}
+
+func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+	lokiReq, ok := req.(*queryrange.LokiRequest)
+	if !ok {
+		return h.next.Do(ctx, req)
+	}
+	logger := util_log.WithContext(ctx, h.logger)
+	if shardPlanningRerunGuardFromContext(ctx) {
+		h.observeShardPlanning("fallback", "rerun_guard")
+		return h.next.Do(ctx, req)
+	}
+	if httpreq.ExtractHeader(ctx, LoglineSkipCacheHeader) != "" {
+		ctx = hintprovider.WithSkipCache(ctx)
+		level.Debug(logger).Log("msg", "hint cache skipped by request header", "header", LoglineSkipCacheHeader)
+	}
+
+	header := httpreq.ExtractHeader(ctx, LoglineIndexHeader)
+	tenant, _ := user.ExtractOrgID(ctx)
+	tenantMode := ModeUnset
+	minQueryBytes := h.minQueryBytes
+	if h.tenantSettings != nil {
+		tenantMode = h.tenantSettings.Mode(tenant)
+		if tenantMinQueryBytes, ok := h.tenantSettings.MinQueryBytesForIndex(tenant); ok {
+			minQueryBytes = tenantMinQueryBytes
+		}
+	}
+	mode, passthrough := resolveMode(header, tenantMode, h.defaultMode, h.requireOptInHeader)
+	if passthrough {
+		return h.next.Do(ctx, req)
+	}
+
+	expr, err := syntax.ParseExpr(lokiReq.Query)
+	if err != nil {
+		return h.next.Do(ctx, req)
+	}
+
+	// Metric queries (SampleExpr) return numeric series, not log entries,
+	// so there is nothing to narrow or verify.
+	if _, ok := expr.(syntax.SampleExpr); ok {
+		return h.next.Do(ctx, req)
+	}
+
+	// Shared eligibility: supported query shape.
+	// When ngramLength is not configured (<=0), skip the early check and let
+	// ProvideHints handle support detection internally.
+	if h.ngramLength > 0 && len(hintprovider.SupportedQuery(expr, h.ngramLength)) == 0 {
+		return h.next.Do(ctx, req)
+	}
+
+	// Shared eligibility: stats-based byte threshold.
+	from := lokiReq.StartTs.UTC()
+	through := lokiReq.EndTs.UTC()
+	queryBytes := uint64(0)
+	if minQueryBytes > 0 {
+		queryBytes, err = h.getQueryBytes(ctx, expr, from, through)
+		if err != nil {
+			level.Warn(logger).Log(
+				"msg", "failed to get query stats for logline gating; skipping hint lookup",
+				"err", err,
+				"threshold_bytes", minQueryBytes,
+			)
+			return h.next.Do(ctx, req)
+		}
+		if queryBytes < uint64(minQueryBytes) {
+			if h.metrics != nil && h.metrics.hintSkippedSmallQuery != nil {
+				h.metrics.hintSkippedSmallQuery.Inc()
+			}
+			level.Debug(logger).Log(
+				"msg", "query below logline index threshold; skipping hint lookup",
+				"query_bytes", queryBytes,
+				"threshold_bytes", minQueryBytes,
+			)
+			return h.next.Do(ctx, req)
+		}
+	}
+
+	if mode == ModeDryRun {
+		return h.doDryRun(ctx, req, lokiReq, expr, from, through, queryBytes)
+	}
+
+	ingesterCutoff := through
+	if h.queryIngestersWithin > 0 {
+		cutoff := time.Now().Add(-h.queryIngestersWithin).UTC()
+		if cutoff.After(from) && cutoff.Before(through) {
+			ingesterCutoff = cutoff
+		} else if !cutoff.After(from) {
+			// Entire query is in the ingester window. Store this so filter middleware
+			// can pass through without waiting for object storage hints.
+			ingesterCutoff = from
+		}
+	}
+
+	result := &hintPrefetchResult{
+		queryStart:     from,
+		queryEnd:       through,
+		queryBytes:     queryBytes,
+		ingesterCutoff: ingesterCutoff,
+		stats:          hintprovider.NewQueryStats(),
+		done:           make(chan struct{}),
+	}
+
+	prefetchCtx := ctx
+	go func() {
+		defer close(result.done)
+
+		start := time.Now()
+		defer func() {
+			dur := time.Since(start)
+			h.metrics.hintProviderDuration.Observe(dur.Seconds())
+			if isCancel(result.err) {
+				level.Info(logger).Log("msg", "hint prefetch canceled", "duration", dur)
+				return
+			}
+			if result.stats != nil {
+				result.stats.SetWallTime(dur)
+				snap := result.stats.Snapshot()
+				level.Info(logger).Log(
+					"msg", "hint prefetch completed",
+					"duration", dur,
+					"query_bytes", result.queryBytes,
+					"ranges", len(result.ranges),
+					"hint_ranges_detail", hintprovider.FormatHintRanges(result.ranges),
+					"hint_total_seconds", hintRangesTotalSeconds(result.ranges),
+					"err", result.err,
+					"object_requests", snap.ObjectStorageRequests,
+					"header_reads", snap.HeaderReads,
+					"metadata_reads", snap.MetadataReads,
+					"term_dict_reads", snap.TermDictReads,
+					"bitmap_reads", snap.BitmapReads,
+					"header_cache_misses", snap.HeaderCacheMisses,
+					"metadata_cache_misses", snap.MetadataCacheMisses,
+					"io_wait", snap.TotalIOWait,
+					"io_bytes", snap.TotalIOBytes,
+					"peak_concurrency", snap.PeakConcurrency,
+					"effective_concurrency", snap.EffectiveConcurrency,
+					"prefetch_calls", snap.PrefetchCalls,
+					"prefetch_timeouts", snap.PrefetchTimeouts,
+					"index_queries_total", snap.IndexQueriesTotal,
+					"index_queries_term_miss", snap.IndexQueriesTermMiss,
+					"index_queries_empty_and", snap.IndexQueriesEmptyAnd,
+					"index_queries_positive", snap.IndexQueriesPositive,
+					"term_batches_processed_total", snap.TotalTermBatchesProcessed,
+					"hint_cache_result", snap.HintCacheResult,
+					"hint_cache_days_fetched", snap.HintCacheDaysFetched,
+					"hint_cache_days_hit", snap.HintCacheDaysHit,
+				)
+				return
+			}
+			level.Info(logger).Log(
+				"msg", "hint prefetch completed",
+				"duration", dur,
+				"query_bytes", result.queryBytes,
+				"ranges", len(result.ranges),
+				"hint_ranges_detail", hintprovider.FormatHintRanges(result.ranges),
+				"hint_total_seconds", hintRangesTotalSeconds(result.ranges),
+				"err", result.err,
+			)
+		}()
+
+		eligibleEnd := ingesterCutoff
+		if !eligibleEnd.After(from) {
+			return
+		}
+
+		eligibleFrom := model.TimeFromUnixNano(from.UnixNano())
+		eligibleThrough := model.TimeFromUnixNano(eligibleEnd.UnixNano())
+
+		hints, stats, err := h.hintProvider.ProvideHints(prefetchCtx, tenant, expr, eligibleFrom, eligibleThrough)
+		if stats != nil {
+			result.stats.Merge(stats)
+		}
+		if err != nil {
+			result.err = err
+			return
+		}
+		if hints != nil {
+			result.ranges = hints.TimeRanges // already normalized+sorted
+			h.metrics.hintRangesReturned.Observe(float64(len(result.ranges)))
+		}
+	}()
+
+	ctx = withHintPrefetch(ctx, result)
+	if !h.shardPlanning.Enabled {
+		resp, err := h.next.Do(ctx, req)
+		if err != nil {
+			return resp, err
+		}
+
+		h.logHintImpact(logger, resp, result)
+		return resp, nil
+	}
+
+	// Shard planning races hint prefetch against a provisional query. If hints
+	// finish first and narrow enough, cancel the in-flight query and rerun with
+	// power_of_two sharding. Otherwise keep the provisional query result.
+	provisionalQueryCtx, cancelProvisionalQuery := context.WithCancel(ctx)
+	defer cancelProvisionalQuery()
+	provisionalQueryDone := make(chan provisionalQueryResult, 1)
+	go func() {
+		resp, err := h.next.Do(provisionalQueryCtx, req)
+		provisionalQueryDone <- provisionalQueryResult{resp: resp, err: err}
+	}()
+
+	select {
+	case provisional := <-provisionalQueryDone:
+		h.observeShardPlanning("provisional_query", "query_finished_first")
+		if provisional.err != nil {
+			return provisional.resp, provisional.err
+		}
+		h.logHintImpact(logger, provisional.resp, result)
+		return provisional.resp, nil
+	case <-result.done:
+		select {
+		case provisional := <-provisionalQueryDone:
+			h.observeShardPlanning("provisional_query", "query_finished_first")
+			if provisional.err != nil {
+				return provisional.resp, provisional.err
+			}
+			h.logHintImpact(logger, provisional.resp, result)
+			return provisional.resp, nil
+		default:
+		}
+
+		decision := h.shardPlanningDecision(result, from, through)
+		if !decision.eligible {
+			h.observeShardPlanning("fallback", decision.reason)
+			provisional := <-provisionalQueryDone
+			if provisional.err != nil {
+				return provisional.resp, provisional.err
+			}
+			h.logHintImpact(logger, provisional.resp, result)
+			return provisional.resp, nil
+		}
+
+		// Hints finished first with enough time reduction — cancel the provisional
+		// query and rerun with power_of_two sharding.
+		h.observeShardPlanning("cancel_then_rerun", decision.reason)
+		cancelProvisionalQuery()
+
+		rerunCtx := withShardPlanningRerunGuard(ctx)
+		rerunCtx = withShardPlanningQueryLimits(rerunCtx, shardPlanningStrategyPowerOfTwo)
+		resp, err := h.next.Do(rerunCtx, req)
+		if err != nil {
+			return resp, err
+		}
+		h.logHintImpact(logger, resp, result)
+		return resp, nil
+	}
+}
+
+func (h *loglinePrefetchHandler) logHintImpact(logger log.Logger, resp queryrangebase.Response, result *hintPrefetchResult) {
+	if result == nil {
+		return
+	}
+
+	select {
+	case <-result.done:
+	default:
+		return
+	}
+
+	if result.err != nil {
+		return
+	}
+
+	impact := result.impactSnapshot()
+	logValues := []any{
+		"msg", "query hint impact",
+		"query_start", result.queryStart.Format(time.RFC3339Nano),
+		"query_end", result.queryEnd.Format(time.RFC3339Nano),
+		"query_range", result.queryEnd.Sub(result.queryStart),
+		"hint_ranges", len(result.ranges),
+		"total_intervals", impact.totalIntervals,
+		"skipped_intervals", impact.skippedIntervals,
+		"narrowed_intervals", impact.narrowedIntervals,
+		"passthrough_intervals", impact.passthroughIntervals,
+		"original_duration", impact.originalDuration,
+		"queried_duration", impact.queryDuration,
+		"time_reduction_ratio", impact.timeReductionRatio,
+	}
+
+	if lokiResp, ok := resp.(*queryrange.LokiResponse); ok {
+		totalChunksRef := lokiResp.Statistics.Querier.Store.GetTotalChunksRef() +
+			lokiResp.Statistics.Ingester.Store.GetTotalChunksRef()
+		totalChunksDownloaded := lokiResp.Statistics.Querier.Store.GetTotalChunksDownloaded() +
+			lokiResp.Statistics.Ingester.Store.GetTotalChunksDownloaded()
+		totalDecompressedBytes := lokiResp.Statistics.Querier.Store.Chunk.GetDecompressedBytes() +
+			lokiResp.Statistics.Ingester.Store.Chunk.GetDecompressedBytes()
+		totalDecompressedLines := lokiResp.Statistics.Querier.Store.Chunk.GetDecompressedLines() +
+			lokiResp.Statistics.Ingester.Store.Chunk.GetDecompressedLines()
+
+		logValues = append(logValues,
+			"total_chunks_ref", totalChunksRef,
+			"total_chunks_downloaded", totalChunksDownloaded,
+			"decompressed_bytes", totalDecompressedBytes,
+			"decompressed_lines", totalDecompressedLines,
+			"total_entries_returned", lokiResp.Statistics.Summary.GetTotalEntriesReturned(),
+		)
+	}
+
+	level.Info(logger).Log(logValues...)
+}
+
+// NewLoglineFilterMiddleware intercepts each interval sub-request from
+// SplitByInterval and narrows/skips it using prefetched hints.
+func NewLoglineFilterMiddleware(
+	hintTimeout time.Duration,
+	metrics *Metrics,
+	logger log.Logger,
+) queryrangebase.Middleware {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
+		return &loglineFilterHandler{
+			next:        next,
+			hintTimeout: hintTimeout,
+			metrics:     metrics,
+			logger:      logger,
+		}
+	})
+}
+
+type loglineFilterHandler struct {
+	next        queryrangebase.Handler
+	hintTimeout time.Duration
+	metrics     *Metrics
+	logger      log.Logger
+}
+
+func (h *loglineFilterHandler) Do(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+	lokiReq, ok := req.(*queryrange.LokiRequest)
+	if !ok {
+		return h.next.Do(ctx, req)
+	}
+	logger := util_log.WithContext(ctx, h.logger)
+
+	result := hintPrefetchFromContext(ctx)
+	if result == nil {
+		return h.next.Do(ctx, req)
+	}
+
+	intervalStart := lokiReq.StartTs.UTC()
+	intervalEnd := lokiReq.EndTs.UTC()
+	originalDuration := intervalDuration(intervalStart, intervalEnd)
+
+	timer := time.NewTimer(h.hintTimeout)
+	defer timer.Stop()
+	select {
+	case <-result.done:
+		result.stats.ObservePrefetchCall(false)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timer.C:
+		result.stats.ObservePrefetchCall(true)
+		result.recordPassthrough(originalDuration)
+		h.metrics.hintPassthrough.WithLabelValues("timeout").Inc()
+		level.Warn(logger).Log("msg", "hint prefetch timeout, falling back to passthrough", "timeout", h.hintTimeout)
+		return h.next.Do(ctx, req)
+	}
+
+	if result.err != nil {
+		result.recordPassthrough(originalDuration)
+		if errors.Is(result.err, hintprovider.ErrUnsupported) {
+			h.metrics.hintPassthrough.WithLabelValues("unsupported").Inc()
+		} else {
+			h.metrics.hintPassthrough.WithLabelValues("error").Inc()
+			level.Warn(logger).Log("msg", "hint provider error, passing through", "err", result.err)
+		}
+		return h.next.Do(ctx, req)
+	}
+
+	if intervalEnd.After(result.ingesterCutoff) {
+		result.recordPassthrough(originalDuration)
+		h.metrics.passthroughSubRequests.WithLabelValues("ingester_window").Inc()
+		return h.next.Do(ctx, req)
+	}
+
+	overlapping := rangesOverlapping(result.ranges, intervalStart, intervalEnd)
+	if len(overlapping) == 0 {
+		result.recordSkipped(originalDuration)
+		h.metrics.hintSubRequests.WithLabelValues("skipped").Inc()
+		return emptyLokiResponse(lokiReq), nil
+	}
+
+	if len(overlapping) == 1 {
+		start := maxTime(overlapping[0].Start, intervalStart)
+		end := minTime(overlapping[0].End, intervalEnd)
+		if overlapping[0].IsPassthrough() {
+			result.recordPassthrough(originalDuration)
+			h.metrics.passthroughSubRequests.WithLabelValues("pre_min_date").Inc()
+			return h.next.Do(ctx, req.WithStartEnd(start, end))
+		}
+		result.recordNarrowed(originalDuration, intervalDuration(start, end))
+		h.metrics.hintSubRequests.WithLabelValues("narrowed").Inc()
+		return h.next.Do(ctx, req.WithStartEnd(start, end))
+	}
+
+	responses := make([]queryrangebase.Response, 0, len(overlapping))
+	var queriedDuration time.Duration
+	for _, hint := range overlapping {
+		start := maxTime(hint.Start, intervalStart)
+		end := minTime(hint.End, intervalEnd)
+		resp, err := h.next.Do(ctx, req.WithStartEnd(start, end))
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, resp)
+		queriedDuration += intervalDuration(start, end)
+		if hint.IsPassthrough() {
+			h.metrics.passthroughSubRequests.WithLabelValues("pre_min_date").Inc()
+		} else {
+			h.metrics.hintSubRequests.WithLabelValues("narrowed").Inc()
+		}
+	}
+	result.recordNarrowed(originalDuration, queriedDuration)
+	return queryrange.DefaultCodec.MergeResponse(responses...)
+}
+
+func isCancel(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// rangesOverlapping returns hint ranges that overlap [start, end].
+// Assumes ranges are sorted by Start.
+func rangesOverlapping(ranges []hintprovider.HintTimeRange, start, end time.Time) []hintprovider.HintTimeRange {
+	if len(ranges) == 0 {
+		return nil
+	}
+
+	idx := sort.Search(len(ranges), func(i int) bool {
+		return !ranges[i].End.Before(start)
+	})
+
+	var result []hintprovider.HintTimeRange
+	for i := idx; i < len(ranges); i++ {
+		if ranges[i].Start.After(end) {
+			break
+		}
+		result = append(result, ranges[i])
+	}
+	return result
+}
+
+func maxTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}
+
+func emptyLokiResponse(req *queryrange.LokiRequest) *queryrange.LokiResponse {
+	return &queryrange.LokiResponse{
+		Status:    "success",
+		Direction: req.Direction,
+		Limit:     req.Limit,
+		Version:   uint32(loghttp.GetVersion(req.Path)),
+		Data: queryrange.LokiData{
+			ResultType: loghttp.ResultTypeStream,
+			Result:     []logproto.Stream{},
+		},
+	}
+}

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -11,6 +11,10 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -18,9 +22,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
 )
@@ -219,7 +220,7 @@ func buildStatsAwareQuerier(
 }
 
 func findLogLine(logs, contains string) string {
-	for _, line := range strings.Split(logs, "\n") {
+	for line := range strings.SplitSeq(logs, "\n") {
 		if strings.Contains(line, contains) {
 			return line
 		}
@@ -1946,7 +1947,7 @@ func TestEmptyLokiResponseMergesSafely(t *testing.T) {
 	}
 
 	empty := emptyLokiResponse(req)
-	real := &queryrange.LokiResponse{
+	realResp := &queryrange.LokiResponse{
 		Status:    "success",
 		Direction: logproto.FORWARD,
 		Limit:     100,
@@ -1965,7 +1966,7 @@ func TestEmptyLokiResponseMergesSafely(t *testing.T) {
 		},
 	}
 
-	merged, err := queryrange.DefaultCodec.MergeResponse(empty, real)
+	merged, err := queryrange.DefaultCodec.MergeResponse(empty, realResp)
 	require.NoError(t, err)
 
 	lokiMerged := merged.(*queryrange.LokiResponse)

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -1,0 +1,2375 @@
+package queryfrontend
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/loki/v3/pkg/loghttp"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/loki"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
+)
+
+// ---------------------------------------------------------------------------
+// Test mocks
+// ---------------------------------------------------------------------------
+
+type mockHintProvider struct {
+	mu           sync.RWMutex
+	hints        *hintprovider.Hints
+	err          error
+	calls        int
+	sawSkipCache bool
+	sawCancel    bool
+	delay        time.Duration
+}
+
+type mockTenantSettings struct {
+	modes                 map[string]Mode
+	minQueryBytesForIndex map[string]int64
+}
+
+func (m mockTenantSettings) Mode(tenant string) Mode {
+	if m.modes == nil {
+		return ModeUnset
+	}
+	mode, ok := m.modes[tenant]
+	if !ok {
+		return ModeUnset
+	}
+	return mode
+}
+
+func (m mockTenantSettings) MinQueryBytesForIndex(tenant string) (int64, bool) {
+	if m.minQueryBytesForIndex == nil {
+		return 0, false
+	}
+	minQueryBytes, ok := m.minQueryBytesForIndex[tenant]
+	return minQueryBytes, ok
+}
+
+func (m *mockHintProvider) ProvideHints(
+	ctx context.Context,
+	_ string,
+	_ syntax.Expr,
+	_,
+	_ model.Time,
+) (*hintprovider.Hints, *hintprovider.QueryStats, error) {
+	stats := hintprovider.NewQueryStats()
+
+	m.mu.Lock()
+	m.calls++
+	hints := m.hints
+	err := m.err
+	m.sawSkipCache = hintprovider.SkipCache(ctx)
+	delay := m.delay
+	m.mu.Unlock()
+
+	if delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			m.mu.Lock()
+			m.sawCancel = true
+			m.mu.Unlock()
+			return nil, stats, ctx.Err()
+		}
+	}
+	return hints, stats, err
+}
+
+func (m *mockHintProvider) Calls() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.calls
+}
+
+func (m *mockHintProvider) SawSkipCache() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sawSkipCache
+}
+
+func (m *mockHintProvider) SawCancel() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sawCancel
+}
+
+func newTestMetrics() *Metrics {
+	return NewMetrics(prometheus.NewRegistry())
+}
+
+func newTestLokiRequest(query string, from, through time.Time) *queryrange.LokiRequest {
+	return &queryrange.LokiRequest{
+		Query:   query,
+		StartTs: from,
+		EndTs:   through,
+	}
+}
+
+func emptyStreamResponse() *queryrange.LokiResponse {
+	return &queryrange.LokiResponse{
+		Status:    "success",
+		Direction: logproto.BACKWARD,
+		Data:      queryrange.LokiData{ResultType: "streams", Result: []logproto.Stream{}},
+	}
+}
+
+func streamResponseWithEntries(entries ...logproto.Entry) *queryrange.LokiResponse {
+	return &queryrange.LokiResponse{
+		Status:    "success",
+		Direction: logproto.BACKWARD,
+		Data: queryrange.LokiData{
+			ResultType: "streams",
+			Result: []logproto.Stream{
+				{
+					Labels:  `{job="test"}`,
+					Entries: entries,
+				},
+			},
+		},
+	}
+}
+
+// buildStack wires prefetch + filter middleware the same way service.go does,
+// except the "Loki tripperware" is replaced by a transparent pass-through.
+// This lets us test the two-layer interaction in isolation.
+func buildStack(
+	hp *mockHintProvider,
+	cfg MiddlewareConfig,
+	metrics *Metrics,
+	querier queryrangebase.Handler,
+	tenantSettings ...TenantSettings,
+) queryrangebase.Handler {
+	if cfg.ShardPlanning == (ShardPlanningConfig{}) {
+		cfg.ShardPlanning.Enabled = false
+		cfg.ShardPlanning.MinTimeReductionRatio = defaultShardPlanningMinReductionRatio
+	}
+	filterMW := NewLoglineFilterMiddleware(10*time.Second, metrics, nil)
+	var settings TenantSettings
+	if len(tenantSettings) > 0 {
+		settings = tenantSettings[0]
+	}
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, settings, metrics, nil)
+	return prefetchMW.Wrap(filterMW.Wrap(querier))
+}
+
+func buildStackWithLogger(
+	hp *mockHintProvider,
+	cfg MiddlewareConfig,
+	metrics *Metrics,
+	logger log.Logger,
+	querier queryrangebase.Handler,
+	tenantSettings ...TenantSettings,
+) queryrangebase.Handler {
+	if cfg.ShardPlanning == (ShardPlanningConfig{}) {
+		cfg.ShardPlanning.Enabled = false
+		cfg.ShardPlanning.MinTimeReductionRatio = defaultShardPlanningMinReductionRatio
+	}
+	filterMW := NewLoglineFilterMiddleware(10*time.Second, metrics, logger)
+	var settings TenantSettings
+	if len(tenantSettings) > 0 {
+		settings = tenantSettings[0]
+	}
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, settings, metrics, logger)
+	return prefetchMW.Wrap(filterMW.Wrap(querier))
+}
+
+func buildStatsAwareQuerier(
+	statsResp *logproto.IndexStatsResponse,
+	statsErr error,
+	statsCalls *int,
+	queryHandler queryrangebase.Handler,
+) queryrangebase.Handler {
+	return queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		switch req.(type) {
+		case *logproto.IndexStatsRequest:
+			if statsCalls != nil {
+				*statsCalls = *statsCalls + 1
+			}
+			if statsErr != nil {
+				return nil, statsErr
+			}
+			if statsResp == nil {
+				statsResp = &logproto.IndexStatsResponse{}
+			}
+			return &queryrange.IndexStatsResponse{Response: statsResp}, nil
+		default:
+			return queryHandler.Do(ctx, req)
+		}
+	})
+}
+
+func findLogLine(logs, contains string) string {
+	for _, line := range strings.Split(logs, "\n") {
+		if strings.Contains(line, contains) {
+			return line
+		}
+	}
+	return ""
+}
+
+func testTenantContext() context.Context {
+	return user.InjectOrgID(context.Background(), "test")
+}
+
+func testTenantContextWithDryRun() context.Context {
+	ctx := testTenantContext()
+	return httpreq.InjectHeader(ctx, LoglineIndexHeader, string(LoglineIndexDryRun))
+}
+
+func testTenantContextWithLive() context.Context {
+	ctx := testTenantContext()
+	return httpreq.InjectHeader(ctx, LoglineIndexHeader, string(LoglineIndexLive))
+}
+
+func testTenantContextWithForceLive() context.Context {
+	ctx := testTenantContext()
+	return httpreq.InjectHeader(ctx, LoglineIndexHeader, string(LoglineIndexLive))
+}
+
+func testTenantContextWithForceDisable() context.Context {
+	ctx := testTenantContext()
+	return httpreq.InjectHeader(ctx, LoglineIndexHeader, string(LoglineIndexOff))
+}
+
+// ---------------------------------------------------------------------------
+// Prefetch + Filter integration tests
+// ---------------------------------------------------------------------------
+
+func TestPrefetchFilter_NonLokiRequest(t *testing.T) {
+	hp := &mockHintProvider{}
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return &queryrange.LokiSeriesResponse{}, nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	_, err := handler.Do(ctx, &queryrange.LokiSeriesRequest{})
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled)
+	require.Equal(t, 0, hp.Calls(), "hint provider should not be called for non-LokiRequest")
+}
+
+func TestPrefetchFilter_ParseError(t *testing.T) {
+	hp := &mockHintProvider{}
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`not valid logql!!!`, time.Now().Add(-1*time.Hour), time.Now())
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled)
+	require.Equal(t, 0, hp.Calls())
+}
+
+func TestPrefetchFilter_OptInHeader_Missing(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContext() // header intentionally omitted
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled, "should pass through when opt-in header is missing")
+	require.Equal(t, 0, hp.Calls(), "should not call ProvideHints without opt-in header")
+}
+
+func TestPrefetchFilter_OptInHeader_Present(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "should call ProvideHints when opt-in header is present")
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestPrefetchFilter_RequireOptInHeaderFalse_UsesHintsWithoutHeader(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{RequireOptInHeader: false}
+	handler := buildStack(hp, cfg, newTestMetrics(), next)
+	ctx := testTenantContext() // header intentionally omitted
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "should call ProvideHints when header requirement is disabled")
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestDryRun_QueryUnmodified(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: hintStart, Line: "failure"}), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+	handler := buildStack(hp, cfg, newTestMetrics(), next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, req.StartTs, gotStart, "dry-run must not narrow query start")
+	require.Equal(t, req.EndTs, gotEnd, "dry-run must not narrow query end")
+	require.Equal(t, 1, hp.Calls(), "dry-run should still perform a hint lookup")
+}
+
+func TestDryRun_VerifiesHintCoverage(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-35 * time.Minute), Line: "failure"}), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run verification")
+	require.NotEmpty(t, logLine)
+	require.Contains(t, logLine, "correct=true")
+	require.Contains(t, logLine, "false_negatives=0")
+	require.Contains(t, logLine, "total_entries=1")
+	require.Contains(t, logLine, "query_timeout=false")
+	require.Contains(t, logLine, "query_hash=")
+}
+
+func TestDryRun_LogsHintSummaryFields(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	queryStart := now.Add(-1 * time.Hour)
+	queryEnd := now
+	ranges := []hintprovider.HintTimeRange{
+		{Start: now.Add(-50 * time.Minute), End: now.Add(-49 * time.Minute)},
+		{Start: now.Add(-40 * time.Minute), End: now.Add(-40*time.Minute + 500*time.Millisecond)},
+	}
+
+	cases := []struct {
+		name      string
+		direction logproto.Direction
+	}{
+		{name: "forward", direction: logproto.FORWARD},
+		{name: "backward", direction: logproto.BACKWARD},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hp := &mockHintProvider{
+				hints: &hintprovider.Hints{TimeRanges: ranges},
+			}
+			next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				time.Sleep(25 * time.Millisecond)
+				return streamResponseWithEntries(logproto.Entry{Timestamp: ranges[0].Start.Add(10 * time.Second), Line: "failure"}), nil
+			})
+
+			var logs bytes.Buffer
+			logger := log.NewLogfmtLogger(&logs)
+			cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+			handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+
+			req := newTestLokiRequest(`{job="test"} |= "failure"`, queryStart, queryEnd)
+			req.Direction = tc.direction
+
+			_, err := handler.Do(testTenantContext(), req)
+			require.NoError(t, err)
+
+			logLine := findLogLine(logs.String(), "logline dry-run verification")
+			require.NotEmpty(t, logLine)
+
+			summary := summarizeDryRunHints(ranges, queryStart, queryEnd, queryEnd, tc.direction)
+			require.Contains(t, logLine, "hint_total_seconds="+summary.hintTotalSeconds)
+			require.Contains(t, logLine, "earliest_hint_time="+summary.earliestHintTime)
+			require.Contains(t, logLine, "latest_hint_time="+summary.latestHintTime)
+			require.Contains(t, logLine, "initial_skip_seconds="+summary.initialSkipSeconds)
+			require.Contains(t, logLine, "hint_ranges_checksum="+summary.rangesChecksum)
+		})
+	}
+}
+
+func TestDryRun_EmptyHintRanges_LogsSummaryFields(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	queryStart := now.Add(-1 * time.Hour)
+	queryEnd := now
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: nil},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		time.Sleep(25 * time.Millisecond)
+		return emptyStreamResponse(), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, queryStart, queryEnd)
+	req.Direction = logproto.FORWARD
+
+	_, err := handler.Do(testTenantContext(), req)
+	require.NoError(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run verification")
+	require.NotEmpty(t, logLine)
+
+	summary := summarizeDryRunHints(nil, queryStart, queryEnd, queryEnd, req.Direction)
+	require.Contains(t, logLine, "hint_total_seconds="+summary.hintTotalSeconds)
+	require.Contains(t, logLine, "earliest_hint_time="+summary.earliestHintTime)
+	require.Contains(t, logLine, "latest_hint_time="+summary.latestHintTime)
+	require.Contains(t, logLine, "initial_skip_seconds="+summary.initialSkipSeconds)
+	require.Contains(t, logLine, "hint_ranges_checksum="+summary.rangesChecksum)
+}
+
+func TestDryRun_FalseNegative(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-40 * time.Minute)},
+			},
+		},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-20 * time.Minute), Line: "failure"}), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run verification")
+	require.NotEmpty(t, logLine)
+	require.Contains(t, logLine, "correct=false")
+	require.Contains(t, logLine, "false_negatives=1")
+	require.Contains(t, logLine, "total_entries=1")
+}
+
+func TestDryRun_EmptyResults_CorrectTrue(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		time.Sleep(25 * time.Millisecond)
+		return emptyStreamResponse(), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run verification")
+	require.NotEmpty(t, logLine, "zero-entry queries should still produce a verification log")
+	require.Contains(t, logLine, "correct=true")
+	require.Contains(t, logLine, "total_entries=0")
+}
+
+func TestDryRun_IngesterWindowOnly_SkipsDryRun(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-20 * time.Minute), End: now.Add(-10 * time.Minute)},
+			},
+		},
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3, QueryIngestersWithin: 3 * time.Hour}
+	handler := buildStack(hp, cfg, newTestMetrics(), next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-30*time.Minute), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled, "query should pass through")
+	require.Equal(t, 0, hp.Calls(), "should not call ProvideHints when entirely in ingester window")
+}
+
+func TestDryRun_IngesterWindowEntries_ExcludedFromVerification(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-5 * time.Hour)
+	hintEnd := now.Add(-4 * time.Hour)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(
+			logproto.Entry{Timestamp: now.Add(-4*time.Hour - 30*time.Minute), Line: "covered"},
+			logproto.Entry{Timestamp: now.Add(-1 * time.Hour), Line: "in ingester window"},
+		), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3, QueryIngestersWithin: 3 * time.Hour}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "covered"`, now.Add(-6*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run verification")
+	require.NotEmpty(t, logLine)
+	require.Contains(t, logLine, "correct=true")
+	require.Contains(t, logLine, "total_entries=1", "ingester-window entry should be excluded")
+	require.Contains(t, logLine, "false_negatives=0")
+}
+
+func TestDryRun_QueryFinishesBeforeHints(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-40 * time.Minute)},
+			},
+		},
+		delay: 200 * time.Millisecond,
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return emptyStreamResponse(), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3, HintTimeout: 5 * time.Second}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return hp.SawCancel() }, time.Second, 10*time.Millisecond)
+
+	logLine := findLogLine(logs.String(), "logline dry-run hint lookup incomplete")
+	require.NotEmpty(t, logLine)
+	require.Contains(t, logLine, "query_timeout=false")
+	require.Contains(t, logLine, "query_hash=")
+}
+
+func TestDryRun_ClientTimeout_HintLookupCompleted(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	// Simulate a client timeout by cancelling the context while the query
+	// is in flight. The hint lookup (no delay) will finish first.
+	queryCtx, cancelQuery := context.WithCancel(testTenantContext())
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		time.Sleep(25 * time.Millisecond)
+		cancelQuery()
+		return nil, context.Canceled
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3, HintTimeout: 5 * time.Second}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(queryCtx, req)
+	require.Error(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run verification")
+	require.NotEmpty(t, logLine, "should log verification even when query times out")
+	require.Contains(t, logLine, "correct=true")
+	require.Contains(t, logLine, "query_timeout=true")
+	require.Contains(t, logLine, "query_hash=")
+	require.Contains(t, logLine, "hint_ranges=1")
+	summary := summarizeDryRunHints([]hintprovider.HintTimeRange{{Start: hintStart, End: hintEnd}}, req.StartTs, req.EndTs, req.EndTs, req.Direction)
+	require.Contains(t, logLine, "hint_total_seconds="+summary.hintTotalSeconds)
+	require.Contains(t, logLine, "earliest_hint_time="+summary.earliestHintTime)
+	require.Contains(t, logLine, "latest_hint_time="+summary.latestHintTime)
+	require.Contains(t, logLine, "initial_skip_seconds="+summary.initialSkipSeconds)
+	require.Contains(t, logLine, "hint_ranges_checksum="+summary.rangesChecksum)
+}
+
+func TestDryRun_ClientTimeout_HintLookupIncomplete(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+		delay: 500 * time.Millisecond,
+	}
+
+	// Simulate a client timeout: cancel the context, and the hint lookup
+	// is slow enough that it won't finish in time.
+	queryCtx, cancelQuery := context.WithCancel(testTenantContext())
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		cancelQuery()
+		return nil, context.Canceled
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3, HintTimeout: 5 * time.Second}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(queryCtx, req)
+	require.Error(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run hint lookup incomplete")
+	require.NotEmpty(t, logLine, "should log hint lookup incomplete on client timeout")
+	require.Contains(t, logLine, "query_timeout=true")
+	require.Contains(t, logLine, "query_hash=")
+}
+
+func TestDryRun_ClientTimeout_HintLookupCancelledByContext(t *testing.T) {
+	// The hint lookup goroutine finishes (done channel closes) but with a
+	// context.Canceled error because the parent context was cancelled.
+	// This should be logged as "incomplete" with query_timeout=true.
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+		delay: 50 * time.Millisecond,
+	}
+
+	queryCtx, cancelQuery := context.WithCancel(testTenantContext())
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		cancelQuery()
+		time.Sleep(100 * time.Millisecond)
+		return nil, context.Canceled
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3, HintTimeout: 5 * time.Second}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(queryCtx, req)
+	require.Error(t, err)
+
+	logLine := findLogLine(logs.String(), "logline dry-run hint lookup incomplete")
+	require.NotEmpty(t, logLine, "context-cancelled hint lookup should be treated as incomplete")
+	require.Contains(t, logLine, "query_timeout=true")
+	require.Contains(t, logLine, "query_hash=")
+}
+
+func TestDryRun_RateLimitSkipsSecondDryRun(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-40 * time.Minute)},
+			},
+		},
+	}
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	callNum := 0
+	var callMu sync.Mutex
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		callMu.Lock()
+		callNum++
+		current := callNum
+		callMu.Unlock()
+		if current == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		return streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-43 * time.Minute), Line: "failure"}), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContext()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+		_, err := handler.Do(ctx, req)
+		firstDone <- err
+	}()
+
+	<-firstStarted
+	secondReq := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, secondReq)
+	require.NoError(t, err)
+
+	close(releaseFirst)
+	require.NoError(t, <-firstDone)
+	require.Eventually(t, func() bool { return hp.Calls() == 1 }, time.Second, 10*time.Millisecond,
+		"second dry-run should skip hint lookup due to inflight rate limit")
+
+	logLine := findLogLine(logs.String(), "dry-run hint lookup skipped due to inflight limit")
+	require.NotEmpty(t, logLine)
+	require.Contains(t, logLine, "query_hash=")
+}
+
+func TestDryRun_UnsupportedQuerySkipped(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)}}},
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3}
+	handler := buildStack(hp, cfg, newTestMetrics(), next)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"}`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled)
+	require.Equal(t, 0, hp.Calls(), "unsupported query should not invoke dry-run hint lookup")
+}
+
+func TestDryRun_StatsBelowThresholdSkipped(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	queryCalls := 0
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		queryCalls++
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		&logproto.IndexStatsResponse{Bytes: 100},
+		nil,
+		&statsCalls,
+		queryHandler,
+	)
+
+	cfg := MiddlewareConfig{DryRun: true, NgramLength: 3, MinQueryBytesForIndex: 500}
+	handler := buildStack(hp, cfg, newTestMetrics(), querier)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, statsCalls, "should call index stats once for dry-run gating")
+	require.Equal(t, 0, hp.Calls(), "should skip dry-run hint lookup when query bytes are below threshold")
+	require.Equal(t, 1, queryCalls, "should execute query via passthrough path")
+	require.Equal(t, req.StartTs, gotStart, "query should keep original start when dry-run is skipped")
+	require.Equal(t, req.EndTs, gotEnd, "query should keep original end when dry-run is skipped")
+}
+
+func TestDryRun_HeaderGated_WithHeader(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-35 * time.Minute), Line: "failure"}), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, RequireOptInHeader: true, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContextWithDryRun()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "header-gated dry-run with header should perform hint lookup")
+
+	logLine := findLogLine(logs.String(), "logline dry-run verification")
+	require.NotEmpty(t, logLine, "should produce verification log")
+}
+
+func TestDryRun_HeaderGated_WithoutHeader(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: true, RequireOptInHeader: true, NgramLength: 3}
+	handler := buildStack(hp, cfg, newTestMetrics(), next)
+	ctx := testTenantContext() // no header
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled, "header-gated dry-run without header should passthrough")
+	require.Equal(t, 0, hp.Calls(), "should not perform hint lookup without opt-in header")
+}
+
+func TestWrapMiddleware_Disabled(t *testing.T) {
+	wrapped, storeSvc, cleanup, err := WrapMiddleware(
+		loki.ConfigWrapper{},
+		Config{Enabled: false},
+		nil,
+		nil,
+		log.NewNopLogger(),
+		prometheus.NewRegistry(),
+	)
+	require.NoError(t, err)
+	require.Nil(t, storeSvc)
+	require.NotNil(t, cleanup)
+
+	calls := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		calls++
+		return emptyStreamResponse(), nil
+	})
+
+	handler := wrapped.Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, time.Now().Add(-1*time.Hour), time.Now())
+	_, err = handler.Do(testTenantContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "disabled config should leave middleware as identity")
+	cleanup()
+}
+
+func TestPrefetchFilter_QueryBytesBelowThreshold_SkipsHintPrefetch(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	queryCalls := 0
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		queryCalls++
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		&logproto.IndexStatsResponse{Bytes: 100},
+		nil,
+		&statsCalls,
+		queryHandler,
+	)
+
+	cfg := MiddlewareConfig{MinQueryBytesForIndex: 500}
+	handler := buildStack(hp, cfg, newTestMetrics(), querier)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, statsCalls, "should call index stats once for gating")
+	require.Equal(t, 0, hp.Calls(), "should skip hint prefetch when query bytes are below threshold")
+	require.Equal(t, 1, queryCalls, "should execute query via passthrough path")
+	require.Equal(t, req.StartTs, gotStart, "query should keep original start when hints are skipped")
+	require.Equal(t, req.EndTs, gotEnd, "query should keep original end when hints are skipped")
+}
+
+func TestPrefetchFilter_QueryBytesAboveThreshold_UsesHints(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	queryCalls := 0
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		queryCalls++
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		&logproto.IndexStatsResponse{Bytes: 1000},
+		nil,
+		&statsCalls,
+		queryHandler,
+	)
+
+	cfg := MiddlewareConfig{MinQueryBytesForIndex: 500}
+	handler := buildStack(hp, cfg, newTestMetrics(), querier)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, statsCalls, "should call index stats once for gating")
+	require.Equal(t, 1, hp.Calls(), "should prefetch hints when query bytes exceed threshold")
+	require.Equal(t, 1, queryCalls)
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestPrefetchFilter_TenantMinQueryBytesOverridesGlobalThreshold(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		&logproto.IndexStatsResponse{Bytes: 1000},
+		nil,
+		&statsCalls,
+		queryHandler,
+	)
+	settings := mockTenantSettings{
+		minQueryBytesForIndex: map[string]int64{"test": 500},
+	}
+
+	cfg := MiddlewareConfig{MinQueryBytesForIndex: 5000}
+	handler := buildStack(hp, cfg, newTestMetrics(), querier, settings)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, statsCalls, "should call index stats once for tenant gating")
+	require.Equal(t, 1, hp.Calls(), "tenant threshold should allow hint prefetch")
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestPrefetchFilter_QueryStatsError_SkipsHintPrefetch(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	queryCalls := 0
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		queryCalls++
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		nil,
+		errors.New("stats backend unavailable"),
+		&statsCalls,
+		queryHandler,
+	)
+
+	cfg := MiddlewareConfig{MinQueryBytesForIndex: 500}
+	handler := buildStack(hp, cfg, newTestMetrics(), querier)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, statsCalls, "should attempt index stats once for gating")
+	require.Equal(t, 0, hp.Calls(), "should skip hint prefetch when stats call fails")
+	require.Equal(t, 1, queryCalls, "should execute query via passthrough path")
+	require.Equal(t, req.StartTs, gotStart, "query should keep original start when stats fail")
+	require.Equal(t, req.EndTs, gotEnd, "query should keep original end when stats fail")
+}
+
+func TestPrefetchFilter_MinQueryBytesZero_DisablesStatsGating(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		&logproto.IndexStatsResponse{Bytes: 1000},
+		nil,
+		&statsCalls,
+		queryHandler,
+	)
+
+	cfg := MiddlewareConfig{MinQueryBytesForIndex: 0}
+	handler := buildStack(hp, cfg, newTestMetrics(), querier)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 0, statsCalls, "stats gating should be disabled when threshold is zero")
+	require.Equal(t, 1, hp.Calls(), "hint prefetch should run when stats gating is disabled")
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestPrefetchFilter_TenantMinQueryBytesZero_DisablesStatsGating(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		&logproto.IndexStatsResponse{Bytes: 1000},
+		nil,
+		&statsCalls,
+		queryHandler,
+	)
+	settings := mockTenantSettings{
+		minQueryBytesForIndex: map[string]int64{"test": 0},
+	}
+
+	cfg := MiddlewareConfig{MinQueryBytesForIndex: 500}
+	handler := buildStack(hp, cfg, newTestMetrics(), querier, settings)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 0, statsCalls, "tenant zero threshold should disable stats gating")
+	require.Equal(t, 1, hp.Calls(), "hint prefetch should run when tenant disables stats gating")
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestPrefetchFilter_HintPrefetchCompletedLogIncludesQueryBytes(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return emptyStreamResponse(), nil
+	})
+
+	statsCalls := 0
+	querier := buildStatsAwareQuerier(
+		&logproto.IndexStatsResponse{Bytes: 700},
+		nil,
+		&statsCalls,
+		queryHandler,
+	)
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{MinQueryBytesForIndex: 500}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, querier)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, statsCalls)
+
+	logLine := findLogLine(logs.String(), "hint prefetch completed")
+	require.NotEmpty(t, logLine)
+	require.Contains(t, logLine, "query_bytes=700")
+	require.Contains(t, logLine, "hint_total_seconds=900.0")
+	require.Contains(t, logLine, "hint_ranges_detail=")
+	require.Contains(t, logLine, " +15m0s]")
+}
+
+func TestPrefetchFilter_SkipCacheHeaderSetsHintContext(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	ctx = httpreq.InjectHeader(ctx, LoglineSkipCacheHeader, "true")
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls())
+	require.True(t, hp.SawSkipCache(), "prefetch middleware should inject skip-cache context")
+}
+
+func TestPrefetchFilter_Unsupported(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		err: hintprovider.ErrUnsupported,
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled, "should pass through on ErrUnsupported")
+}
+
+func TestPrefetchFilter_ProviderError(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		err: errors.New("index unavailable"),
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled, "should pass through on provider error")
+}
+
+func TestPrefetchFilter_EmptyHints_SkipsQuerier(t *testing.T) {
+	// No matching documents → empty response, no querier call.
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: nil},
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	resp, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 0, nextCalled, "querier should NOT be called when hints are empty")
+
+	lokiResp, ok := resp.(*queryrange.LokiResponse)
+	require.True(t, ok)
+	require.Equal(t, "success", lokiResp.Status)
+}
+
+func TestPrefetchFilter_NarrowsToHintRanges(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestPrefetchFilter_PreMinDateHintSource_RecordsPassthrough(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	reqStart := now.Add(-90 * time.Minute)
+	reqEnd := now.Add(-75 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{
+					Start:  time.Time{},
+					End:    now.Add(-30 * time.Minute),
+					Source: hintprovider.HintSourcePreMinDate,
+				},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	var prefetchResult *hintPrefetchResult
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		prefetchResult = hintPrefetchFromContext(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, reqStart, reqEnd)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, prefetchResult)
+
+	require.Equal(t, reqStart.UTC(), gotStart, "pre-min-date hint should pass through original start")
+	require.Equal(t, reqEnd.UTC(), gotEnd, "pre-min-date hint should pass through original end")
+
+	impact := prefetchResult.impactSnapshot()
+	require.Equal(t, int64(1), impact.totalIntervals)
+	require.Equal(t, int64(0), impact.narrowedIntervals)
+	require.Equal(t, int64(1), impact.passthroughIntervals)
+}
+
+func TestPrefetchFilter_QueryStatsAttached(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-30 * time.Minute), End: now.Add(-20 * time.Minute)},
+			},
+		},
+	}
+
+	var prefetchResult *hintPrefetchResult
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		prefetchResult = hintPrefetchFromContext(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, prefetchResult)
+	stats := prefetchResult.stats
+	require.NotNil(t, stats)
+
+	snap := stats.Snapshot()
+	require.Equal(t, int32(1), snap.PrefetchCalls)
+	require.Equal(t, int32(0), snap.PrefetchTimeouts)
+}
+
+func TestPrefetchFilter_QueryStatsCountsTimeout(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: nil},
+		delay: 100 * time.Millisecond,
+	}
+
+	metrics := newTestMetrics()
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, MiddlewareConfig{RequireOptInHeader: true}, nil, metrics, nil)
+	filterMW := NewLoglineFilterMiddleware(10*time.Millisecond, metrics, nil)
+	var prefetchResult *hintPrefetchResult
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		prefetchResult = hintPrefetchFromContext(ctx)
+		return emptyStreamResponse(), nil
+	})
+	handler := prefetchMW.Wrap(filterMW.Wrap(next))
+
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, prefetchResult)
+	stats := prefetchResult.stats
+	require.NotNil(t, stats)
+	snap := stats.Snapshot()
+	require.Equal(t, int32(1), snap.PrefetchCalls)
+	require.Equal(t, int32(1), snap.PrefetchTimeouts)
+}
+
+func TestPrefetchFilter_MultipleHintRanges(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	r1 := hintprovider.HintTimeRange{Start: now.Add(-50 * time.Minute), End: now.Add(-45 * time.Minute)}
+	r2 := hintprovider.HintTimeRange{Start: now.Add(-20 * time.Minute), End: now.Add(-10 * time.Minute)}
+
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{r1, r2},
+		},
+	}
+
+	var mu sync.Mutex
+	var gotStarts []time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		mu.Lock()
+		gotStarts = append(gotStarts, lokiReq.StartTs)
+		mu.Unlock()
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, gotStarts, 2, "should dispatch one sub-request per hint range")
+	require.Contains(t, gotStarts, r1.Start)
+	require.Contains(t, gotStarts, r2.Start)
+}
+
+// --- Ingester window tests ---
+
+func TestPrefetchFilter_IngesterWindowOnly(t *testing.T) {
+	// Entire query within ingester window → pass through, no hint lookup.
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{QueryIngestersWithin: 3 * time.Hour}
+	handler := buildStack(hp, cfg, newTestMetrics(), next)
+	ctx := testTenantContextWithLive()
+	// Query last 2h — entirely within 3h ingester window.
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-2*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled, "should pass through entire query")
+	require.Equal(t, 0, hp.Calls(), "should not call ProvideHints")
+}
+
+func TestPrefetchFilter_IngesterWindowPassthrough(t *testing.T) {
+	// Query spans covered + ingester window. The filter should pass through
+	// intervals in the ingester window but narrow covered intervals.
+	now := time.Now().Truncate(time.Millisecond)
+	hintRange := hintprovider.HintTimeRange{
+		Start: now.Add(-5 * time.Hour),
+		End:   now.Add(-4 * time.Hour),
+	}
+
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{hintRange},
+		},
+	}
+
+	// Simulate SplitByInterval dispatching two intervals:
+	// 1. Covered interval: [-6h, -3h]
+	// 2. Ingester interval: [-3h, now]
+	cfg := MiddlewareConfig{QueryIngestersWithin: 3 * time.Hour}
+	metrics := newTestMetrics()
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, nil, metrics, nil)
+
+	var mu sync.Mutex
+	type subReqInfo struct {
+		start, end time.Time
+	}
+	var gotReqs []subReqInfo
+
+	// The filter + querier for both intervals.
+	filterMW := NewLoglineFilterMiddleware(10*time.Second, metrics, nil)
+	querier := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		mu.Lock()
+		gotReqs = append(gotReqs, subReqInfo{start: lokiReq.StartTs, end: lokiReq.EndTs})
+		mu.Unlock()
+		return emptyStreamResponse(), nil
+	})
+
+	// Fake "SplitByInterval" that dispatches two intervals.
+	splitSimulator := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		filteredQuerier := filterMW.Wrap(querier)
+
+		// Interval 1: covered
+		covered := lokiReq.WithStartEnd(now.Add(-6*time.Hour), now.Add(-3*time.Hour))
+		resp1, err := filteredQuerier.Do(ctx, covered)
+		if err != nil {
+			return nil, err
+		}
+
+		// Interval 2: ingester window
+		ingester := lokiReq.WithStartEnd(now.Add(-3*time.Hour), now)
+		resp2, err := filteredQuerier.Do(ctx, ingester)
+		if err != nil {
+			return nil, err
+		}
+
+		return queryrange.DefaultCodec.MergeResponse(resp1, resp2)
+	})
+
+	handler := prefetchMW.Wrap(splitSimulator)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-6*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+
+	// Covered interval should be narrowed to the hint range.
+	// Ingester interval should pass through to querier.
+	require.Len(t, gotReqs, 2, "should have narrowed + ingester sub-requests")
+
+	// One should be the hint range, one should be the ingester window.
+	hasNarrowed := false
+	hasIngester := false
+	for _, r := range gotReqs {
+		if r.start.Equal(hintRange.Start) && r.end.Equal(hintRange.End) {
+			hasNarrowed = true
+		}
+		if r.end.Equal(now) {
+			hasIngester = true
+		}
+	}
+	require.True(t, hasNarrowed, "should have a narrowed sub-request")
+	require.True(t, hasIngester, "should have an ingester passthrough sub-request")
+}
+
+func TestPrefetchFilter_24hQueryWith3hIngesterWindow(t *testing.T) {
+	// Past-24h query, 3h ingester window, full coverage.
+	// Covered interval should narrow to hint range.
+	// Ingester interval should pass through.
+	now := time.Now().Truncate(time.Millisecond)
+	hintRange := hintprovider.HintTimeRange{
+		Start: now.Add(-12 * time.Hour),
+		End:   now.Add(-10 * time.Hour),
+	}
+
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{hintRange},
+		},
+	}
+
+	cfg := MiddlewareConfig{QueryIngestersWithin: 3 * time.Hour}
+	metrics := newTestMetrics()
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, nil, metrics, nil)
+	filterMW := NewLoglineFilterMiddleware(10*time.Second, metrics, nil)
+
+	var mu sync.Mutex
+	type subReqInfo struct{ start, end time.Time }
+	var gotReqs []subReqInfo
+	querier := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		mu.Lock()
+		gotReqs = append(gotReqs, subReqInfo{start: lokiReq.StartTs, end: lokiReq.EndTs})
+		mu.Unlock()
+		return emptyStreamResponse(), nil
+	})
+
+	// Fake split: [-24h, -3h] and [-3h, now]
+	splitSim := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		fq := filterMW.Wrap(querier)
+		resp1, err := fq.Do(ctx, req.WithStartEnd(now.Add(-24*time.Hour), now.Add(-3*time.Hour)))
+		if err != nil {
+			return nil, err
+		}
+		resp2, err := fq.Do(ctx, req.WithStartEnd(now.Add(-3*time.Hour), now))
+		if err != nil {
+			return nil, err
+		}
+		return queryrange.DefaultCodec.MergeResponse(resp1, resp2)
+	})
+
+	handler := prefetchMW.Wrap(splitSim)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-24*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+
+	// Covered interval [-24h, -3h] should narrow to hint range [-12h, -10h].
+	// Ingester interval [-3h, now] should pass through.
+	require.Equal(t, 2, len(gotReqs), "expected narrowed + ingester sub-requests, got %d", len(gotReqs))
+
+	hasNarrowed := false
+	hasIngester := false
+	for _, r := range gotReqs {
+		if r.start.Equal(hintRange.Start) && r.end.Equal(hintRange.End) {
+			hasNarrowed = true
+		}
+		if r.end.Equal(now) {
+			hasIngester = true
+			dur := r.end.Sub(r.start)
+			require.InDelta(t, (3 * time.Hour).Seconds(), dur.Seconds(), 5)
+		}
+	}
+	require.True(t, hasNarrowed, "should have narrowed sub-request")
+	require.True(t, hasIngester, "should have ingester passthrough")
+}
+
+func TestPrefetchFilter_ImpactCountersAcrossSkipNarrowPassthrough(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintRange := hintprovider.HintTimeRange{
+		Start: now.Add(-6 * time.Hour),
+		End:   now.Add(-5 * time.Hour),
+	}
+
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{hintRange}},
+	}
+
+	cfg := MiddlewareConfig{QueryIngestersWithin: 2 * time.Hour}
+	metrics := newTestMetrics()
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, nil, metrics, nil)
+	filterMW := NewLoglineFilterMiddleware(10*time.Second, metrics, nil)
+
+	var prefetchResult *hintPrefetchResult
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return emptyStreamResponse(), nil
+	})
+
+	// Simulate SplitByInterval producing three intervals:
+	// 1) covered but no overlap with hints => skipped
+	// 2) covered overlap => narrowed
+	// 3) ingester window => passthrough
+	splitSim := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		prefetchResult = hintPrefetchFromContext(ctx)
+		require.NotNil(t, prefetchResult)
+
+		filtered := filterMW.Wrap(next)
+		resp1, err := filtered.Do(ctx, req.WithStartEnd(now.Add(-8*time.Hour), now.Add(-7*time.Hour)))
+		require.NoError(t, err)
+		resp2, err := filtered.Do(ctx, req.WithStartEnd(now.Add(-7*time.Hour), now.Add(-4*time.Hour)))
+		require.NoError(t, err)
+		resp3, err := filtered.Do(ctx, req.WithStartEnd(now.Add(-1*time.Hour), now))
+		require.NoError(t, err)
+		return queryrange.DefaultCodec.MergeResponse(resp1, resp2, resp3)
+	})
+
+	handler := prefetchMW.Wrap(splitSim)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-8*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, prefetchResult)
+
+	impact := prefetchResult.impactSnapshot()
+	require.Equal(t, int64(3), impact.totalIntervals)
+	require.Equal(t, int64(1), impact.skippedIntervals)
+	require.Equal(t, int64(1), impact.narrowedIntervals)
+	require.Equal(t, int64(1), impact.passthroughIntervals)
+	require.Equal(t, 5*time.Hour, impact.originalDuration)
+	require.Equal(t, 2*time.Hour, impact.queryDuration)
+	require.InDelta(t, 0.6, impact.timeReductionRatio, 0.0001)
+}
+
+func TestPrefetchFilter_LogsHintImpactSummary(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{
+					Start: now.Add(-45 * time.Minute),
+					End:   now.Add(-15 * time.Minute),
+				},
+			},
+		},
+	}
+
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		resp := emptyStreamResponse()
+		resp.Statistics.Querier.Store.TotalChunksRef = 10
+		resp.Statistics.Querier.Store.TotalChunksDownloaded = 4
+		resp.Statistics.Querier.Store.Chunk.DecompressedBytes = 1024
+		resp.Statistics.Querier.Store.Chunk.DecompressedLines = 100
+		resp.Statistics.Ingester.Store.TotalChunksRef = 2
+		resp.Statistics.Ingester.Store.TotalChunksDownloaded = 1
+		resp.Statistics.Ingester.Store.Chunk.DecompressedBytes = 128
+		resp.Statistics.Ingester.Store.Chunk.DecompressedLines = 10
+		resp.Statistics.Summary.TotalEntriesReturned = 9
+		return resp, nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	handler := buildStackWithLogger(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), logger, next)
+	ctx := testTenantContextWithLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+
+	logLine := findLogLine(logs.String(), "query hint impact")
+	require.NotEmpty(t, logLine)
+	require.Contains(t, logLine, "total_intervals=1")
+	require.Contains(t, logLine, "skipped_intervals=0")
+	require.Contains(t, logLine, "narrowed_intervals=1")
+	require.Contains(t, logLine, "passthrough_intervals=0")
+	require.Contains(t, logLine, "time_reduction_ratio=0.5")
+	require.Contains(t, logLine, "total_chunks_ref=12")
+	require.Contains(t, logLine, "total_chunks_downloaded=5")
+	require.Contains(t, logLine, "decompressed_bytes=1152")
+	require.Contains(t, logLine, "decompressed_lines=110")
+	require.Contains(t, logLine, "total_entries_returned=9")
+}
+
+// --- rangesOverlapping tests ---
+
+func TestRangesOverlapping(t *testing.T) {
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	ranges := []hintprovider.HintTimeRange{
+		{Start: base.Add(10 * time.Minute), End: base.Add(20 * time.Minute)},
+		{Start: base.Add(30 * time.Minute), End: base.Add(40 * time.Minute)},
+		{Start: base.Add(50 * time.Minute), End: base.Add(60 * time.Minute)},
+	}
+
+	tests := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+		want  int
+	}{
+		{"before all", base, base.Add(5 * time.Minute), 0},
+		{"after all", base.Add(70 * time.Minute), base.Add(80 * time.Minute), 0},
+		{"overlaps first", base.Add(15 * time.Minute), base.Add(25 * time.Minute), 1},
+		{"overlaps all", base, base.Add(70 * time.Minute), 3},
+		{"between ranges", base.Add(21 * time.Minute), base.Add(29 * time.Minute), 0},
+		{"exact match", base.Add(30 * time.Minute), base.Add(40 * time.Minute), 1},
+		{"overlaps two", base.Add(15 * time.Minute), base.Add(35 * time.Minute), 2},
+		{"empty ranges", base, base.Add(70 * time.Minute), 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rangesOverlapping(ranges, tc.start, tc.end)
+			require.Len(t, got, tc.want)
+		})
+	}
+
+	// Empty input.
+	require.Nil(t, rangesOverlapping(nil, base, base.Add(time.Hour)))
+}
+
+func testTime(n int) time.Time {
+	return time.Date(2025, 1, 1, 0, 0, n, 0, time.UTC)
+}
+
+func TestEmptyLokiResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *queryrange.LokiRequest
+		wantDir   logproto.Direction
+		wantLimit uint32
+		wantVer   uint32
+	}{
+		{
+			name: "forward query with limit",
+			req: &queryrange.LokiRequest{
+				Direction: logproto.FORWARD,
+				Limit:     1000,
+				Path:      "/loki/api/v1/query_range",
+			},
+			wantDir:   logproto.FORWARD,
+			wantLimit: 1000,
+			wantVer:   uint32(loghttp.VersionV1),
+		},
+		{
+			name: "backward query with limit",
+			req: &queryrange.LokiRequest{
+				Direction: logproto.BACKWARD,
+				Limit:     500,
+				Path:      "/loki/api/v1/query_range",
+			},
+			wantDir:   logproto.BACKWARD,
+			wantLimit: 500,
+			wantVer:   uint32(loghttp.VersionV1),
+		},
+		{
+			name: "legacy path",
+			req: &queryrange.LokiRequest{
+				Direction: logproto.FORWARD,
+				Limit:     42,
+				Path:      "/api/prom/query",
+			},
+			wantDir:   logproto.FORWARD,
+			wantLimit: 42,
+			wantVer:   uint32(loghttp.VersionLegacy),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := emptyLokiResponse(tc.req)
+
+			require.Equal(t, "success", resp.Status)
+			require.Equal(t, tc.wantDir, resp.Direction)
+			require.Equal(t, tc.wantLimit, resp.Limit)
+			require.Equal(t, tc.wantVer, resp.Version)
+			require.Equal(t, loghttp.ResultTypeStream, resp.Data.ResultType)
+			require.Empty(t, resp.Data.Result)
+		})
+	}
+}
+
+func TestEmptyLokiResponseMergesSafely(t *testing.T) {
+	req := &queryrange.LokiRequest{
+		Direction: logproto.FORWARD,
+		Limit:     100,
+		Path:      "/loki/api/v1/query_range",
+	}
+
+	empty := emptyLokiResponse(req)
+	real := &queryrange.LokiResponse{
+		Status:    "success",
+		Direction: logproto.FORWARD,
+		Limit:     100,
+		Version:   uint32(loghttp.VersionV1),
+		Data: queryrange.LokiData{
+			ResultType: loghttp.ResultTypeStream,
+			Result: []logproto.Stream{
+				{
+					Labels: `{app="test"}`,
+					Entries: []logproto.Entry{
+						{Timestamp: testTime(1), Line: "line1"},
+						{Timestamp: testTime(2), Line: "line2"},
+					},
+				},
+			},
+		},
+	}
+
+	merged, err := queryrange.DefaultCodec.MergeResponse(empty, real)
+	require.NoError(t, err)
+
+	lokiMerged := merged.(*queryrange.LokiResponse)
+	require.Equal(t, logproto.FORWARD, lokiMerged.Direction, "direction must match the original request")
+	require.Equal(t, uint32(100), lokiMerged.Limit, "limit must match the original request")
+	require.Equal(t, uint32(loghttp.VersionV1), lokiMerged.Version, "version must match the original request")
+	require.Len(t, lokiMerged.Data.Result, 1, "real stream entries must survive the merge")
+	require.Len(t, lokiMerged.Data.Result[0].Entries, 2)
+}
+
+// ---------------------------------------------------------------------------
+// Header override tests
+// ---------------------------------------------------------------------------
+
+func TestResolveMode_HeaderOffOverridesAllConfig(t *testing.T) {
+	cases := []struct {
+		name               string
+		tenantMode         Mode
+		defaultMode        Mode
+		requireOptInHeader bool
+	}{
+		{name: "tenant unset global live", tenantMode: ModeUnset, defaultMode: ModeLive},
+		{name: "tenant unset global dry-run", tenantMode: ModeUnset, defaultMode: ModeDryRun},
+		{name: "tenant live", tenantMode: ModeLive, defaultMode: ModeDryRun},
+		{name: "tenant dry-run", tenantMode: ModeDryRun, defaultMode: ModeLive},
+		{name: "tenant off with opt-in required", tenantMode: ModeOff, defaultMode: ModeLive, requireOptInHeader: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, passthrough := resolveMode(string(LoglineIndexOff), tc.tenantMode, tc.defaultMode, tc.requireOptInHeader)
+			require.Equal(t, ModeOff, mode)
+			require.True(t, passthrough)
+		})
+	}
+}
+
+func TestHeaderOff_OverridesEnabledConfigAndTenantLive(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+	settings := mockTenantSettings{
+		modes: map[string]Mode{"test": ModeLive},
+	}
+
+	var gotStart, gotEnd time.Time
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: true, RequireOptInHeader: false, NgramLength: 3}
+	handler := buildStack(hp, cfg, newTestMetrics(), next, settings)
+	ctx := testTenantContextWithForceDisable()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled, "force-disable should pass through to Loki")
+	require.Equal(t, 0, hp.Calls(), "force-disable should skip hint lookups")
+	require.Equal(t, req.StartTs, gotStart, "force-disable should keep original start")
+	require.Equal(t, req.EndTs, gotEnd, "force-disable should keep original end")
+}
+
+func TestTenantMode_Off_OnlyExplicitModeHeaderOverridesTenantOff(t *testing.T) {
+	mode, passthrough := resolveMode("unexpected", ModeOff, ModeLive, false)
+	require.Equal(t, ModeOff, mode)
+	require.True(t, passthrough)
+
+	mode, passthrough = resolveMode(string(LoglineIndexLive), ModeOff, ModeDryRun, false)
+	require.Equal(t, ModeLive, mode)
+	require.False(t, passthrough)
+
+	mode, passthrough = resolveMode(string(LoglineIndexDryRun), ModeOff, ModeLive, false)
+	require.Equal(t, ModeDryRun, mode)
+	require.False(t, passthrough)
+}
+
+func TestDryRun_ForceLiveHeader_OverridesToLivePath(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, RequireOptInHeader: false, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContextWithForceLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "force-live should still call ProvideHints")
+	require.Equal(t, hintStart, gotStart, "force-live should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "force-live should narrow to hint end")
+
+	require.NotContains(t, logs.String(), "dry-run verification", "should NOT take dry-run path")
+}
+
+func TestDryRun_ForceLiveHeader_WithOptInRequired(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: true, RequireOptInHeader: true, NgramLength: 3}
+	handler := buildStack(hp, cfg, newTestMetrics(), next)
+	ctx := testTenantContextWithForceLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "force-live with requireOptInHeader should still activate (header is present)")
+	require.Equal(t, hintStart, gotStart, "should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "should narrow to hint end")
+}
+
+func TestDryRun_DryRunHeader_StaysInDryRun(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-35 * time.Minute), Line: "failure"}), nil
+	})
+
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	cfg := MiddlewareConfig{DryRun: true, RequireOptInHeader: true, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next)
+	ctx := testTenantContextWithDryRun()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "dry_run header should still call ProvideHints for verification")
+	require.Equal(t, req.StartTs, gotStart, "dry-run should NOT narrow query start")
+	require.Equal(t, req.EndTs, gotEnd, "dry-run should NOT narrow query end")
+	require.Contains(t, logs.String(), "dry-run verification", "should take dry-run path")
+}
+
+func TestTenantMode_Off_Passthrough(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+	settings := mockTenantSettings{
+		modes: map[string]Mode{"test": ModeOff},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{RequireOptInHeader: false}
+	handler := buildStack(hp, cfg, newTestMetrics(), next, settings)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 0, hp.Calls(), "off tenant mode should skip hint lookups")
+	require.Equal(t, req.StartTs, gotStart, "off tenant mode should keep original start")
+	require.Equal(t, req.EndTs, gotEnd, "off tenant mode should keep original end")
+}
+
+func TestTenantMode_Off_HeaderLive_ForcesLive(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+	settings := mockTenantSettings{
+		modes: map[string]Mode{"test": ModeOff},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: false, RequireOptInHeader: false}
+	handler := buildStack(hp, cfg, newTestMetrics(), next, settings)
+	ctx := testTenantContextWithForceLive()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "force-live should override tenant off mode")
+	require.Equal(t, hintStart, gotStart, "force-live should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "force-live should narrow to hint end")
+}
+
+func TestTenantMode_Off_HeaderDryRun_ForcesDryRun(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+	settings := mockTenantSettings{
+		modes: map[string]Mode{"test": ModeOff},
+	}
+
+	var gotStart, gotEnd time.Time
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: hintStart, Line: "failure"}), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: false, RequireOptInHeader: false, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next, settings)
+	ctx := testTenantContextWithDryRun()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "dry_run should override tenant off mode")
+	require.Equal(t, req.StartTs, gotStart, "dry_run should keep original start")
+	require.Equal(t, req.EndTs, gotEnd, "dry_run should keep original end")
+	require.Contains(t, logs.String(), "dry-run verification", "should take dry-run path")
+}
+
+func TestTenantMode_Live_OverridesGlobalDryRun(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+	settings := mockTenantSettings{
+		modes: map[string]Mode{"test": ModeLive},
+	}
+
+	var gotStart, gotEnd time.Time
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: true, RequireOptInHeader: false}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next, settings)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls())
+	require.Equal(t, hintStart, gotStart, "tenant live mode should narrow even when global dry-run is true")
+	require.Equal(t, hintEnd, gotEnd, "tenant live mode should narrow even when global dry-run is true")
+	require.NotContains(t, logs.String(), "dry-run verification", "tenant live mode should not execute dry-run path")
+}
+
+func TestTenantMode_DryRun_OverridesGlobalLive(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+	settings := mockTenantSettings{
+		modes: map[string]Mode{"test": ModeDryRun},
+	}
+
+	var gotStart, gotEnd time.Time
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		time.Sleep(25 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: hintStart, Line: "failure"}), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: false, RequireOptInHeader: false, NgramLength: 3}
+	handler := buildStackWithLogger(hp, cfg, newTestMetrics(), logger, next, settings)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "failure"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls())
+	require.Equal(t, req.StartTs, gotStart, "tenant dry-run mode should keep original start")
+	require.Equal(t, req.EndTs, gotEnd, "tenant dry-run mode should keep original end")
+	require.Contains(t, logs.String(), "dry-run verification", "tenant dry-run mode should execute dry-run path")
+}
+
+func TestTenantMode_Live_BypassesRequireOptInHeader(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+	settings := mockTenantSettings{
+		modes: map[string]Mode{"test": ModeLive},
+	}
+
+	var gotStart, gotEnd time.Time
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{DryRun: false, RequireOptInHeader: true}
+	handler := buildStack(hp, cfg, newTestMetrics(), next, settings)
+	ctx := testTenantContext()
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "tenant live mode should bypass opt-in-header gating")
+	require.Equal(t, hintStart, gotStart, "tenant live mode should narrow to hint start")
+	require.Equal(t, hintEnd, gotEnd, "tenant live mode should narrow to hint end")
+}

--- a/pkg/logline/queryfrontend/shard_planning_test.go
+++ b/pkg/logline/queryfrontend/shard_planning_test.go
@@ -8,14 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"go.yaml.in/yaml/v3"
+
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util/querylimits"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
 )

--- a/pkg/logline/queryfrontend/shard_planning_test.go
+++ b/pkg/logline/queryfrontend/shard_planning_test.go
@@ -1,0 +1,405 @@
+package queryfrontend
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
+)
+
+func defaultShardPlanningTestConfig() MiddlewareConfig {
+	return MiddlewareConfig{
+		RequireOptInHeader:    true,
+		NgramLength:           3,
+		MinQueryBytesForIndex: 0,
+		HintTimeout:           time.Second,
+		ShardPlanning: ShardPlanningConfig{
+			Enabled:               true,
+			MinTimeReductionRatio: 0.75,
+		},
+	}
+}
+
+func TestShardPlanningConfigValidationAndFlags(t *testing.T) {
+	cfg := MiddlewareConfig{}
+	require.NoError(t, cfg.Validate())
+	require.True(t, cfg.ShardPlanning.Enabled)
+	require.Equal(t, 0.75, cfg.ShardPlanning.MinTimeReductionRatio)
+
+	flagCfg := MiddlewareConfig{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagCfg.RegisterFlagsWithPrefix("logline-query-frontend", fs)
+	require.NotNil(t, fs.Lookup("logline-query-frontend.shard-planning.enabled"))
+	require.NotNil(t, fs.Lookup("logline-query-frontend.shard-planning.min-time-reduction-ratio"))
+	require.True(t, flagCfg.ShardPlanning.Enabled)
+	require.Equal(t, 0.75, flagCfg.ShardPlanning.MinTimeReductionRatio)
+
+	invalid := defaultShardPlanningTestConfig()
+	invalid.ShardPlanning.MinTimeReductionRatio = -0.1
+	require.ErrorContains(t, invalid.Validate(), "min_time_reduction_ratio")
+}
+
+func TestShardPlanningConfigYAMLDefaultsAndOptOut(t *testing.T) {
+	var cfg MiddlewareConfig
+	require.NoError(t, yaml.Unmarshal([]byte("{}"), &cfg))
+	require.NoError(t, cfg.Validate())
+	require.True(t, cfg.ShardPlanning.Enabled)
+	require.Equal(t, 0.75, cfg.ShardPlanning.MinTimeReductionRatio)
+
+	cfg = MiddlewareConfig{}
+	require.NoError(t, yaml.Unmarshal([]byte("shard_planning:\n  enabled: false\n"), &cfg))
+	require.NoError(t, cfg.Validate())
+	require.False(t, cfg.ShardPlanning.Enabled)
+	require.Equal(t, 0.75, cfg.ShardPlanning.MinTimeReductionRatio)
+}
+
+func TestShardPlanning_FirstQueryWinsReturnsUnchangedResponse(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+			{Start: now.Add(-40 * time.Minute), End: now.Add(-35 * time.Minute)},
+		}},
+		delay: 100 * time.Millisecond,
+	}
+
+	want := streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-10 * time.Minute), Line: "first"})
+	var calls atomic.Int64
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		calls.Add(1)
+		require.Nil(t, querylimits.ExtractQueryLimitsFromContext(ctx))
+		return want, nil
+	})
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, defaultShardPlanningTestConfig(), nil, newTestMetrics(), nil)
+	handler := prefetchMW.Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	resp, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Same(t, want, resp)
+	require.Equal(t, int64(1), calls.Load())
+}
+
+func TestShardPlanning_NarrowSingleHintRerunsWithQueryLimitsOverride(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	reqStart := now.Add(-1 * time.Hour)
+	reqEnd := now
+	hintRange := hintprovider.HintTimeRange{Start: now.Add(-35 * time.Minute), End: now.Add(-30 * time.Minute)}
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{hintRange}},
+		delay: 100 * time.Millisecond,
+	}
+
+	filterMW := NewLoglineFilterMiddleware(time.Second, newTestMetrics(), nil)
+	var gotOuterStart, gotOuterEnd time.Time
+	var gotInnerStart, gotInnerEnd time.Time
+	var gotStrategy string
+	var sawQueryLimits bool
+	firstCanceled := make(chan struct{})
+
+	querier := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotInnerStart = lokiReq.StartTs
+		gotInnerEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	var calls atomic.Int64
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		c := calls.Add(1)
+		if c == 1 {
+			<-ctx.Done()
+			close(firstCanceled)
+			return nil, ctx.Err()
+		}
+
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotOuterStart = lokiReq.StartTs
+		gotOuterEnd = lokiReq.EndTs
+		limits := querylimits.ExtractQueryLimitsFromContext(ctx)
+		sawQueryLimits = limits != nil
+		if limits != nil {
+			gotStrategy = limits.TSDBShardingStrategy
+		}
+		return filterMW.Wrap(querier).Do(ctx, req)
+	})
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, defaultShardPlanningTestConfig(), nil, newTestMetrics(), nil)
+	handler := prefetchMW.Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, reqStart, reqEnd)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		select {
+		case <-firstCanceled:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(2), calls.Load())
+	require.Equal(t, 1, hp.Calls(), "rerun must reuse the existing hint prefetch")
+	require.Equal(t, shardPlanningStrategyPowerOfTwo, gotStrategy)
+	require.True(t, sawQueryLimits)
+	require.Equal(t, reqStart, gotOuterStart, "rerun should preserve the original request start")
+	require.Equal(t, reqEnd, gotOuterEnd, "rerun should preserve the original request end")
+	require.Equal(t, hintRange.Start, gotInnerStart, "filter middleware should do the actual narrowing")
+	require.Equal(t, hintRange.End, gotInnerEnd)
+}
+
+func TestShardPlanning_ZeroOverlapsRerunsAndFilterReturnsEmptyResponse(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+			{Start: now.Add(-3 * time.Hour), End: now.Add(-2 * time.Hour)},
+		}},
+		delay: 100 * time.Millisecond,
+	}
+
+	filterMW := NewLoglineFilterMiddleware(time.Second, newTestMetrics(), nil)
+	querierCalls := 0
+	querier := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		querierCalls++
+		return emptyStreamResponse(), nil
+	})
+
+	var calls atomic.Int64
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		c := calls.Add(1)
+		if c == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return filterMW.Wrap(querier).Do(ctx, req)
+	})
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, defaultShardPlanningTestConfig(), nil, newTestMetrics(), nil)
+	handler := prefetchMW.Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	resp, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), calls.Load())
+	require.Equal(t, 0, querierCalls, "empty result should still be produced by the filter middleware")
+	lokiResp := resp.(*queryrange.LokiResponse)
+	require.Empty(t, lokiResp.Data.Result)
+}
+
+func TestShardPlanning_MultipleDisjointNarrowHintsRerunWithinThresholds(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	r1 := hintprovider.HintTimeRange{Start: now.Add(-50 * time.Minute), End: now.Add(-48 * time.Minute)}
+	r2 := hintprovider.HintTimeRange{Start: now.Add(-20 * time.Minute), End: now.Add(-18 * time.Minute)}
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{r1, r2}},
+		delay: 100 * time.Millisecond,
+	}
+
+	filterMW := NewLoglineFilterMiddleware(time.Second, newTestMetrics(), nil)
+	var mu sync.Mutex
+	var gotStarts []time.Time
+	querier := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		mu.Lock()
+		gotStarts = append(gotStarts, lokiReq.StartTs)
+		mu.Unlock()
+		return emptyStreamResponse(), nil
+	})
+
+	var calls atomic.Int64
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		c := calls.Add(1)
+		if c == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		limits := querylimits.ExtractQueryLimitsFromContext(ctx)
+		require.NotNil(t, limits)
+		require.Equal(t, shardPlanningStrategyPowerOfTwo, limits.TSDBShardingStrategy)
+		return filterMW.Wrap(querier).Do(ctx, req)
+	})
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, defaultShardPlanningTestConfig(), nil, newTestMetrics(), nil)
+	handler := prefetchMW.Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), calls.Load())
+	require.ElementsMatch(t, []time.Time{r1.Start, r2.Start}, gotStarts)
+}
+
+func TestShardPlanning_BroadOrUnsafeHintsFallBackToFirstQuery(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	baseCfg := defaultShardPlanningTestConfig()
+	firstResp := streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-10 * time.Minute), Line: "first"})
+
+	tests := []struct {
+		name string
+		cfg  MiddlewareConfig
+		hp   *mockHintProvider
+		req  *queryrange.LokiRequest
+	}{
+		{
+			name: "time reduction too small falls back",
+			cfg:  baseCfg,
+			hp: &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-50 * time.Minute), End: now.Add(-20 * time.Minute)},
+			}}},
+			req: newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now),
+		},
+		{
+			name: "hint provider error falls back",
+			cfg:  baseCfg,
+			hp:   &mockHintProvider{err: errors.New("hint backend down")},
+			req:  newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now),
+		},
+		{
+			name: "unsupported query falls back",
+			cfg:  baseCfg,
+			hp:   &mockHintProvider{err: hintprovider.ErrUnsupported},
+			req:  newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now),
+		},
+		{
+			name: "passthrough range falls back",
+			cfg:  baseCfg,
+			hp: &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+				{Start: time.Time{}, End: now.Add(-30 * time.Minute), Source: hintprovider.HintSourcePreMinDate},
+			}}},
+			req: newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now),
+		},
+		{
+			name: "ingester window request falls back",
+			cfg: func() MiddlewareConfig {
+				cfg := baseCfg
+				cfg.QueryIngestersWithin = 3 * time.Hour
+				return cfg
+			}(),
+			hp:  &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: nil}},
+			req: newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-30*time.Minute), now),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int64
+			next := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				calls.Add(1)
+				require.Nil(t, querylimits.ExtractQueryLimitsFromContext(ctx))
+				time.Sleep(20 * time.Millisecond)
+				return firstResp, nil
+			})
+
+			prefetchMW := NewLoglinePrefetchMiddleware(tc.hp, tc.cfg, nil, newTestMetrics(), nil)
+			handler := prefetchMW.Wrap(next)
+			resp, err := handler.Do(testTenantContextWithLive(), tc.req)
+			require.NoError(t, err)
+			require.Same(t, firstResp, resp)
+			require.Equal(t, int64(1), calls.Load())
+		})
+	}
+}
+
+func TestShardPlanning_DryRunModeNeverReruns(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	cfg := defaultShardPlanningTestConfig()
+	cfg.DryRun = true
+	hp := &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+		{Start: now.Add(-35 * time.Minute), End: now.Add(-30 * time.Minute)},
+	}}}
+
+	var calls atomic.Int64
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		calls.Add(1)
+		require.Nil(t, querylimits.ExtractQueryLimitsFromContext(ctx))
+		time.Sleep(20 * time.Millisecond)
+		return streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-33 * time.Minute), Line: "error"}), nil
+	})
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil)
+	handler := prefetchMW.Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithDryRun(), req)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), calls.Load())
+	require.Equal(t, 1, hp.Calls())
+}
+
+func TestShardPlanning_RerunGuardPreventsRecursion(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+		{Start: now.Add(-35 * time.Minute), End: now.Add(-30 * time.Minute)},
+	}}}
+
+	var calls atomic.Int64
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		calls.Add(1)
+		return emptyStreamResponse(), nil
+	})
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, defaultShardPlanningTestConfig(), nil, newTestMetrics(), nil)
+	handler := prefetchMW.Wrap(next)
+	ctx := withShardPlanningRerunGuard(testTenantContextWithLive())
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), calls.Load())
+	require.Equal(t, 0, hp.Calls())
+}
+
+func TestShardPlanning_PreservesExistingQueryLimitsOnRerun(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+			{Start: now.Add(-35 * time.Minute), End: now.Add(-30 * time.Minute)},
+		}},
+		delay: 100 * time.Millisecond,
+	}
+
+	var calls atomic.Int64
+	var gotLimits *querylimits.QueryLimits
+	var gotStrategy string
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		c := calls.Add(1)
+		if c == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		gotLimits = querylimits.ExtractQueryLimitsFromContext(ctx)
+		if gotLimits != nil {
+			gotStrategy = gotLimits.TSDBShardingStrategy
+		}
+		return emptyStreamResponse(), nil
+	})
+
+	prefetchMW := NewLoglinePrefetchMiddleware(hp, defaultShardPlanningTestConfig(), nil, newTestMetrics(), nil)
+	handler := prefetchMW.Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+
+	ctx := querylimits.InjectQueryLimitsIntoContext(testTenantContextWithLive(), querylimits.QueryLimits{MaxEntriesLimitPerQuery: 123})
+	_, err := handler.Do(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, gotLimits)
+	require.Equal(t, 123, gotLimits.MaxEntriesLimitPerQuery)
+	require.Equal(t, shardPlanningStrategyPowerOfTwo, gotStrategy)
+}
+
+func TestShardPlanningMetricDoesNotRequireRegisterer(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
+	require.NotNil(t, metrics.shardPlanningTotal)
+}

--- a/pkg/logline/queryfrontend/tenant_settings.go
+++ b/pkg/logline/queryfrontend/tenant_settings.go
@@ -1,0 +1,26 @@
+package queryfrontend
+
+// Mode controls how logline query frontend handling behaves for a tenant.
+type Mode int
+
+const (
+	ModeUnset Mode = iota
+	ModeOff
+	ModeDryRun
+	ModeLive
+)
+
+// TenantSettings provides per-tenant overrides for logline query frontend
+// behavior. Implementations must be safe for concurrent use.
+type TenantSettings interface {
+	Mode(tenant string) Mode
+	// MinQueryBytesForIndex returns an optional per-tenant stats-gating threshold.
+	// A value of 0 disables stats gating; implementations must not return negatives.
+	MinQueryBytesForIndex(tenant string) (int64, bool)
+}
+
+type staticTenantSettings struct{}
+
+func (staticTenantSettings) Mode(string) Mode { return ModeUnset }
+
+func (staticTenantSettings) MinQueryBytesForIndex(string) (int64, bool) { return 0, false }

--- a/pkg/logline/version_test.go
+++ b/pkg/logline/version_test.go
@@ -1012,7 +1012,7 @@ func writeIndexAtPath(t *testing.T, version, path string, docs []format.Document
 	t.Helper()
 
 	// Disable density filter so general-correctness tests get exact intersection semantics.
-	// Density-filter behaviour is covered by dedicated tests in pkg/logline/v3/.
+	// Density-filter behaviour is covered by dedicated tests in pkg/logline/internal/v3/.
 	writer, err := NewWriter(version, path, docs, &format.WriterConfig{DensityThreshold: -1})
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR moves logline's packages `queryfrontend` and `limits` into Loki, under
`pkg/logline/queryfrontend` and `pkg/logline/limits`.

**Note on `sync/atomic`**: the fix-up swaps the `sync/atomic` counters in
`queryfrontend/middleware.go` (`atomic.AddInt64` / `atomic.LoadInt64` over raw
`int64` fields) for `go.uber.org/atomic` types (`atomic.Int64` with `.Add()` /
`.Load()`). Loki's `faillint` config bans `sync/atomic` in favor of
`go.uber.org/atomic`, so this keeps the behavior identical while satisfying the
linter.
