### PR TITLE
feat(logline): Split Logline filters into k gap-cut envelopes

### DIFF
--- a/pkg/logline/queryfrontend/AGENTS.md
+++ b/pkg/logline/queryfrontend/AGENTS.md
@@ -20,7 +20,9 @@ or narrow time intervals that the logline index proves contain no matching log l
    below the results cache. For each interval sub-request, it consults the prefetched
    hints to either:
    - **Skip** the interval entirely (return empty response) if no hint ranges overlap
-   - **Narrow** to only the matching time ranges within the interval
+   - **Narrow** to at most k envelopes (k = ceil(interval/15m), cap 8) by cutting
+     the largest inter-hint gaps. One `next.Do` per envelope; intra-group gaps
+     are scanned so nearby hints do not refetch the same chunk.
    - **Pass through** if the interval is in the ingester window, or on error/timeout
 
 ## Key integration points

--- a/pkg/logline/queryfrontend/config.go
+++ b/pkg/logline/queryfrontend/config.go
@@ -60,6 +60,11 @@ type MiddlewareConfig struct {
 	// cover this window, so it is always passed through to the Loki pipeline.
 	// Populated from Loki's querier.query_ingesters_within at assembly time.
 	QueryIngestersWithin time.Duration `yaml:"query_ingesters_within"`
+	// QuerySplitDuration is Loki's split_queries_by_interval. Prefetch sits
+	// above SplitByInterval and uses this to apply the filter's k-budget per
+	// slice. Populated from limits_config.split_queries_by_interval at assembly
+	// time. Zero disables splitting, matching Loki.
+	QuerySplitDuration time.Duration `yaml:"-"`
 	// HintTimeout is the maximum time to wait for the logline index hint
 	// lookup before falling back to passthrough. Defaults to 15s when zero.
 	HintTimeout time.Duration `yaml:"hint_timeout"`

--- a/pkg/logline/queryfrontend/integration.go
+++ b/pkg/logline/queryfrontend/integration.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
@@ -200,6 +201,9 @@ func WrapMiddlewareWithStore(
 	hp := hintprovider.NewCachingHintProvider(baseHintProvider, hintCache, reg)
 	if cfg.QueryIngestersWithin == 0 {
 		cfg.QueryIngestersWithin = lokiCfg.Querier.QueryIngestersWithin
+	}
+	if cfg.QuerySplitDuration == 0 {
+		cfg.QuerySplitDuration = time.Duration(lokiCfg.LimitsConfig.QuerySplitDuration)
 	}
 
 	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, tenantSettings, metrics, logger)

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -1209,9 +1209,6 @@ func groupHintEnvelopes(ranges []hintprovider.HintTimeRange, intervalStart, inte
 	if len(clipped) == 0 {
 		return nil
 	}
-	if maxGroups < 1 {
-		maxGroups = 1
-	}
 
 	n := len(clipped)
 	cutCount := maxGroups - 1
@@ -1226,9 +1223,6 @@ func groupHintEnvelopes(ranges []hintprovider.HintTimeRange, intervalStart, inte
 	ranked := make([]rankedGap, 0, n-1)
 	for i := 0; i < n-1; i++ {
 		d := clipped[i+1].Start.Sub(clipped[i].End)
-		if d < 0 {
-			d = 0
-		}
 		ranked = append(ranked, rankedGap{after: i, d: d})
 	}
 	sort.Slice(ranked, func(i, j int) bool {

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -36,7 +36,7 @@ import (
 //
 // 2. Filter MW (below SplitByInterval, below cache): for each interval
 //    sub-request, consults the prefetched hints to skip empty intervals
-//    or narrow to matching time ranges within the interval.
+//    or narrow to at most k hint envelopes (k = ceil(interval/15m), cap 8).
 //
 // SplitByInterval handles direction ordering, LIMIT early-exit, and
 // interval-level caching. We just help it skip or narrow intervals.
@@ -64,6 +64,15 @@ const (
 )
 
 const LoglineSkipCacheHeader = "X-Logline-Skip-Cache"
+
+// envelopeTargetDuration is the target coverage of each narrowed envelope.
+// k = ceil(incoming interval / envelopeTargetDuration), capped at
+// maxEnvelopesPerInterval. Groups are formed by cutting the k-1 largest
+// inter-hint gaps so distant clusters are not unioned into one scan.
+const (
+	envelopeTargetDuration  = 15 * time.Minute
+	maxEnvelopesPerInterval = 8
+)
 
 type hintPrefetchKeyType struct{}
 type shardPlanningRerunGuardKeyType struct{}
@@ -1130,38 +1139,134 @@ func (h *loglineFilterHandler) Do(ctx context.Context, req queryrangebase.Reques
 		return emptyLokiResponse(lokiReq), nil
 	}
 
-	if len(overlapping) == 1 {
-		start := maxTime(overlapping[0].Start, intervalStart)
-		end := minTime(overlapping[0].End, intervalEnd)
-		if overlapping[0].IsPassthrough() {
-			result.recordPassthrough(originalDuration)
-			h.metrics.passthroughSubRequests.WithLabelValues("pre_min_date").Inc()
-			return h.next.Do(ctx, req.WithStartEnd(start, end))
-		}
-		result.recordNarrowed(originalDuration, intervalDuration(start, end))
-		h.metrics.hintSubRequests.WithLabelValues("narrowed").Inc()
-		return h.next.Do(ctx, req.WithStartEnd(start, end))
+	groups := groupHintEnvelopes(overlapping, intervalStart, intervalEnd, envelopeBudget(originalDuration))
+	if len(groups) == 0 {
+		result.recordSkipped(originalDuration)
+		h.metrics.hintSubRequests.WithLabelValues("skipped").Inc()
+		return emptyLokiResponse(lokiReq), nil
 	}
 
-	responses := make([]queryrangebase.Response, 0, len(overlapping))
-	var queriedDuration time.Duration
-	for _, hint := range overlapping {
-		start := maxTime(hint.Start, intervalStart)
-		end := minTime(hint.End, intervalEnd)
-		resp, err := h.next.Do(ctx, req.WithStartEnd(start, end))
+	if len(overlapping) == 1 && overlapping[0].IsPassthrough() {
+		result.recordPassthrough(originalDuration)
+		h.metrics.passthroughSubRequests.WithLabelValues("pre_min_date").Inc()
+		return h.next.Do(ctx, req.WithStartEnd(groups[0].Start, groups[0].End))
+	}
+
+	var queried time.Duration
+	for _, g := range groups {
+		queried += intervalDuration(g.Start, g.End)
+	}
+	result.recordNarrowed(originalDuration, queried)
+	h.metrics.hintSubRequests.WithLabelValues("narrowed").Inc()
+
+	if len(groups) == 1 {
+		return h.next.Do(ctx, req.WithStartEnd(groups[0].Start, groups[0].End))
+	}
+
+	responses := make([]queryrangebase.Response, 0, len(groups))
+	for _, g := range groups {
+		resp, err := h.next.Do(ctx, req.WithStartEnd(g.Start, g.End))
 		if err != nil {
 			return nil, err
 		}
 		responses = append(responses, resp)
-		queriedDuration += intervalDuration(start, end)
-		if hint.IsPassthrough() {
-			h.metrics.passthroughSubRequests.WithLabelValues("pre_min_date").Inc()
-		} else {
-			h.metrics.hintSubRequests.WithLabelValues("narrowed").Inc()
-		}
 	}
-	result.recordNarrowed(originalDuration, queriedDuration)
 	return queryrange.DefaultCodec.MergeResponse(responses...)
+}
+
+type hintEnvelope struct {
+	Start time.Time
+	End   time.Time
+}
+
+func envelopeBudget(interval time.Duration) int {
+	if interval <= 0 {
+		return 1
+	}
+	k := int((interval + envelopeTargetDuration - 1) / envelopeTargetDuration)
+	if k < 1 {
+		return 1
+	}
+	if k > maxEnvelopesPerInterval {
+		return maxEnvelopesPerInterval
+	}
+	return k
+}
+
+// groupHintEnvelopes partitions start-sorted hints into at most maxGroups
+// envelopes by cutting the largest inter-hint gaps. Overlapping or touching
+// hints (gap <= 0) are never split. Each envelope is clipped to [intervalStart, intervalEnd].
+func groupHintEnvelopes(ranges []hintprovider.HintTimeRange, intervalStart, intervalEnd time.Time, maxGroups int) []hintEnvelope {
+	clipped := make([]hintprovider.HintTimeRange, 0, len(ranges))
+	for _, r := range ranges {
+		start := maxTime(r.Start, intervalStart)
+		end := minTime(r.End, intervalEnd)
+		if !end.After(start) {
+			continue
+		}
+		clipped = append(clipped, hintprovider.HintTimeRange{Start: start, End: end})
+	}
+	if len(clipped) == 0 {
+		return nil
+	}
+	if maxGroups < 1 {
+		maxGroups = 1
+	}
+
+	n := len(clipped)
+	cutCount := maxGroups - 1
+	if cutCount > n-1 {
+		cutCount = n - 1
+	}
+
+	type rankedGap struct {
+		after int
+		d     time.Duration
+	}
+	ranked := make([]rankedGap, 0, n-1)
+	for i := 0; i < n-1; i++ {
+		d := clipped[i+1].Start.Sub(clipped[i].End)
+		if d < 0 {
+			d = 0
+		}
+		ranked = append(ranked, rankedGap{after: i, d: d})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].d != ranked[j].d {
+			return ranked[i].d > ranked[j].d
+		}
+		return ranked[i].after < ranked[j].after
+	})
+
+	cutAfter := make([]bool, n-1)
+	cuts := 0
+	for _, g := range ranked {
+		if cuts >= cutCount {
+			break
+		}
+		if g.d <= 0 {
+			continue
+		}
+		cutAfter[g.after] = true
+		cuts++
+	}
+
+	var groups []hintEnvelope
+	runStart := 0
+	for i := 0; i < n; i++ {
+		if i < n-1 && !cutAfter[i] {
+			continue
+		}
+		end := clipped[runStart].End
+		for j := runStart + 1; j <= i; j++ {
+			if clipped[j].End.After(end) {
+				end = clipped[j].End
+			}
+		}
+		groups = append(groups, hintEnvelope{Start: clipped[runStart].Start, End: end})
+		runStart = i + 1
+	}
+	return groups
 }
 
 func isCancel(err error) bool {

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -274,6 +274,7 @@ func NewLoglinePrefetchMiddleware(
 			hintTimeout:          cfg.HintTimeout,
 			minQueryBytes:        cfg.MinQueryBytesForIndex,
 			queryIngestersWithin: cfg.QueryIngestersWithin,
+			querySplitDuration:   cfg.QuerySplitDuration,
 			shardPlanning:        cfg.ShardPlanning,
 			tenantSettings:       tenantSettings,
 			metrics:              metrics,
@@ -292,6 +293,7 @@ type loglinePrefetchHandler struct {
 	dryRunInflight       atomic.Int32
 	minQueryBytes        int64
 	queryIngestersWithin time.Duration
+	querySplitDuration   time.Duration
 	shardPlanning        ShardPlanningConfig
 	tenantSettings       TenantSettings
 	metrics              *Metrics
@@ -404,10 +406,11 @@ func (h *loglinePrefetchHandler) shardPlanningDecision(result *hintPrefetchResul
 	if queryDuration == 0 {
 		return shardPlanningDecision{reason: "time_reduction_too_small", overlaps: overlaps}
 	}
-	// Use k-envelope coverage, not raw hint duration. The filter scans the
-	// filled gaps, so hint-only math overstates time reduction and can trip
-	// a power_of_two rerun when the actual scan would miss the threshold.
-	cumulative := envelopeQueriedDuration(overlaps, from, through)
+	// Use k-envelope coverage after the same SplitByInterval slices the
+	// filter will see. Hint-only math, or a single k-budget on the unsplit
+	// range, overstates scanned time once the cap of 8 unions distant
+	// clusters the filter would keep separate.
+	cumulative := envelopeQueriedDuration(overlaps, from, through, h.querySplitDuration)
 	timeReductionRatio := float64(queryDuration-cumulative) / float64(queryDuration)
 	if timeReductionRatio < 0 {
 		timeReductionRatio = 0
@@ -1176,7 +1179,17 @@ type hintEnvelope struct {
 	End   time.Time
 }
 
-func envelopeQueriedDuration(ranges []hintprovider.HintTimeRange, start, end time.Time) time.Duration {
+func envelopeQueriedDuration(ranges []hintprovider.HintTimeRange, start, end time.Time, split time.Duration) time.Duration {
+	var queried time.Duration
+	// LokiRequest splits are half-open [start, end). Zero split disables
+	// splitting, matching querier.split-queries-by-interval.
+	util.ForInterval(split, start, end, false, func(sliceStart, sliceEnd time.Time) {
+		queried += intervalEnvelopeDuration(ranges, sliceStart, sliceEnd)
+	})
+	return queried
+}
+
+func intervalEnvelopeDuration(ranges []hintprovider.HintTimeRange, start, end time.Time) time.Duration {
 	var queried time.Duration
 	for _, g := range groupHintEnvelopes(ranges, start, end, envelopeBudget(intervalDuration(start, end))) {
 		queried += intervalDuration(g.Start, g.End)

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -400,17 +400,14 @@ func (h *loglinePrefetchHandler) shardPlanningDecision(result *hintPrefetchResul
 
 	overlaps := rangesOverlapping(result.ranges, from, through)
 
-	var cumulative time.Duration
-	for _, hint := range overlaps {
-		start := maxTime(hint.Start, from)
-		end := minTime(hint.End, through)
-		cumulative += intervalDuration(start, end)
-	}
-
 	queryDuration := intervalDuration(from, through)
 	if queryDuration == 0 {
 		return shardPlanningDecision{reason: "time_reduction_too_small", overlaps: overlaps}
 	}
+	// Use k-envelope coverage, not raw hint duration. The filter scans the
+	// filled gaps, so hint-only math overstates time reduction and can trip
+	// a power_of_two rerun when the actual scan would miss the threshold.
+	cumulative := envelopeQueriedDuration(overlaps, from, through)
 	timeReductionRatio := float64(queryDuration-cumulative) / float64(queryDuration)
 	if timeReductionRatio < 0 {
 		timeReductionRatio = 0
@@ -1177,6 +1174,14 @@ func (h *loglineFilterHandler) Do(ctx context.Context, req queryrangebase.Reques
 type hintEnvelope struct {
 	Start time.Time
 	End   time.Time
+}
+
+func envelopeQueriedDuration(ranges []hintprovider.HintTimeRange, start, end time.Time) time.Duration {
+	var queried time.Duration
+	for _, g := range groupHintEnvelopes(ranges, start, end, envelopeBudget(intervalDuration(start, end))) {
+		queried += intervalDuration(g.Start, g.End)
+	}
+	return queried
 }
 
 func envelopeBudget(interval time.Duration) int {

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -1624,6 +1624,26 @@ func TestEnvelopeBudget(t *testing.T) {
 	require.Equal(t, 1, envelopeBudget(0))
 }
 
+func TestEnvelopeQueriedDuration_AppliesBudgetPerSplitInterval(t *testing.T) {
+	start := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	end := start.Add(8 * time.Hour)
+	var ranges []hintprovider.HintTimeRange
+	for i := 0; i < 16; i++ {
+		hintStart := start.Add(time.Duration(i) * 30 * time.Minute)
+		ranges = append(ranges, hintprovider.HintTimeRange{
+			Start: hintStart,
+			End:   hintStart.Add(time.Minute),
+		})
+	}
+
+	// One k=8 budget on the unsplit 8h range unions eight 29m gaps.
+	require.Equal(t, 16*time.Minute+8*29*time.Minute, intervalEnvelopeDuration(ranges, start, end))
+	require.Equal(t, 16*time.Minute+8*29*time.Minute, envelopeQueriedDuration(ranges, start, end, 0))
+	// After the configured 1h SplitByInterval slices, each hour keeps both 1m hints.
+	require.Equal(t, 16*time.Minute, envelopeQueriedDuration(ranges, start, end, time.Hour))
+	require.Equal(t, 16*time.Minute, envelopeQueriedDuration(ranges, start, end, 30*time.Minute))
+}
+
 func TestPrefetchFilter_MultipleHintRanges(t *testing.T) {
 	// 12:00–12:59 / 15m target → k=4. Five disjoint hints cut at the three
 	// largest gaps: isolate the far ones, keep 12:35–12:42 together.

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -1522,35 +1523,280 @@ func TestPrefetchFilter_QueryStatsCountsTimeout(t *testing.T) {
 	require.Equal(t, int32(1), snap.PrefetchTimeouts)
 }
 
-func TestPrefetchFilter_MultipleHintRanges(t *testing.T) {
-	now := time.Now().Truncate(time.Millisecond)
-	r1 := hintprovider.HintTimeRange{Start: now.Add(-50 * time.Minute), End: now.Add(-45 * time.Minute)}
-	r2 := hintprovider.HintTimeRange{Start: now.Add(-20 * time.Minute), End: now.Add(-10 * time.Minute)}
+func TestGroupHintEnvelopes(t *testing.T) {
+	utc := func(h, m int) time.Time {
+		return time.Date(2026, 9, 8, h, m, 0, 0, time.UTC)
+	}
+	hint := func(sh, sm, eh, em int) hintprovider.HintTimeRange {
+		return hintprovider.HintTimeRange{Start: utc(sh, sm), End: utc(eh, em)}
+	}
+	env := func(sh, sm, eh, em int) hintEnvelope {
+		return hintEnvelope{Start: utc(sh, sm), End: utc(eh, em)}
+	}
 
-	hp := &mockHintProvider{
-		hints: &hintprovider.Hints{
-			TimeRanges: []hintprovider.HintTimeRange{r1, r2},
+	intervalStart := utc(12, 0)
+	intervalEnd := utc(12, 59)
+
+	tests := []struct {
+		name      string
+		start     time.Time
+		end       time.Time
+		hints     []hintprovider.HintTimeRange
+		maxGroups int
+		want      []hintEnvelope
+	}{
+		{
+			name:  "five hints k=4 cuts the three largest gaps",
+			start: intervalStart,
+			end:   intervalEnd,
+			hints: []hintprovider.HintTimeRange{
+				hint(12, 5, 12, 6),
+				hint(12, 21, 12, 22),
+				hint(12, 35, 12, 36),
+				hint(12, 41, 12, 42),
+				hint(12, 51, 12, 52),
+			},
+			maxGroups: 4,
+			want: []hintEnvelope{
+				env(12, 5, 12, 6),
+				env(12, 21, 12, 22),
+				env(12, 35, 12, 42),
+				env(12, 51, 12, 52),
+			},
+		},
+		{
+			name:  "k=1 unions all hints",
+			start: intervalStart,
+			end:   intervalEnd,
+			hints: []hintprovider.HintTimeRange{
+				hint(12, 5, 12, 6),
+				hint(12, 21, 12, 22),
+				hint(12, 35, 12, 36),
+			},
+			maxGroups: 1,
+			want:      []hintEnvelope{env(12, 5, 12, 36)},
+		},
+		{
+			name:  "overlapping hints are never split",
+			start: intervalStart,
+			end:   intervalEnd,
+			hints: []hintprovider.HintTimeRange{
+				hint(12, 5, 12, 20),
+				hint(12, 18, 12, 22),
+				hint(12, 40, 12, 41),
+			},
+			maxGroups: 4,
+			want: []hintEnvelope{
+				env(12, 5, 12, 22),
+				env(12, 40, 12, 41),
+			},
+		},
+		{
+			name:  "clips to the request interval",
+			start: utc(12, 10),
+			end:   utc(12, 40),
+			hints: []hintprovider.HintTimeRange{
+				hint(12, 0, 12, 20),
+				hint(12, 30, 12, 50),
+			},
+			maxGroups: 2,
+			want: []hintEnvelope{
+				env(12, 10, 12, 20),
+				env(12, 30, 12, 40),
+			},
 		},
 	}
 
-	var mu sync.Mutex
-	var gotStarts []time.Time
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := groupHintEnvelopes(tc.hints, tc.start, tc.end, tc.maxGroups)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEnvelopeBudget(t *testing.T) {
+	require.Equal(t, 1, envelopeBudget(15*time.Minute))
+	require.Equal(t, 2, envelopeBudget(15*time.Minute+time.Nanosecond))
+	require.Equal(t, 4, envelopeBudget(59*time.Minute))
+	require.Equal(t, 4, envelopeBudget(time.Hour))
+	require.Equal(t, maxEnvelopesPerInterval, envelopeBudget(24*time.Hour))
+	require.Equal(t, 1, envelopeBudget(0))
+}
+
+func TestPrefetchFilter_MultipleHintRanges(t *testing.T) {
+	// 12:00–12:59 / 15m target → k=4. Five disjoint hints cut at the three
+	// largest gaps: isolate the far ones, keep 12:35–12:42 together.
+	intervalStart := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	intervalEnd := time.Date(2026, 9, 8, 12, 59, 0, 0, time.UTC)
+	hints := []hintprovider.HintTimeRange{
+		{Start: time.Date(2026, 9, 8, 12, 5, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 6, 0, 0, time.UTC)},
+		{Start: time.Date(2026, 9, 8, 12, 21, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 22, 0, 0, time.UTC)},
+		{Start: time.Date(2026, 9, 8, 12, 35, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 36, 0, 0, time.UTC)},
+		{Start: time.Date(2026, 9, 8, 12, 41, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 42, 0, 0, time.UTC)},
+		{Start: time.Date(2026, 9, 8, 12, 51, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 52, 0, 0, time.UTC)},
+	}
+
+	hp := &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: hints}}
+
+	var got [][2]time.Time
+	var prefetchResult *hintPrefetchResult
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		lokiReq := req.(*queryrange.LokiRequest)
+		got = append(got, [2]time.Time{lokiReq.StartTs, lokiReq.EndTs})
+		prefetchResult = hintPrefetchFromContext(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	metrics := newTestMetrics()
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, metrics, next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, intervalStart, intervalEnd)
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Equal(t, [][2]time.Time{
+		{hints[0].Start, hints[0].End},
+		{hints[1].Start, hints[1].End},
+		{hints[2].Start, hints[3].End},
+		{hints[4].Start, hints[4].End},
+	}, got)
+
+	require.NotNil(t, prefetchResult)
+	impact := prefetchResult.impactSnapshot()
+	require.Equal(t, int64(1), impact.totalIntervals)
+	require.Equal(t, int64(1), impact.narrowedIntervals)
+	require.Equal(t, 59*time.Minute, impact.originalDuration)
+	require.Equal(t, 10*time.Minute, impact.queryDuration, "queried duration must be the sum of k envelopes")
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.hintSubRequests.WithLabelValues("narrowed")))
+	require.Equal(t, 0.0, testutil.ToFloat64(metrics.hintSubRequests.WithLabelValues("skipped")))
+}
+
+func TestPrefetchFilter_EnvelopeClippedToRequest(t *testing.T) {
+	intervalStart := time.Date(2026, 9, 8, 12, 10, 0, 0, time.UTC)
+	intervalEnd := time.Date(2026, 9, 8, 12, 40, 0, 0, time.UTC)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+			{Start: time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 20, 0, 0, time.UTC)},
+			{Start: time.Date(2026, 9, 8, 12, 30, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 50, 0, 0, time.UTC)},
+		}},
+	}
+
+	var got [][2]time.Time
 	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
 		lokiReq := req.(*queryrange.LokiRequest)
-		mu.Lock()
-		gotStarts = append(gotStarts, lokiReq.StartTs)
-		mu.Unlock()
+		got = append(got, [2]time.Time{lokiReq.StartTs, lokiReq.EndTs})
 		return emptyStreamResponse(), nil
 	})
 
 	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
-	ctx := testTenantContextWithLive()
-	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
-	_, err := handler.Do(ctx, req)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, intervalStart, intervalEnd)
+	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
-	require.Len(t, gotStarts, 2, "should dispatch one sub-request per hint range")
-	require.Contains(t, gotStarts, r1.Start)
-	require.Contains(t, gotStarts, r2.Start)
+	require.Equal(t, [][2]time.Time{
+		{intervalStart, time.Date(2026, 9, 8, 12, 20, 0, 0, time.UTC)},
+		{time.Date(2026, 9, 8, 12, 30, 0, 0, time.UTC), intervalEnd},
+	}, got)
+}
+
+func TestPrefetchFilter_HintsOutsideIntervalIgnored(t *testing.T) {
+	intervalStart := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	intervalEnd := time.Date(2026, 9, 8, 13, 0, 0, 0, time.UTC)
+	inside := hintprovider.HintTimeRange{Start: time.Date(2026, 9, 8, 12, 20, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 21, 0, 0, time.UTC)}
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+			{Start: time.Date(2026, 9, 8, 11, 0, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 11, 5, 0, 0, time.UTC)},
+			inside,
+			{Start: time.Date(2026, 9, 8, 13, 10, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 13, 15, 0, 0, time.UTC)},
+		}},
+	}
+
+	var gotStart, gotEnd time.Time
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		lokiReq := req.(*queryrange.LokiRequest)
+		gotStart = lokiReq.StartTs
+		gotEnd = lokiReq.EndTs
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, intervalStart, intervalEnd)
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalled)
+	require.Equal(t, inside.Start, gotStart)
+	require.Equal(t, inside.End, gotEnd)
+}
+
+func TestPrefetchFilter_DownstreamErrorPropagated(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+			{Start: now.Add(-45 * time.Minute), End: now.Add(-40 * time.Minute)},
+			{Start: now.Add(-20 * time.Minute), End: now.Add(-15 * time.Minute)},
+		}},
+	}
+
+	nextCalled := 0
+	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		nextCalled++
+		return nil, errors.New("querier boom")
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now)
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.EqualError(t, err, "querier boom")
+	require.Equal(t, 1, nextCalled)
+}
+
+func TestPrefetchFilter_PreservesRequestFields(t *testing.T) {
+	intervalStart := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	intervalEnd := time.Date(2026, 9, 8, 13, 0, 0, 0, time.UTC)
+	storeChunks := &logproto.ChunkRefGroup{}
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+			{Start: time.Date(2026, 9, 8, 12, 5, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 6, 0, 0, time.UTC)},
+			{Start: time.Date(2026, 9, 8, 12, 35, 0, 0, time.UTC), End: time.Date(2026, 9, 8, 12, 36, 0, 0, time.UTC)},
+		}},
+	}
+
+	var got []*queryrange.LokiRequest
+	next := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		got = append(got, req.(*queryrange.LokiRequest))
+		return emptyStreamResponse(), nil
+	})
+
+	handler := buildStack(hp, MiddlewareConfig{RequireOptInHeader: true}, newTestMetrics(), next)
+	req := &queryrange.LokiRequest{
+		Query:       `{job="test"} |= "error"`,
+		Limit:       42,
+		Step:        1000,
+		Interval:    2000,
+		StartTs:     intervalStart,
+		EndTs:       intervalEnd,
+		Direction:   logproto.FORWARD,
+		Path:        "/loki/api/v1/query_range",
+		Shards:      []string{"0_of_4"},
+		StoreChunks: storeChunks,
+	}
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, time.Date(2026, 9, 8, 12, 5, 0, 0, time.UTC), got[0].StartTs)
+	require.Equal(t, time.Date(2026, 9, 8, 12, 6, 0, 0, time.UTC), got[0].EndTs)
+	require.Equal(t, time.Date(2026, 9, 8, 12, 35, 0, 0, time.UTC), got[1].StartTs)
+	require.Equal(t, time.Date(2026, 9, 8, 12, 36, 0, 0, time.UTC), got[1].EndTs)
+	for _, g := range got {
+		require.Equal(t, req.Query, g.Query)
+		require.Equal(t, req.Limit, g.Limit)
+		require.Equal(t, req.Step, g.Step)
+		require.Equal(t, req.Interval, g.Interval)
+		require.Equal(t, req.Direction, g.Direction)
+		require.Equal(t, req.Path, g.Path)
+		require.Equal(t, req.Shards, g.Shards)
+		require.Equal(t, req.StoreChunks, g.StoreChunks)
+	}
 }
 
 // --- Ingester window tests ---

