### PR TITLE
fix(kafka-init): Use incremental AlterBrokerConfigs 

### DIFF
--- a/pkg/kafka/client/reader_client.go
+++ b/pkg/kafka/client/reader_client.go
@@ -64,7 +64,7 @@ func setDefaultNumberOfPartitionsForAutocreatedTopics(cfg kafka.Config, cl *kgo.
 	adm := kadm.NewClient(cl)
 
 	defaultNumberOfPartitions := fmt.Sprintf("%d", cfg.AutoCreateTopicDefaultPartitions)
-	_, err := adm.AlterBrokerConfigsState(context.Background(), []kadm.AlterConfig{
+	_, err := adm.AlterBrokerConfigs(context.Background(), []kadm.AlterConfig{
 		{
 			Op:    kadm.SetConfig,
 			Name:  "num.partitions",


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses the incremental AlterBrokerConfigs instead of AlterBrokerConfigsState which overwrites the entire set of config options.

The current AlterBrokerConfigsState resets all other parameters back to their defaults if they aren't specified in the request, whereas the AlterBrokerConfigs patches the parameter being set and ignores the others.