### PR TITLE
fix(kafka): Use incremental AlterBrokerConfigs  (#24466)

### DIFF
--- a/pkg/kafka/client/reader_client.go
+++ b/pkg/kafka/client/reader_client.go
@@ -64,7 +64,7 @@ func setDefaultNumberOfPartitionsForAutocreatedTopics(cfg kafka.Config, cl *kgo.
 	adm := kadm.NewClient(cl)
 
 	defaultNumberOfPartitions := fmt.Sprintf("%d", cfg.AutoCreateTopicDefaultPartitions)
-	_, err := adm.AlterBrokerConfigsState(context.Background(), []kadm.AlterConfig{
+	_, err := adm.AlterBrokerConfigs(context.Background(), []kadm.AlterConfig{
 		{
 			Op:    kadm.SetConfig,
 			Name:  "num.partitions",


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports [this fix](https://github.com/grafana/loki/pull/24466) to k323 so it can be tested this week.