--- a/pkg/logline/queryfrontend/shard_planning_test.go
+++ b/pkg/logline/queryfrontend/shard_planning_test.go
@@ -27,6 +27,7 @@ func defaultShardPlanningTestConfig() MiddlewareConfig {
 		NgramLength:           3,
 		MinQueryBytesForIndex: 0,
 		HintTimeout:           time.Second,
+		QuerySplitDuration:    time.Hour,
 		ShardPlanning: ShardPlanningConfig{
 			Enabled:               true,
 			MinTimeReductionRatio: 0.75,
@@ -245,10 +246,13 @@ func TestShardPlanning_MultipleDisjointNarrowHintsRerunWithinThresholds(t *testi
 
 func TestShardPlanningDecision_UsesEnvelopeDuration(t *testing.T) {
 	start := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
-	h := &loglinePrefetchHandler{shardPlanning: ShardPlanningConfig{
-		Enabled:               true,
-		MinTimeReductionRatio: 0.75,
-	}}
+	h := &loglinePrefetchHandler{
+		querySplitDuration: time.Hour,
+		shardPlanning: ShardPlanningConfig{
+			Enabled:               true,
+			MinTimeReductionRatio: 0.75,
+		},
+	}
 
 	t.Run("bookend hints on a 15m range fail after k=1 union", func(t *testing.T) {
 		end := start.Add(15 * time.Minute)
@@ -278,10 +282,47 @@ func TestShardPlanningDecision_UsesEnvelopeDuration(t *testing.T) {
 		require.True(t, got.eligible)
 		require.Equal(t, "eligible", got.reason)
 	})
+
+	t.Run("sparse hourly hints on an 8h range stay eligible after per-split budgets", func(t *testing.T) {
+		end := start.Add(8 * time.Hour)
+		var ranges []hintprovider.HintTimeRange
+		for i := 0; i < 16; i++ {
+			hintStart := start.Add(time.Duration(i) * 30 * time.Minute)
+			ranges = append(ranges, hintprovider.HintTimeRange{
+				Start: hintStart,
+				End:   hintStart.Add(time.Minute),
+			})
+		}
+		result := &hintPrefetchResult{ranges: ranges, ingesterCutoff: end}
+		// Unsplit k=8 fills eight 29m gaps (~4.1h, ratio 0.48). After 1h
+		// splits, each slice keeps both 1m hints (16m, ratio 0.97).
+		require.Greater(t, intervalEnvelopeDuration(ranges, start, end), 4*time.Hour)
+		require.Equal(t, 16*time.Minute, envelopeQueriedDuration(ranges, start, end, time.Hour))
+		got := h.shardPlanningDecision(result, start, end)
+		require.True(t, got.eligible)
+		require.Equal(t, "eligible", got.reason)
+	})
+
+	t.Run("unsplit configured interval keeps the 8h sparse case ineligible", func(t *testing.T) {
+		end := start.Add(8 * time.Hour)
+		var ranges []hintprovider.HintTimeRange
+		for i := 0; i < 16; i++ {
+			hintStart := start.Add(time.Duration(i) * 30 * time.Minute)
+			ranges = append(ranges, hintprovider.HintTimeRange{
+				Start: hintStart,
+				End:   hintStart.Add(time.Minute),
+			})
+		}
+		unsplit := &loglinePrefetchHandler{shardPlanning: h.shardPlanning}
+		got := unsplit.shardPlanningDecision(&hintPrefetchResult{ranges: ranges, ingesterCutoff: end}, start, end)
+		require.False(t, got.eligible)
+		require.Equal(t, "time_reduction_too_small", got.reason)
+	})
 }
 
 func TestShardPlanning_BroadOrUnsafeHintsFallBackToFirstQuery(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
+	hour := now.Truncate(time.Hour)
 	baseCfg := defaultShardPlanningTestConfig()
 	firstResp := streamResponseWithEntries(logproto.Entry{Timestamp: now.Add(-10 * time.Minute), Line: "first"})
 
@@ -303,10 +344,11 @@ func TestShardPlanning_BroadOrUnsafeHintsFallBackToFirstQuery(t *testing.T) {
 			name: "envelope fill drops reduction below threshold",
 			cfg:  baseCfg,
 			hp: &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
-				{Start: now.Add(-14 * time.Minute), End: now.Add(-13 * time.Minute)},
-				{Start: now.Add(-2 * time.Minute), End: now.Add(-time.Minute)},
+				{Start: hour.Add(-14 * time.Minute), End: hour.Add(-13 * time.Minute)},
+				{Start: hour.Add(-2 * time.Minute), End: hour.Add(-time.Minute)},
 			}}},
-			req: newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-15*time.Minute), now),
+			// Stay inside one SplitByInterval hour so k=1 unions the bookends.
+			req: newTestLokiRequest(`{job="test"} |= "error"`, hour.Add(-15*time.Minute), hour),
 		},
 		{
 			name: "hint provider error falls back",

--- a/pkg/logline/queryfrontend/shard_planning_test.go
+++ b/pkg/logline/queryfrontend/shard_planning_test.go
@@ -240,7 +240,7 @@ func TestShardPlanning_MultipleDisjointNarrowHintsRerunWithinThresholds(t *testi
 	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), calls.Load())
