### PR TITLE
perf(queue): Keep tenant queues after they drain to reduce allocations in query scheduler

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -78,7 +78,7 @@ func NewRequestQueue(maxOutstandingPerTenant int, forgetDelay time.Duration, lim
 	}
 
 	q.cond = contextCond{Cond: sync.NewCond(&q.mtx)}
-	q.Service = services.NewTimerService(forgetCheckPeriod, nil, q.forgetDisconnectedConsumers, q.stopping).WithName("request queue")
+	q.Service = services.NewTimerService(forgetCheckPeriod, nil, q.cleanup, q.stopping).WithName("request queue")
 
 	return q
 }
@@ -109,6 +109,8 @@ func (q *RequestQueue) Enqueue(tenant string, path []string, req Request, succes
 
 	queue, err := q.queues.getOrAddQueue(tenant, path)
 	if err != nil {
+		// decrement, because we already optimistically increased the counter
+		q.queues.perUserQueueLen.Dec(tenant)
 		return fmt.Errorf("no queue found: %w", err)
 	}
 
@@ -182,14 +184,14 @@ func (q *RequestQueue) dequeue(ctx context.Context, last QueueIndex, wantedQueue
 FindQueue:
 	// We need to wait if there are no tenants, or no pending requests for given querier.
 	// However, if `wantedQueueName` is not empty, the caller must not be blocked because it wants to read exactly from that queue, not others.
-	for (q.queues.hasNoTenantQueues() || querierWait) && ctx.Err() == nil && !q.stopped && wantedQueueName == anyQueue {
+	for (q.queues.hasNoPendingRequests() || querierWait) && ctx.Err() == nil && !q.stopped && wantedQueueName == anyQueue {
 		querierWait = false
 		q.cond.Wait(ctx)
 	}
 
 	// If the current consumer wants to read from specific queue, but he does not have any queues available for him,
 	// return an error to notify that queue has been already removed.
-	if q.queues.hasNoTenantQueues() && wantedQueueName != anyQueue {
+	if q.queues.hasNoPendingRequests() && wantedQueueName != anyQueue {
 		return nil, last, wantedQueueName, false, ErrQueueWasRemoved
 	}
 
@@ -228,11 +230,11 @@ FindQueue:
 		return nil, last, queue.Name(), false, ErrQueueWasRemoved
 	}
 	// Pick next request from the queue.
+	// A drained queue is not removed here, but by cleanup once it has been idle
+	// for a while. That avoids re-creating the queue for every request of a
+	// tenant whose queue depth oscillates around zero.
 	request := queue.Dequeue()
 	isTenantQueueEmpty := queue.Len() == 0
-	if isTenantQueueEmpty {
-		q.queues.deleteQueue(tenant)
-	}
 
 	q.queues.perUserQueueLen.Dec(tenant)
 	q.metrics.queueLength.WithLabelValues(tenant).Dec()
@@ -243,7 +245,8 @@ FindQueue:
 	return request, last, queue.Name(), isTenantQueueEmpty, nil
 }
 
-func (q *RequestQueue) forgetDisconnectedConsumers(_ context.Context) error {
+// cleanup forgets disconnected consumers and removes idle tenant queues.
+func (q *RequestQueue) cleanup(_ context.Context) error {
 	q.mtx.Lock()
 	defer q.mtx.Unlock()
 
@@ -253,6 +256,8 @@ func (q *RequestQueue) forgetDisconnectedConsumers(_ context.Context) error {
 		q.cond.Broadcast()
 	}
 
+	q.queues.removeIdleQueues()
+
 	return nil
 }
 
@@ -260,7 +265,7 @@ func (q *RequestQueue) stopping(_ error) error {
 	q.mtx.Lock()
 	defer q.mtx.Unlock()
 
-	for !q.queues.hasNoTenantQueues() && q.connectedConsumers.Load() > 0 {
+	for !q.queues.hasNoPendingRequests() && q.connectedConsumers.Load() > 0 {
 		q.cond.Wait(context.Background())
 	}
 

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -505,6 +505,55 @@ func Test_Queue_DequeueMany(t *testing.T) {
 	}
 }
 
+func BenchmarkEnqueueDequeueCycle(b *testing.B) {
+	// Default of -query-scheduler.max-outstanding-requests-per-tenant.
+	const maxOutstandingPerTenant = 32000
+
+	queue := NewRequestQueue(maxOutstandingPerTenant, 0, noQueueLimits, NewMetrics(nil, constants.Loki, "query_scheduler"))
+	queue.RegisterConsumerConnection("consumer")
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if err := queue.Enqueue("tenant", nil, "request", nil); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := queue.Dequeue(ctx, StartIndexWithLocalQueue, "consumer"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestQueueIsRetainedAfterItDrains(t *testing.T) {
+	queue := NewRequestQueue(10, 0, noQueueLimits, NewMetrics(nil, constants.Loki, "query_scheduler"))
+	queue.RegisterConsumerConnection("consumer")
+
+	require.NoError(t, queue.Enqueue("tenant", nil, "request", nil))
+
+	req, _, err := queue.Dequeue(context.Background(), StartIndexWithLocalQueue, "consumer")
+	require.NoError(t, err)
+	require.Equal(t, "request", req)
+
+	// The drained queue is kept, so that the next request of the same tenant
+	// does not have to allocate a new one.
+	require.NotNil(t, queue.queues.mapping.GetByKey("tenant"))
+
+	// The retained queue is empty and must not be handed out to a consumer.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	req, _, err = queue.Dequeue(ctx, StartIndexWithLocalQueue, "consumer")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, req)
+
+	// Idle queues are removed by the periodic cleanup. The first run only
+	// resets the usage flag.
+	require.NoError(t, queue.cleanup(context.Background()))
+	require.NotNil(t, queue.queues.mapping.GetByKey("tenant"))
+	require.NoError(t, queue.cleanup(context.Background()))
+	require.Nil(t, queue.queues.mapping.GetByKey("tenant"))
+}
+
 func TestDequeueAfterEnqueueFails(t *testing.T) {
 	// Create a RequestQueue with maxOutstandingPerTenant=0
 	// This will cause all enqueue to fail

--- a/pkg/queue/tenant_queues.go
+++ b/pkg/queue/tenant_queues.go
@@ -101,6 +101,10 @@ type tenantQueue struct {
 	// Seed for shuffle sharding of consumers. This seed is based on userID only and is therefore consistent
 	// between different frontends.
 	seed int64
+
+	// Set when a request is enqueued for this tenant and reset by removeIdleQueues.
+	// Empty queues that were not used since the previous cleanup are removed.
+	enqueuedSinceLastCleanup bool
 }
 
 func newTenantQueues(maxUserQueueSize int, forgetDelay time.Duration, limits Limits) *tenantQueues {
@@ -117,12 +121,36 @@ func newTenantQueues(maxUserQueueSize int, forgetDelay time.Duration, limits Lim
 	}
 }
 
-func (q *tenantQueues) hasNoTenantQueues() bool {
-	return q.mapping.Len() == 0
+// hasNoPendingRequests returns true if no tenant queue holds a request.
+// Tenant queues are kept in the mapping after they have been drained, so the
+// number of queues does not tell whether there is anything to dequeue.
+func (q *tenantQueues) hasNoPendingRequests() bool {
+	return len(q.perUserQueueLen) == 0
 }
 
 func (q *tenantQueues) deleteQueue(tenant string) {
 	q.mapping.Remove(tenant)
+}
+
+// removeIdleQueues removes all tenant queues that are empty and did not receive
+// a request since the previous call. It returns the number of removed queues.
+// Queues are kept for at least one cleanup interval so that tenants with a
+// queue depth oscillating around zero do not pay for queue re-creation.
+func (q *tenantQueues) removeIdleQueues() int {
+	removed := 0
+	for _, tenantID := range q.mapping.Keys() {
+		uq := q.mapping.GetByKey(tenantID)
+		if uq == nil {
+			continue
+		}
+		if uq.enqueuedSinceLastCleanup || uq.Len() > 0 {
+			uq.enqueuedSinceLastCleanup = false
+			continue
+		}
+		q.deleteQueue(tenantID)
+		removed++
+	}
+	return removed
 }
 
 // Returns existing or new queue for a tenant.
@@ -146,6 +174,7 @@ func (q *tenantQueues) getOrAddQueue(tenantID string, path []string) (Queue, err
 		uq.TreeQueue = newTreeQueue(q.maxUserQueueSize, tenantID)
 		q.mapping.Put(tenantID, uq)
 	}
+	uq.enqueuedSinceLastCleanup = true
 
 	consumersToSelect := validation.SmallestPositiveNonZeroIntPerTenant(
 		tenantIDs,
@@ -192,6 +221,12 @@ func (q *tenantQueues) getNextQueueForConsumer(lastUserIndex QueueIndex, consume
 			break
 		}
 		uid = tq.pos
+
+		// Drained queues are not removed right away, so they must be skipped here.
+		// Otherwise consumers would receive an empty queue instead of waiting.
+		if tq.Len() == 0 {
+			continue
+		}
 
 		if tq.consumers != nil {
 			if _, ok := tq.consumers[consumerID]; !ok {

--- a/pkg/queue/tenant_queues_test.go
+++ b/pkg/queue/tenant_queues_test.go
@@ -21,8 +21,12 @@ import (
 
 var noQueueLimits = limits.NewQueueLimits(nil)
 
+// testQueueSize is the local queue size used by tests that need to enqueue
+// requests to keep tenant queues non-empty.
+const testQueueSize = 4
+
 func TestQueues(t *testing.T) {
-	uq := newTenantQueues(0, 0, noQueueLimits)
+	uq := newTenantQueues(testQueueSize, 0, noQueueLimits)
 	assert.NotNil(t, uq)
 	assert.NoError(t, isConsistent(uq))
 
@@ -80,7 +84,7 @@ func TestQueues(t *testing.T) {
 }
 
 func TestQueuesOnTerminatingConsumer(t *testing.T) {
-	uq := newTenantQueues(0, 0, noQueueLimits)
+	uq := newTenantQueues(testQueueSize, 0, noQueueLimits)
 	assert.NotNil(t, uq)
 	assert.NoError(t, isConsistent(uq))
 
@@ -111,7 +115,7 @@ func TestQueuesOnTerminatingConsumer(t *testing.T) {
 
 func TestQueuesWithConsumers(t *testing.T) {
 	maxConsumers := 5
-	uq := newTenantQueues(0, 0, &mockQueueLimits{maxConsumers: maxConsumers})
+	uq := newTenantQueues(testQueueSize, 0, &mockQueueLimits{maxConsumers: maxConsumers})
 	assert.NotNil(t, uq)
 	assert.NoError(t, isConsistent(uq))
 
@@ -177,6 +181,41 @@ func TestQueuesWithConsumers(t *testing.T) {
 	assert.InDelta(t, stdDev, 0, mean*0.2)
 }
 
+func TestRemoveIdleQueues(t *testing.T) {
+	uq := newTenantQueues(testQueueSize, 0, noQueueLimits)
+	uq.addConsumerToConnection("consumer-1")
+
+	// "one" holds a request, "two" is empty.
+	getOrAdd(t, uq, "one")
+	_, err := uq.getOrAddQueue("two", nil)
+	require.NoError(t, err)
+
+	// The first run only resets the usage flag, both queues were used since the
+	// previous run.
+	require.Equal(t, 0, uq.removeIdleQueues())
+	require.NotNil(t, uq.mapping.GetByKey("one"))
+	require.NotNil(t, uq.mapping.GetByKey("two"))
+
+	// The empty and unused queue is removed, the non-empty one is kept.
+	require.Equal(t, 1, uq.removeIdleQueues())
+	require.NotNil(t, uq.mapping.GetByKey("one"))
+	require.Nil(t, uq.mapping.GetByKey("two"))
+	require.NoError(t, isConsistent(uq))
+}
+
+func TestGetNextQueueForConsumerSkipsEmptyQueues(t *testing.T) {
+	uq := newTenantQueues(testQueueSize, 0, noQueueLimits)
+	uq.addConsumerToConnection("consumer-1")
+
+	_, err := uq.getOrAddQueue("empty", nil)
+	require.NoError(t, err)
+	qTwo := getOrAdd(t, uq, "non-empty")
+
+	q, tenant, _ := uq.getNextQueueForConsumer(StartIndex, "consumer-1")
+	require.Equal(t, qTwo, q)
+	require.Equal(t, "non-empty", tenant)
+}
+
 func TestQueuesConsistency(t *testing.T) {
 	tests := map[string]struct {
 		forgetDelay time.Duration
@@ -238,7 +277,7 @@ func TestQueues_ForgetDelay(t *testing.T) {
 	)
 
 	now := time.Now()
-	uq := newTenantQueues(0, forgetDelay, &mockQueueLimits{maxConsumers: maxConsumers})
+	uq := newTenantQueues(testQueueSize, forgetDelay, &mockQueueLimits{maxConsumers: maxConsumers})
 	assert.NotNil(t, uq)
 	assert.NoError(t, isConsistent(uq))
 
@@ -330,7 +369,7 @@ func TestQueues_ForgetDelay_ShouldCorrectlyHandleConsumerReconnectingBeforeForge
 	)
 
 	now := time.Now()
-	uq := newTenantQueues(0, forgetDelay, &mockQueueLimits{maxConsumers: maxConsumers})
+	uq := newTenantQueues(testQueueSize, forgetDelay, &mockQueueLimits{maxConsumers: maxConsumers})
 	assert.NotNil(t, uq)
 	assert.NoError(t, isConsistent(uq))
 
@@ -407,6 +446,9 @@ func generateConsumer(r *rand.Rand) string {
 	return fmt.Sprint("consumer-", r.Int()%5)
 }
 
+// getOrAdd creates the tenant queue and enqueues a single request, so that the
+// queue is not skipped by getNextQueueForConsumer, which only returns
+// non-empty queues.
 func getOrAdd(t *testing.T, uq *tenantQueues, tenant string) Queue {
 	actor := []string{}
 	q, err := uq.getOrAddQueue(tenant, actor)
@@ -416,6 +458,10 @@ func getOrAdd(t *testing.T, uq *tenantQueues, tenant string) Queue {
 	q2, err := uq.getOrAddQueue(tenant, actor)
 	assert.NoError(t, err)
 	assert.Equal(t, q, q2)
+	if q.Len() == 0 {
+		q.Chan() <- "request"
+		uq.perUserQueueLen.Inc(tenant)
+	}
 	return q
 }
 

--- a/pkg/queue/treequeue.go
+++ b/pkg/queue/treequeue.go
@@ -120,7 +120,9 @@ func (q *TreeQueue) Name() string {
 // This may be expensive depending on the size of the queue tree.
 func (q *TreeQueue) Len() int {
 	count := len(q.ch)
-	for _, subq := range q.mapping.Values() {
+	// Iterate the map directly, since Values() allocates a slice and Len() is
+	// called on the hot path of every dequeue.
+	for _, subq := range q.mapping.m {
 		count += subq.Len()
 	}
 	return count


### PR DESCRIPTION
**What this PR does / why we need it**:

The scheduler deleted a tenant queue as soon as it was drained and rebuilt it on the next request. Each queue holds a buffered channel sized by `-query-scheduler.max-outstanding-requests-per-tenant` (default 32000), so every create/destroy cycle allocated 512 KB. For a tenant whose queue depth oscillates between 0 and 1 that is one 512 KB allocation per request. On a production scheduler this accounted for 80% of all allocated bytes (536 GB of 664 GB over 30 minutes), plus another 6.5% for the consumer shard that `getOrAddQueue` recomputed for every freshly created queue.

Queues now stay in the mapping and are removed by the existing forgetCheckPeriod timer once they have been empty and unused for a full cleanup interval. Because a queue in the mapping no longer implies pending work, the "is there anything to dequeue" check moved to the per-tenant request counter, and queue selection skips empty queues so consumers wait on the cond instead of receiving an empty queue. TreeQueue.Len no longer allocates, since it is now called for every queue visited while scanning.

The Enqueue error path decremented nothing when getOrAddQueue failed. That leaked the per-tenant counter, which is now the signal for pending requests, so it is fixed here.

Benchmark (AMD Ryzen AI 9 HX 370, go1.26):

    go test -run XXX -bench BenchmarkEnqueueDequeueCycle -benchtime 20000x ./pkg/queue/

    before  94288 ns/op   522252 B/op   18 allocs/op
    after     663 ns/op      122 B/op    5 allocs/op

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/2809

**Special notes for your reviewer**:

Trade-off: queue selection may scan more mapping entries per dequeue, bounded by the number of tenants active within the cleanup interval.