### PR TITLE
fix(querier): Stop reporting a cancelled tail teardown as an error

### DIFF
--- a/pkg/querier/tail/tail.go
+++ b/pkg/querier/tail/tail.go
@@ -226,7 +226,7 @@ func (t *Tailer) readTailClient(addr string, querierTailClient logproto.Querier_
 		resp, err = querierTailClient.Recv()
 		if err != nil {
 			// We don't want to log error when its due to stopping the tail request
-			if !stopped {
+			if !t.stopped.Load() {
 				level.Error(logger).Log("msg", "Error receiving response from grpc tail client", "err", err)
 			}
 			break


### PR DESCRIPTION
fixes #24463