-	require.ElementsMatch(t, []time.Time{r1.Start, r2.Start}, gotStarts)
+	require.ElementsMatch(t, []time.Time{r1.Start, r2.Start}, gotStarts, "28m gap exceeds the k-envelope cut, so each hint is its own group")
 }
 
 func TestShardPlanning_BroadOrUnsafeHintsFallBackToFirstQuery(t *testing.T) {

--- a/pkg/logline/queryfrontend/shard_planning_test.go
+++ b/pkg/logline/queryfrontend/shard_planning_test.go
@@ -243,6 +243,43 @@ func TestShardPlanning_MultipleDisjointNarrowHintsRerunWithinThresholds(t *testi
 	require.ElementsMatch(t, []time.Time{r1.Start, r2.Start}, gotStarts, "28m gap exceeds the k-envelope cut, so each hint is its own group")
 }
 
+func TestShardPlanningDecision_UsesEnvelopeDuration(t *testing.T) {
+	start := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	h := &loglinePrefetchHandler{shardPlanning: ShardPlanningConfig{
+		Enabled:               true,
+		MinTimeReductionRatio: 0.75,
+	}}
+
+	t.Run("bookend hints on a 15m range fail after k=1 union", func(t *testing.T) {
+		end := start.Add(15 * time.Minute)
+		result := &hintPrefetchResult{
+			ranges: []hintprovider.HintTimeRange{
+				{Start: start.Add(time.Minute), End: start.Add(2 * time.Minute)},
+				{Start: end.Add(-2 * time.Minute), End: end.Add(-time.Minute)},
+			},
+			ingesterCutoff: end,
+		}
+		// Raw hints cover 2m (ratio 0.867). One envelope covers 12m (ratio 0.2).
+		got := h.shardPlanningDecision(result, start, end)
+		require.False(t, got.eligible)
+		require.Equal(t, "time_reduction_too_small", got.reason)
+	})
+
+	t.Run("distant clusters on a 1h range stay eligible", func(t *testing.T) {
+		end := start.Add(time.Hour)
+		result := &hintPrefetchResult{
+			ranges: []hintprovider.HintTimeRange{
+				{Start: start.Add(5 * time.Minute), End: start.Add(6 * time.Minute)},
+				{Start: start.Add(50 * time.Minute), End: start.Add(51 * time.Minute)},
+			},
+			ingesterCutoff: end,
+		}
+		got := h.shardPlanningDecision(result, start, end)
+		require.True(t, got.eligible)
+		require.Equal(t, "eligible", got.reason)
+	})
+}
+
 func TestShardPlanning_BroadOrUnsafeHintsFallBackToFirstQuery(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
 	baseCfg := defaultShardPlanningTestConfig()
@@ -261,6 +298,15 @@ func TestShardPlanning_BroadOrUnsafeHintsFallBackToFirstQuery(t *testing.T) {
 				{Start: now.Add(-50 * time.Minute), End: now.Add(-20 * time.Minute)},
 			}}},
 			req: newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-1*time.Hour), now),
