### PR TITLE
fix(ruler): Trim whitespace surrounding rule expressions

### DIFF
--- a/pkg/ruler/base/api_test.go
+++ b/pkg/ruler/base/api_test.go
@@ -847,6 +847,59 @@ rules:
 	}
 }
 
+// An expression whose first line begins with whitespace used to be stored verbatim, and
+// every later read of the namespace re-marshalled it into YAML that no parser could read,
+// so the ruler answered 500 for the whole namespace and its rules never loaded. Wider
+// indents took the other branch and silently lost two columns per round trip until they
+// too became unreadable. Same defect as https://github.com/grafana/mimir/issues/6763.
+//
+// The payload below quotes the expression so that what reaches the ruler is unambiguous;
+// what is under test is every read that follows.
+func TestRuler_CreateWithLeadingWhitespaceInExpr(t *testing.T) {
+	const body = "sum by (level) (\n    count_over_time({job=~\".+\"}[1m])\n  )"
+
+	for _, indent := range []string{" ", "  ", "   ", "     ", "\n  "} {
+		t.Run(fmt.Sprintf("%q", indent), func(t *testing.T) {
+			cfg := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
+
+			r := newTestRuler(t, cfg)
+			defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
+
+			a := NewAPI(r, r.store, log.NewNopLogger())
+
+			router := mux.NewRouter()
+			router.Path("/api/v1/rules/{namespace}").Methods(http.MethodPost).HandlerFunc(a.CreateRuleGroup)
+			router.Path("/api/v1/rules/{namespace}/{groupName}").Methods(http.MethodGet).HandlerFunc(a.GetRuleGroup)
+			router.Path("/api/v1/rules").Methods(http.MethodGet).HandlerFunc(a.ListRules)
+
+			input := fmt.Sprintf("name: test\ninterval: 15s\nrules:\n- record: up_rule\n  expr: %q\n", indent+body+"\n")
+
+			req := requestFor(t, http.MethodPost, "https://localhost:8080/api/v1/rules/namespace", strings.NewReader(input), "user1")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusAccepted, w.Code, w.Body.String())
+
+			req = requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules/namespace/test", nil, "user1")
+			w = httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var got rulefmt.RuleGroup
+			require.NoError(t, yaml.Unmarshal(w.Body.Bytes(), &got), "rule group must be readable: %s", w.Body.String())
+			require.Equal(t, body, got.Rules[0].Expr)
+
+			req = requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules", nil, "user1")
+			w = httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var namespaces map[string][]rulefmt.RuleGroup
+			require.NoError(t, yaml.Unmarshal(w.Body.Bytes(), &namespaces), "rule list must be readable: %s", w.Body.String())
+			require.Equal(t, body, namespaces["namespace"][0].Rules[0].Expr)
+		})
+	}
+}
+
 func TestRuler_DeleteNamespace(t *testing.T) {
 	cfg := defaultRulerConfig(t, newMockRuleStore(mockRulesNamespaces))
 

--- a/pkg/ruler/base/mapper_test.go
+++ b/pkg/ruler/base/mapper_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/grafana/loki/v3/pkg/ruler/rulespb"
 )
 
 var (
@@ -424,6 +427,39 @@ func TestYamlFormatting(t *testing.T) {
 `
 
 	require.Equal(t, expected, string(data))
+}
+
+// A stored expression whose first line begins with whitespace used to be written to the
+// rule file as YAML that no parser could read. Prometheus' Manager.Update loads every
+// file of a tenant and swaps in nothing if any one of them fails, so a single such rule
+// froze that tenant's entire rule set on its last good snapshot.
+func Test_mapper_MapRulesWithLeadingWhitespaceInExpr(t *testing.T) {
+	m := &mapper{
+		Path:   "/rules",
+		FS:     afero.NewMemMapFs(),
+		logger: log.NewNopLogger(),
+	}
+
+	const expr = "sum by (level) (\n    count_over_time({job=~\".+\"}[1m])\n  )"
+
+	stored := rulespb.RuleGroupList{{
+		Name:      "rulegroup_one",
+		Namespace: "file /one",
+		User:      testUser,
+		Rules:     []*rulespb.RuleDesc{{Record: "example_rule", Expr: "   " + expr + "\n"}},
+	}}
+
+	updated, files, err := m.MapRules(testUser, stored.Formatted())
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Equal(t, []string{fileOnePath}, files)
+
+	data, err := afero.ReadFile(m.FS, fileOnePath)
+	require.NoError(t, err)
+
+	var groups rulefmt.RuleGroups
+	require.NoError(t, yaml.Unmarshal(data, &groups), "rule file must be loadable: %s", data)
+	require.Equal(t, expr, groups.Groups[0].Rules[0].Expr)
 }
 
 func Test_mapper_CleanupShouldNotFailIfPathDoesNotExist(t *testing.T) {

--- a/pkg/ruler/rulespb/compat.go
+++ b/pkg/ruler/rulespb/compat.go
@@ -1,6 +1,7 @@
 package rulespb
 
 import (
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -27,7 +28,7 @@ func formattedRuleToProto(rls []rulefmt.Rule) []*RuleDesc {
 	rules := make([]*RuleDesc, len(rls))
 	for i := range rls {
 		rules[i] = &RuleDesc{
-			Expr:        rls[i].Expr,
+			Expr:        normalizeExpr(rls[i].Expr),
 			Record:      rls[i].Record,
 			Alert:       rls[i].Alert,
 			For:         time.Duration(rls[i].For),
@@ -49,10 +50,8 @@ func FromProto(rg *RuleGroupDesc) rulefmt.RuleGroup {
 	}
 
 	for i, rl := range rg.GetRules() {
-		expr := rl.GetExpr()
-
 		newRule := rulefmt.Rule{
-			Expr:        expr,
+			Expr:        normalizeExpr(rl.GetExpr()),
 			Labels:      logproto.FromLabelAdaptersToLabels(rl.Labels).Map(),
 			Annotations: logproto.FromLabelAdaptersToLabels(rl.Annotations).Map(),
 			For:         model.Duration(rl.GetFor()),
@@ -68,4 +67,16 @@ func FromProto(rg *RuleGroupDesc) rulefmt.RuleGroup {
 	}
 
 	return formattedRuleGroup
+}
+
+// normalizeExpr strips whitespace surrounding a rule expression, which is
+// insignificant to LogQL but not to the YAML emitter: when a value's first line
+// begins with whitespace, yaml.v3 writes a block scalar whose indentation
+// indicator disagrees with the indentation it then emits. Nothing can parse the
+// result, so the ruler API returns 500 for the whole namespace and the tenant's
+// rule manager refuses to load any of its files. Applied on the way in so stored
+// groups round trip, and on the way out so groups stored before this fix are
+// still readable.
+func normalizeExpr(expr string) string {
+	return strings.TrimSpace(expr)
 }

--- a/pkg/ruler/rulespb/compat_test.go
+++ b/pkg/ruler/rulespb/compat_test.go
@@ -1,0 +1,60 @@
+package rulespb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	indentedExpr = "\n   sum by (level) (\n     count_over_time({job=~\".+\"}[1m])\n   )\n  "
+	trimmedExpr  = "sum by (level) (\n     count_over_time({job=~\".+\"}[1m])\n   )"
+)
+
+func TestToProtoTrimsWhitespaceSurroundingExpr(t *testing.T) {
+	group := rulefmt.RuleGroup{
+		Name:     "group",
+		Interval: model.Duration(15 * time.Second),
+		Rules: []rulefmt.Rule{
+			{Record: "recording", Expr: indentedExpr},
+			{
+				Alert:       "alerting",
+				Expr:        indentedExpr,
+				For:         model.Duration(30 * time.Second),
+				Labels:      map[string]string{"severity": "page"},
+				Annotations: map[string]string{"summary": "too many logs"},
+			},
+		},
+	}
+
+	desc := ToProto("user1", "namespace", group)
+
+	require.Equal(t, trimmedExpr, desc.Rules[0].Expr)
+	require.Equal(t, trimmedExpr, desc.Rules[1].Expr)
+
+	require.Equal(t, "recording", desc.Rules[0].Record)
+	require.Equal(t, "alerting", desc.Rules[1].Alert)
+	require.Equal(t, 30*time.Second, desc.Rules[1].For)
+	require.Equal(t, "severity", desc.Rules[1].Labels[0].Name)
+	require.Equal(t, "summary", desc.Rules[1].Annotations[0].Name)
+}
+
+// Groups stored before expressions were trimmed on write must still read back cleanly,
+// otherwise the namespace stays unreadable for as long as the group exists.
+func TestFromProtoTrimsWhitespaceSurroundingExpr(t *testing.T) {
+	desc := &RuleGroupDesc{
+		Name:      "group",
+		Namespace: "namespace",
+		User:      "user1",
+		Interval:  15 * time.Second,
+		Rules:     []*RuleDesc{{Record: "recording", Expr: indentedExpr}},
+	}
+
+	group := FromProto(desc)
+
+	require.Equal(t, trimmedExpr, group.Rules[0].Expr)
+	require.Equal(t, "recording", group.Rules[0].Record)
+}


### PR DESCRIPTION
A rule expression whose first line begins with whitespace was stored verbatim, and yaml.v3 emits such a value as a block scalar whose indentation indicator disagrees with the indentation it then writes. No parser accepts the result, so:

- every read of the namespace failed, taking down the entire rules list for that datasource rather than just the offending group;
- the ruler could not load its own rule file, and because Manager.Update is all or nothing per tenant, every other rule mapped by that pod stopped updating and kept running its last good snapshot;
- wider indents took the other branch of the same defect and silently lost two columns per round trip until they too became unreadable.

Trim on the way in so what is stored round trips, and on the way out so groups written before this change become readable again without operator intervention. Leading and trailing whitespace is insignificant to LogQL, so nothing is lost.

Mimir hit the same defect in grafana/mimir#6763.