+		},
+		{
+			name: "envelope fill drops reduction below threshold",
+			cfg:  baseCfg,
+			hp: &mockHintProvider{hints: &hintprovider.Hints{TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-14 * time.Minute), End: now.Add(-13 * time.Minute)},
+				{Start: now.Add(-2 * time.Minute), End: now.Add(-time.Minute)},
+			}}},
+			req: newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-15*time.Minute), now),
 		},
 		{
 			name: "hint provider error falls back",


### PR DESCRIPTION
**What this PR does / why we need it**:

Filter MW sits below sharding. One `next.Do` per overlapping hint refetched the same shard chunk for every window, so a Logline query could read **more** than the unfiltered original.

This PR unions overlapping hints, then splits them into **at most k envelopes** by cutting the largest inter-hint gaps:

- `k = ceil(incoming interval / 15m)`, capped at 8
- overlapping/touching hints are never split
- `queried_duration` is the sum of the k envelopes (one incoming interval still counts as one `narrowed`)

Ported from grafana/loki-logline-index-private#318 after the query-frontend package moved into Loki.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

Example: incoming `12:00–12:59` (`k=4`) with hints `12:05–06`, `12:21–22`, `12:35–36`, `12:41–42`, `12:51–52` issues four querier calls: `12:05–06`, `12:21–22`, `12:35–42`, `12:51–52`.

Dev-005 - 24 hour UUID query with 2,000 hint ranges

| | Logline Off | Original (main) | k envelopes (this PR) |
|---|---|---|---|
| `hint_ranges` | — | 2024 | 2024 |
| Tasks | 1102 | 1536 | 1102 |
| `queried_duration` | Full range | 42h5m52s | 913h7m9s |
| `time_reduction_ratio` | — | 0.973 | 0.171 |
| `total_chunks_downloaded` | 94381 | 759462 | 106566 |
| `decompressed_bytes` | 687.7GiB | 216.0GiB | 577.0GiB |
| Wall | 17.20s | 57.41s | 15.28s |
| Unfiltered estimate | 596.7GiB | 596.7GiB | 596.7GiB |

k-envelopes improves latency in this extreme case (2k hint ranges), but does result in more bytes scanned than the original (though still less than without Logline)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.


Made with [Cursor](https://cursor.com)