### PR TITLE
feat: Add support for sharding nested streams by rate and time

### DIFF
--- a/pkg/distributor/rate_shard_nested.go
+++ b/pkg/distributor/rate_shard_nested.go
@@ -1,0 +1,97 @@
+package distributor
+
+import (
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// shardNested splits a nested stream's entries across shards, in contiguous runs taken in the order
+// the groups appear.
+//
+// A shard carries the resources and scopes its entries came from, with their attributes repeated,
+// and one that contributed nothing to a shard is left out of it. Contiguous runs are what keeps
+// that cheap: an attribute set is repeated only where a shard boundary falls inside what it belongs
+// to. For R resources holding G scopes between them, over S shards, that is at most R+S-1 copies of
+// the resource attributes and G+S-1 of the scope attributes. Handing every shard entries from every
+// scope, as round-robin does for flat streams, would cost R*S and G*S instead.
+//
+// A shard takes its entries as subslices of the source rather than copying them, which contiguous
+// runs are also what makes possible. Its entries therefore live in the caller's stream,
+// so a caller that rewrites an entry rewrites it for both.
+func shardNested(stream *logproto.InternalStreamAdapter, shards int) []logproto.InternalStreamAdapter {
+	total := nestedEntryCount(stream)
+	if total == 0 || shards < 1 {
+		return nil
+	}
+
+	// No more shards than there are entries to fill them, matching what streamCount does for flat
+	// streams.
+	if shards > total {
+		shards = total
+	}
+
+	// The remainder is spread over the leading shards rather than left to the last one.
+	base, remainder := total/shards, total%shards
+	shardQuota := func(shard int) int {
+		if shard < remainder {
+			return base + 1
+		}
+		return base
+	}
+
+	out := make([]logproto.InternalStreamAdapter, shards)
+	for i := range out {
+		out[i].Labels = stream.Labels
+		out[i].Hash = stream.Hash
+	}
+
+	shard, placed := 0, 0
+	for _, sourceResource := range stream.ResourceLogs {
+		// The resource being filled in the shard being filled, nil until an entry lands in it.
+		// That is what keeps an empty one out of a shard, and what reopens it in the next shard
+		// when a boundary falls inside it.
+		var resource *logproto.ResourceLogs
+
+		for _, sourceScope := range sourceResource.ScopeLogs {
+			var scope *logproto.ScopeLogs
+
+			// A shard takes a run of this scope's entries, so it can hold them as a subslice of
+			// the source. Crossing into the next shard begins a new run.
+			runStart := 0
+
+			for entryIdx := range sourceScope.Entries {
+				if placed == shardQuota(shard) && shard+1 < shards {
+					shard, placed = shard+1, 0
+					resource, scope, runStart = nil, nil, entryIdx
+				}
+
+				if resource == nil {
+					out[shard].ResourceLogs = append(out[shard].ResourceLogs,
+						logproto.ResourceLogs{Attrs: sourceResource.Attrs})
+					resource = &out[shard].ResourceLogs[len(out[shard].ResourceLogs)-1]
+				}
+				if scope == nil {
+					resource.ScopeLogs = append(resource.ScopeLogs,
+						logproto.ScopeLogs{Attrs: sourceScope.Attrs})
+					scope = &resource.ScopeLogs[len(resource.ScopeLogs)-1]
+				}
+
+				// Capped at its own length, so appending to one shard's entries reallocates
+				// rather than overwriting the entries the next shard is about to take.
+				scope.Entries = sourceScope.Entries[runStart : entryIdx+1 : entryIdx+1]
+				placed++
+			}
+		}
+	}
+	return out
+}
+
+// nestedEntryCount is the number of entries the stream holds, across every group.
+func nestedEntryCount(stream *logproto.InternalStreamAdapter) int {
+	n := 0
+	for i := range stream.ResourceLogs {
+		for j := range stream.ResourceLogs[i].ScopeLogs {
+			n += len(stream.ResourceLogs[i].ScopeLogs[j].Entries)
+		}
+	}
+	return n
+}

--- a/pkg/distributor/rate_shard_nested_test.go
+++ b/pkg/distributor/rate_shard_nested_test.go
@@ -1,0 +1,417 @@
+package distributor
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
+	"github.com/grafana/loki/v3/pkg/logproto"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+func buildEntry(line string) push.Entry {
+	return push.Entry{Timestamp: time.Unix(0, 1).UTC(), Line: line}
+}
+
+func buildNestedAttrs(pairs ...string) []push.LabelAdapter {
+	var out []push.LabelAdapter
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, push.LabelAdapter{Name: pairs[i], Value: pairs[i+1]})
+	}
+	return out
+}
+
+// buildGroupedStream is resources of scopes of entries, every entry's line naming where it sits so a
+// shard can be checked against the source without carrying the source around.
+func buildGroupedStream(resources, scopesPer, entriesPer int) logproto.InternalStreamAdapter {
+	stream := logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7}
+	for r := 0; r < resources; r++ {
+		resource := logproto.ResourceLogs{Attrs: buildNestedAttrs("service", fmt.Sprintf("svc-%d", r))}
+		for s := 0; s < scopesPer; s++ {
+			scope := logproto.ScopeLogs{Attrs: buildNestedAttrs("scope", fmt.Sprintf("scope-%d-%d", r, s))}
+			for e := 0; e < entriesPer; e++ {
+				entry := buildEntry(fmt.Sprintf("r%d-s%d-e%d", r, s, e))
+				if e == 0 {
+					// One entry per scope carries metadata of its own, which has to travel with
+					// the entry rather than be confused with the attributes on its group.
+					entry.StructuredMetadata = push.LabelsAdapter(buildNestedAttrs("trace_id", "abc123"))
+				}
+				scope.Entries = append(scope.Entries, entry)
+			}
+			resource.ScopeLogs = append(resource.ScopeLogs, scope)
+		}
+		stream.ResourceLogs = append(stream.ResourceLogs, resource)
+	}
+	return stream
+}
+
+// requireShardsCarryTheStream asserts what has to hold however the entries are dealt out: the
+// shards together hold every entry exactly once and in order, each under the resource and scope
+// attributes it arrived with, and no shard holds an empty group or an unnamed stream.
+func requireShardsCarryTheStream(t *testing.T, source logproto.InternalStreamAdapter, shards []logproto.InternalStreamAdapter) {
+	t.Helper()
+
+	type placed struct {
+		entry         push.Entry
+		resourceAttrs []push.LabelAdapter
+		scopeAttrs    []push.LabelAdapter
+	}
+	var want []placed
+	for i := range source.ResourceLogs {
+		res := &source.ResourceLogs[i]
+		for j := range res.ScopeLogs {
+			scope := &res.ScopeLogs[j]
+			for _, entry := range scope.Entries {
+				want = append(want, placed{entry, res.Attrs, scope.Attrs})
+			}
+		}
+	}
+
+	seen := 0
+	for s := range shards {
+		shard := &shards[s]
+		// The source's labels and hash, carried through unchanged. Naming a shard is the caller's,
+		// so these are placeholders rather than what a named shard ends up with.
+		require.Equal(t, source.Labels, shard.Labels, "shard %d labels", s)
+		require.Equal(t, source.Hash, shard.Hash, "shard %d hash", s)
+		require.NotEmpty(t, shard.ResourceLogs, "shard %d holds no resources", s)
+
+		for i := range shard.ResourceLogs {
+			res := &shard.ResourceLogs[i]
+			require.NotEmpty(t, res.ScopeLogs, "shard %d holds a resource with no scopes", s)
+
+			for j := range res.ScopeLogs {
+				scope := &res.ScopeLogs[j]
+				require.NotEmpty(t, scope.Entries, "shard %d holds a scope with no entries", s)
+
+				for _, entry := range scope.Entries {
+					require.Less(t, seen, len(want), "shard %d holds more entries than the source", s)
+					w := want[seen]
+					seen++
+
+					require.Equal(t, w.entry, entry, "shard %d: entry %d came back changed", s, seen-1)
+					require.Equal(t, w.resourceAttrs, res.Attrs,
+						"shard %d: entry %d is under the wrong resource", s, seen-1)
+					require.Equal(t, w.scopeAttrs, scope.Attrs,
+						"shard %d: entry %d is under the wrong scope", s, seen-1)
+				}
+			}
+		}
+	}
+	require.Equal(t, len(want), seen, "every entry exactly once, in the order given")
+}
+
+// attrCopies is how many times a group's attributes are written across the shards, which is what
+// contiguous runs exist to keep down.
+func attrCopies(shards []logproto.InternalStreamAdapter) int {
+	n := 0
+	for i := range shards {
+		for j := range shards[i].ResourceLogs {
+			n++ // the resource's attributes
+			n += len(shards[i].ResourceLogs[j].ScopeLogs)
+		}
+	}
+	return n
+}
+
+func TestShardNested(t *testing.T) {
+	buildEntries := func(lines ...string) []push.Entry {
+		out := make([]push.Entry, 0, len(lines))
+		for _, line := range lines {
+			out = append(out, buildEntry(line))
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		name        string
+		buildStream func() logproto.InternalStreamAdapter
+		shards      int
+
+		wantShards int // how many come back, when the case is about that
+	}{
+		{
+			name:        "one group over several shards",
+			buildStream: func() logproto.InternalStreamAdapter { return buildGroupedStream(1, 1, 9) },
+			shards:      3, wantShards: 3,
+		},
+		{
+			name:        "a group per shard",
+			buildStream: func() logproto.InternalStreamAdapter { return buildGroupedStream(3, 1, 4) },
+			shards:      3, wantShards: 3,
+		},
+		{
+			name:        "more groups than shards",
+			buildStream: func() logproto.InternalStreamAdapter { return buildGroupedStream(6, 2, 2) },
+			shards:      3, wantShards: 3,
+		},
+		{
+			name:        "more shards than entries",
+			buildStream: func() logproto.InternalStreamAdapter { return buildGroupedStream(1, 1, 2) },
+			shards:      8, wantShards: 2,
+		},
+		{
+			name:        "entries that do not divide evenly",
+			buildStream: func() logproto.InternalStreamAdapter { return buildGroupedStream(2, 2, 5) },
+			shards:      3, wantShards: 3,
+		},
+		{
+			// One shard is still one shard's worth of work: everything in it, built like any
+			// other count rather than handed back as it came.
+			name:        "one shard asked for",
+			buildStream: func() logproto.InternalStreamAdapter { return buildGroupedStream(3, 2, 2) },
+			shards:      1, wantShards: 1,
+		},
+		{
+			name:        "one entry per scope",
+			buildStream: func() logproto.InternalStreamAdapter { return buildGroupedStream(4, 3, 1) },
+			shards:      4, wantShards: 4,
+		},
+		{
+			name: "empty scopes among full ones, and a resource with none",
+			buildStream: func() logproto.InternalStreamAdapter {
+				return logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7, ResourceLogs: []logproto.ResourceLogs{
+					{Attrs: buildNestedAttrs("service", "svc-0"), ScopeLogs: []logproto.ScopeLogs{
+						{Attrs: buildNestedAttrs("scope", "empty-first")},
+						{Attrs: buildNestedAttrs("scope", "full"), Entries: buildEntries("a1", "a2", "a3")},
+						{Attrs: buildNestedAttrs("scope", "empty-last")},
+					}},
+					{Attrs: buildNestedAttrs("service", "no-scopes")},
+					{Attrs: buildNestedAttrs("service", "svc-2"), ScopeLogs: []logproto.ScopeLogs{
+						{Attrs: buildNestedAttrs("scope", "full"), Entries: buildEntries("c1", "c2")},
+					}},
+				}}
+			},
+			shards: 2, wantShards: 2,
+		},
+		{
+			// What FromStream produces: one group, no attributes on either level.
+			name: "no attributes anywhere",
+			buildStream: func() logproto.InternalStreamAdapter {
+				return logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7, ResourceLogs: []logproto.ResourceLogs{
+					{ScopeLogs: []logproto.ScopeLogs{{Entries: buildEntries("a1", "a2", "a3", "a4")}}},
+				}}
+			},
+			shards: 3, wantShards: 3,
+		},
+		{
+			// Two resources a reader cannot tell apart. They are still two.
+			name: "two resources carrying identical attributes",
+			buildStream: func() logproto.InternalStreamAdapter {
+				return logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7, ResourceLogs: []logproto.ResourceLogs{
+					{Attrs: buildNestedAttrs("service", "same"), ScopeLogs: []logproto.ScopeLogs{
+						{Attrs: buildNestedAttrs("scope", "same"), Entries: buildEntries("a1", "a2")},
+					}},
+					{Attrs: buildNestedAttrs("service", "same"), ScopeLogs: []logproto.ScopeLogs{
+						{Attrs: buildNestedAttrs("scope", "same"), Entries: buildEntries("b1", "b2")},
+					}},
+				}}
+			},
+			shards: 2, wantShards: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := tc.buildStream()
+			shards := shardNested(&input, tc.shards)
+
+			// What to expect is built separately rather than read back off the input, which the
+			// code under test holds pointers into and could have changed underneath us.
+			source := tc.buildStream()
+			require.Len(t, shards, tc.wantShards)
+			requireShardsCarryTheStream(t, source, shards)
+
+			// The entry counts are the ones round-robin would produce: base, with the remainder
+			// spread over the leading shards.
+			total := nestedEntryCount(&source)
+			base, remainder := total/len(shards), total%len(shards)
+			for s := range shards {
+				want := base
+				if s < remainder {
+					want++
+				}
+				require.Equal(t, want, nestedEntryCount(&shards[s]), "shard %d entry count", s)
+			}
+		})
+	}
+}
+
+func TestShardNestedRepeatsAGroupOnlyWhereItStraddlesAShard(t *testing.T) {
+	// A group is written to a shard only if one of its entries went there, so the copies of the
+	// group attributes cannot exceed one per group plus one per boundary a group is split across.
+	for _, tc := range []struct{ resources, scopesPer, entriesPer, shards int }{
+		{1, 1, 100, 8},
+		{4, 1, 25, 8},
+		{10, 2, 5, 8},
+		{20, 1, 5, 4},
+		{3, 3, 7, 5},
+	} {
+		input := buildGroupedStream(tc.resources, tc.scopesPer, tc.entriesPer)
+		shards := shardNested(&input, tc.shards)
+
+		source := buildGroupedStream(tc.resources, tc.scopesPer, tc.entriesPer)
+		requireShardsCarryTheStream(t, source, shards)
+
+		resources, groups := tc.resources, tc.resources*tc.scopesPer
+		// Each resource and each scope is written once, plus once more wherever a shard boundary
+		// falls inside it. There are len(shards)-1 boundaries, and one boundary can fall inside
+		// at most one resource and one scope.
+		bound := (resources + len(shards) - 1) + (groups + len(shards) - 1)
+		require.LessOrEqual(t, attrCopies(shards), bound,
+			"%d resources x %d scopes x %d entries over %d shards", tc.resources, tc.scopesPer, tc.entriesPer, tc.shards)
+
+	}
+}
+
+func TestShardNestedReturnsNothingToShard(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stream logproto.InternalStreamAdapter
+		shards int
+	}{
+		{name: "no shards asked for", stream: buildGroupedStream(2, 2, 2), shards: 0},
+		{name: "a negative number of shards", stream: buildGroupedStream(2, 2, 2), shards: -1},
+		{name: "a stream of no entries", stream: buildGroupedStream(2, 2, 0), shards: 4},
+		{name: "a stream of no groups", stream: logproto.InternalStreamAdapter{Labels: `{app="a"}`}, shards: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Nil(t, shardNested(&tc.stream, tc.shards),
+				"nothing to divide, so the caller keeps the stream it has")
+		})
+	}
+}
+
+// A shard's entries are subslices of the source, as the flat path's time shards are, so a caller
+// rewriting an entry rewrites it for both. Everything above the entries is the shard's own, and
+// appending to a shard cannot reach the entries the next one holds.
+func TestShardNestedSharesOnlyItsEntriesWithTheCaller(t *testing.T) {
+	for _, shards := range []int{1, 2, 5} {
+		input := buildGroupedStream(2, 2, 3)
+		out := shardNested(&input, shards)
+		require.NotEmpty(t, out)
+
+		out[0].Labels = "rewritten"
+		out[0].Hash = 99
+		out[0].ResourceLogs[0].Attrs = buildNestedAttrs("service", "MUTATED")
+
+		require.Equal(t, `{app="a"}`, input.Labels, "shards %d: labels", shards)
+		require.Equal(t, uint64(7), input.Hash, "shards %d: hash", shards)
+		require.Equal(t, "svc-0", input.ResourceLogs[0].Attrs[0].Value, "shards %d: attributes", shards)
+
+		// Appending to a shard reallocates rather than reaching into the source. The scope has
+		// to be one a boundary falls inside, or the shard holds it whole and an append runs off
+		// the end where nothing would notice.
+		split := buildGroupedStream(1, 1, 9)
+		partial := shardNested(&split, 3)
+		require.Len(t, partial, 3)
+		require.Len(t, partial[0].ResourceLogs[0].ScopeLogs[0].Entries, 3, "a partial run")
+
+		before := make([]push.Entry, len(split.ResourceLogs[0].ScopeLogs[0].Entries))
+		copy(before, split.ResourceLogs[0].ScopeLogs[0].Entries)
+
+		first := &partial[0].ResourceLogs[0].ScopeLogs[0]
+		first.Entries = append(first.Entries, buildEntry("appended"))
+
+		require.Equal(t, before, split.ResourceLogs[0].ScopeLogs[0].Entries,
+			"appending to a shard reached into the source")
+		require.Equal(t, "r0-s0-e3", partial[1].ResourceLogs[0].ScopeLogs[0].Entries[0].Line,
+			"appending to a shard overwrote what the next one holds")
+	}
+}
+
+// benchStreams builds one logical push in both shapes. The nested one keeps each resource's and
+// scope's attributes on the group that owns them; the flat one carries them on every entry, which
+// is what the OTLP parser produces today. With sharedAttrs of zero the two hold identical entries,
+// which isolates what the sharding itself costs from what carrying the attributes costs.
+func benchStreams(resources, scopes, entriesPerScope, sharedAttrs int) (logproto.InternalStreamAdapter, logproto.Stream) {
+	attrs := func(prefix string, n int) []push.LabelAdapter {
+		out := make([]push.LabelAdapter, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, push.LabelAdapter{
+				Name:  fmt.Sprintf("%s.attr.%d", prefix, i),
+				Value: strings.Repeat("v", 24),
+			})
+		}
+		return out
+	}
+
+	nested := logproto.InternalStreamAdapter{Labels: `{app="checkout", env="prod"}`, Hash: 12345}
+	flat := logproto.Stream{Labels: nested.Labels, Hash: nested.Hash}
+
+	for r := 0; r < resources; r++ {
+		resourceAttrs := attrs(fmt.Sprintf("resource%d", r), sharedAttrs)
+		resource := logproto.ResourceLogs{Attrs: resourceAttrs}
+
+		for s := 0; s < scopes; s++ {
+			scopeAttrs := attrs(fmt.Sprintf("scope%d.%d", r, s), sharedAttrs/4)
+			scope := logproto.ScopeLogs{Attrs: scopeAttrs}
+
+			for e := 0; e < entriesPerScope; e++ {
+				entry := push.Entry{
+					Timestamp: time.Unix(0, 0).UTC().Add(time.Duration(e%360) * time.Minute),
+					Line:      strings.Repeat("x", 250),
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "trace_id", Value: strings.Repeat("a", 32)},
+					},
+				}
+				scope.Entries = append(scope.Entries, entry)
+
+				// The same entry as the flat path holds it: its own metadata, then the resource's
+				// attributes, then the scope's, in the order otlp.go appends them.
+				expanded := entry
+				expanded.StructuredMetadata = make(push.LabelsAdapter, 0,
+					len(entry.StructuredMetadata)+len(resourceAttrs)+len(scopeAttrs))
+				expanded.StructuredMetadata = append(expanded.StructuredMetadata, entry.StructuredMetadata...)
+				expanded.StructuredMetadata = append(expanded.StructuredMetadata, resourceAttrs...)
+				expanded.StructuredMetadata = append(expanded.StructuredMetadata, scopeAttrs...)
+				flat.Entries = append(flat.Entries, expanded)
+			}
+			resource.ScopeLogs = append(resource.ScopeLogs, scope)
+		}
+		nested.ResourceLogs = append(nested.ResourceLogs, resource)
+	}
+	return nested, flat
+}
+
+var benchShapes = []struct {
+	name        string
+	sharedAttrs int
+}{
+	// What an OTLP push looks like: attributes on the groups, copied onto every entry by the flat
+	// path.
+	{"attributes shared by their group", 12},
+	// The same entries either way, which leaves only the difference between the two algorithms.
+	{"no attributes to share", 0},
+}
+
+func BenchmarkRateSharding(b *testing.B) {
+	const shards = 8
+
+	for _, shape := range benchShapes {
+		nested, flat := benchStreams(4, 2, 1000, shape.sharedAttrs)
+
+		b.Run(shape.name+"/nested", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if out := shardNested(&nested, shards); len(out) != shards {
+					b.Fatalf("got %d shards", len(out))
+				}
+			}
+		})
+
+		b.Run(shape.name+"/flat", func(b *testing.B) {
+			d := &Distributor{logger: log.NewNopLogger(), shardTracker: NewShardTracker()}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if out := d.divideEntriesBetweenShards("tenant", shards, shardstreams.Config{}, flat, "policy"); len(out) != shards {
+					b.Fatalf("got %d shards", len(out))
+				}
+			}
+		})
+	}
+}

--- a/pkg/distributor/time_shard_nested.go
+++ b/pkg/distributor/time_shard_nested.go
@@ -1,0 +1,165 @@
+package distributor
+
+import (
+	"sort"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+// nestedTimeShard is one bucket's worth of a stream: the entries whose timestamps fall in
+// [start, end), and the total length of their lines, which rate sharding takes as the push size.
+//
+// The trailing shard, holding entries too recent to bucket, has a zero start and end. It keeps the
+// stream's own name, where a bucketed shard is named after its window.
+type nestedTimeShard struct {
+	start, end    time.Time
+	stream        logproto.InternalStreamAdapter
+	linesTotalLen int
+}
+
+// recent reports whether this is the trailing shard rather than a bucket. A bucket's start is a
+// truncated entry timestamp, and entry timestamps come off the wire through time.Unix, so the zero
+// time is the trailing shard's alone.
+func (s *nestedTimeShard) recent() bool { return s.start.IsZero() }
+
+// timeShardNested splits a nested stream into buckets of shardLen by entry timestamp, with entries
+// newer than ignoreLogsFrom left in a trailing shard of their own. It reports false when there is
+// nothing old enough to bucket, in which case the caller uses the stream as it stands.
+//
+// Which bucket an entry belongs to depends only on its own timestamp, so nothing is sorted: the flat
+// path's sort is there to make its buckets contiguous sub-slices of one array, which this does not
+// need. Groups are walked one at a time, which is what lets a bucket open each group once.
+//
+// Entries therefore keep the order they arrived in, where the flat path leaves each of its shards in
+// timestamp order. Neither is sorted as the ingester sees it, since a bucket interleaves groups
+// either way, and a bucket spans MaxChunkAge/2, which is exactly the window within which the
+// ingester accepts entries in any order.
+func timeShardNested(stream *logproto.InternalStreamAdapter, shardLen time.Duration, ignoreLogsFrom time.Time) ([]nestedTimeShard, bool) {
+	if nestedEntryCount(stream) == 0 {
+		return nil, false
+	}
+
+	// Nothing to do if every entry is recent, which is the common case and the same shortcut the
+	// flat path takes.
+	if oldestEntry(stream).After(ignoreLogsFrom) {
+		return nil, false
+	}
+
+	// Buckets are keyed by the nanosecond their window opens, which is how Loki carries a log
+	// timestamp everywhere else. Whole seconds would merge two windows of a sub-second shardLen.
+	buckets := map[int64]*timeBucket{}
+	var trailing *timeBucket
+
+	bucket := func(m map[int64]*timeBucket, start int64) *timeBucket {
+		if m[start] == nil {
+			m[start] = &timeBucket{
+				stream:       logproto.InternalStreamAdapter{Labels: stream.Labels, Hash: stream.Hash},
+				lastResource: -1,
+			}
+		}
+		return m[start]
+	}
+
+	// byBucket buffers all entries of a single group by their time bucket.
+	byBucket := map[int64][]push.Entry{}
+	for resourceIdx := range stream.ResourceLogs {
+		resource := &stream.ResourceLogs[resourceIdx]
+
+		for scopeIdx := range resource.ScopeLogs {
+			scope := &resource.ScopeLogs[scopeIdx]
+
+			// clear the entries buffered in the bucket
+			clear(byBucket)
+			var recent []push.Entry
+			for entryIdx := range scope.Entries {
+				entry := &scope.Entries[entryIdx]
+				if !entry.Timestamp.Before(ignoreLogsFrom) {
+					recent = append(recent, *entry)
+					continue
+				}
+				start := entry.Timestamp.Truncate(shardLen).UnixNano()
+				byBucket[start] = append(byBucket[start], *entry)
+			}
+
+			for start, entries := range byBucket {
+				bucket(buckets, start).add(resourceIdx, resource, scope, entries)
+			}
+			if len(recent) > 0 {
+				if trailing == nil {
+					trailing = &timeBucket{
+						stream:       logproto.InternalStreamAdapter{Labels: stream.Labels, Hash: stream.Hash},
+						lastResource: -1,
+					}
+				}
+				trailing.add(resourceIdx, resource, scope, recent)
+			}
+		}
+	}
+
+	starts := make([]int64, 0, len(buckets))
+	for start := range buckets {
+		starts = append(starts, start)
+	}
+	sort.Slice(starts, func(i, j int) bool { return starts[i] < starts[j] })
+
+	// Oldest bucket first, with the trailing shard last, as the flat path returns them.
+	shards := make([]nestedTimeShard, 0, len(starts)+1)
+	for _, start := range starts {
+		at := time.Unix(0, start).UTC()
+		shards = append(shards, nestedTimeShard{
+			start:         at,
+			end:           at.Add(shardLen),
+			stream:        buckets[start].stream,
+			linesTotalLen: buckets[start].linesTotalLen,
+		})
+	}
+	if trailing != nil {
+		shards = append(shards, nestedTimeShard{
+			stream:        trailing.stream,
+			linesTotalLen: trailing.linesTotalLen,
+		})
+	}
+	return shards, true
+}
+
+// timeBucket accumulates the entries of one window. Only the resource it is filling is tracked:
+// groups arrive one at a time, so a bucket takes a scope's entries in a single handful and never
+// returns to that scope, but two scopes of one resource do both reach it and share its resource.
+type timeBucket struct {
+	stream        logproto.InternalStreamAdapter
+	lastResource  int
+	linesTotalLen int
+}
+
+func (b *timeBucket) add(resourceIdx int, resource *logproto.ResourceLogs, scope *logproto.ScopeLogs, entries []push.Entry) {
+	if resourceIdx != b.lastResource {
+		b.stream.ResourceLogs = append(b.stream.ResourceLogs, logproto.ResourceLogs{Attrs: resource.Attrs})
+		b.lastResource = resourceIdx
+	}
+
+	last := &b.stream.ResourceLogs[len(b.stream.ResourceLogs)-1]
+	last.ScopeLogs = append(last.ScopeLogs, logproto.ScopeLogs{Attrs: scope.Attrs, Entries: entries})
+
+	for i := range entries {
+		b.linesTotalLen += len(entries[i].Line)
+	}
+}
+
+// oldestEntry is the earliest timestamp the stream holds. The caller has already established that
+// it holds one.
+func oldestEntry(stream *logproto.InternalStreamAdapter) time.Time {
+	var oldest time.Time
+	for i := range stream.ResourceLogs {
+		for j := range stream.ResourceLogs[i].ScopeLogs {
+			for _, entry := range stream.ResourceLogs[i].ScopeLogs[j].Entries {
+				if oldest.IsZero() || entry.Timestamp.Before(oldest) {
+					oldest = entry.Timestamp
+				}
+			}
+		}
+	}
+	return oldest
+}

--- a/pkg/distributor/time_shard_nested_test.go
+++ b/pkg/distributor/time_shard_nested_test.go
@@ -1,0 +1,449 @@
+package distributor
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+const timeShardLen = time.Hour
+
+// shardBase is where the offsets below are measured from. The epoch, because it falls on a bucket
+// boundary for any whole number of hours, so an offset of 30m is in the first bucket and 90m the
+// second, rather than wherever an arbitrary instant would put them.
+func shardBase() time.Time { return time.Unix(0, 0).UTC() }
+
+// timeSpreadStream gives every group an entry at each offset, with the line naming where and when
+// the entry sits so a shard can be checked without carrying the source around.
+func timeSpreadStream(resources, scopesPer int, offsets []time.Duration) logproto.InternalStreamAdapter {
+	stream := logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7}
+	for r := 0; r < resources; r++ {
+		resource := logproto.ResourceLogs{Attrs: buildNestedAttrs("service", fmt.Sprintf("svc-%d", r))}
+		for s := 0; s < scopesPer; s++ {
+			scope := logproto.ScopeLogs{Attrs: buildNestedAttrs("scope", fmt.Sprintf("scope-%d-%d", r, s))}
+			for _, off := range offsets {
+				scope.Entries = append(scope.Entries, push.Entry{
+					Timestamp: shardBase().Add(off),
+					Line:      fmt.Sprintf("r%d-s%d-%s", r, s, off),
+				})
+			}
+			resource.ScopeLogs = append(resource.ScopeLogs, scope)
+		}
+		stream.ResourceLogs = append(stream.ResourceLogs, resource)
+	}
+	return stream
+}
+
+func flatten(stream logproto.InternalStreamAdapter) logproto.Stream {
+	flat := logproto.Stream{Labels: stream.Labels, Hash: stream.Hash}
+	for i := range stream.ResourceLogs {
+		for j := range stream.ResourceLogs[i].ScopeLogs {
+			flat.Entries = append(flat.Entries, stream.ResourceLogs[i].ScopeLogs[j].Entries...)
+		}
+	}
+	return flat
+}
+
+func linesOf(stream logproto.InternalStreamAdapter) []string {
+	var out []string
+	for i := range stream.ResourceLogs {
+		for j := range stream.ResourceLogs[i].ScopeLogs {
+			for _, e := range stream.ResourceLogs[i].ScopeLogs[j].Entries {
+				out = append(out, e.Line)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func flatLinesOf(stream logproto.Stream) []string {
+	out := make([]string, 0, len(stream.Entries))
+	for _, e := range stream.Entries {
+		out = append(out, e.Line)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// requireTimeShardsAreWellFormed asserts what has to hold whatever the entries look like: a shard
+// names the stream, holds no empty group, opens no more resources or scopes than the source has
+// with those attributes, holds only entries the matching source group holds, keeps a bucketed
+// shard's entries inside its window and the trailing shard's at or after the cutoff with that
+// shard last, and between them holds every entry as often as the source does.
+//
+// Groups are matched by their attributes rather than by position, because bucketing reorders
+// entries, and entries are counted by value rather than identified by line, because a stream may
+// carry the same line more than once. Two source groups carrying identical attributes are
+// indistinguishable in the output, so the checks below bound how many of each a shard may open
+// rather than pretending to tell them apart.
+func requireTimeShardsAreWellFormed(t *testing.T, source logproto.InternalStreamAdapter, shards []nestedTimeShard, ignoreLogsFrom time.Time) {
+	t.Helper()
+
+	entryKey := func(e push.Entry) string {
+		return fmt.Sprint(e.Timestamp.UnixNano(), "\x00", e.Line, "\x00", e.StructuredMetadata)
+	}
+	type groupKey struct{ resource, scope string }
+
+	sourceResources := map[string]int{} // how many resources carry these attributes
+	sourceScopes := map[groupKey]int{}  // how many groups carry this pair of attributes
+	sourceEntries := map[groupKey]map[string]int{}
+	want := map[string]int{}
+	for i := range source.ResourceLogs {
+		res := &source.ResourceLogs[i]
+		sourceResources[fmt.Sprint(res.Attrs)]++
+		for j := range res.ScopeLogs {
+			scope := &res.ScopeLogs[j]
+			gk := groupKey{fmt.Sprint(res.Attrs), fmt.Sprint(scope.Attrs)}
+			sourceScopes[gk]++
+			if sourceEntries[gk] == nil {
+				sourceEntries[gk] = map[string]int{}
+			}
+			for _, entry := range scope.Entries {
+				sourceEntries[gk][entryKey(entry)]++
+				want[entryKey(entry)]++
+			}
+		}
+	}
+
+	seen := map[string]int{}
+	for s := range shards {
+		shard := &shards[s]
+		require.Equal(t, source.Labels, shard.stream.Labels, "shard %d labels", s)
+		require.Equal(t, source.Hash, shard.stream.Hash, "shard %d hash", s)
+		require.NotEmpty(t, shard.stream.ResourceLogs, "shard %d holds no resources", s)
+		if shard.recent() {
+			require.Equal(t, len(shards)-1, s, "the trailing shard comes last")
+		}
+
+		// A resource holding several scopes is written once per shard, and a group once per
+		// shard, so a shard cannot hold more of either than the source has to give it.
+		shardResources, shardScopes := map[string]int{}, map[groupKey]int{}
+
+		for i := range shard.stream.ResourceLogs {
+			res := &shard.stream.ResourceLogs[i]
+			require.NotEmpty(t, res.ScopeLogs, "shard %d holds a resource with no scopes", s)
+
+			resourceAttrs := fmt.Sprint(res.Attrs)
+			shardResources[resourceAttrs]++
+			require.LessOrEqual(t, shardResources[resourceAttrs], sourceResources[resourceAttrs],
+				"shard %d opens more resources carrying %s than the source has", s, resourceAttrs)
+
+			for j := range res.ScopeLogs {
+				scope := &res.ScopeLogs[j]
+				require.NotEmpty(t, scope.Entries, "shard %d holds a scope with no entries", s)
+
+				gk := groupKey{resourceAttrs, fmt.Sprint(scope.Attrs)}
+				shardScopes[gk]++
+				require.LessOrEqual(t, shardScopes[gk], sourceScopes[gk],
+					"shard %d opens more scopes carrying %v than the source has", s, gk)
+
+				for _, entry := range scope.Entries {
+					require.NotZero(t, sourceEntries[gk][entryKey(entry)],
+						"shard %d holds %q under attributes the source never had it under", s, entry.Line)
+					seen[entryKey(entry)]++
+
+					if shard.recent() {
+						require.False(t, entry.Timestamp.Before(ignoreLogsFrom),
+							"shard %d is the trailing one, so %s is not too recent to bucket", s, entry.Line)
+						continue
+					}
+					require.True(t,
+						!entry.Timestamp.Before(shard.start) && entry.Timestamp.Before(shard.end),
+						"shard %d [%s, %s) holds an entry at %s", s, shard.start, shard.end, entry.Timestamp)
+				}
+			}
+		}
+	}
+
+	require.Equal(t, want, seen, "every entry appears as often as the source holds it")
+}
+
+// The buckets, and what lands in them, have to be what the flat path produces. Only the shape of
+// each shard differs.
+//
+// The stream is built by the case rather than described by it, so a case can hold timestamps no
+// offset from a base can express. It is a func because the assertions need a copy of the source the
+// code under test never had a pointer into.
+func TestTimeShardNestedMatchesTheFlatPath(t *testing.T) {
+	spread := func(resources, scopes int, offsets ...time.Duration) func() logproto.InternalStreamAdapter {
+		return func() logproto.InternalStreamAdapter { return timeSpreadStream(resources, scopes, offsets) }
+	}
+	oneGroup := func(entries ...push.Entry) func() logproto.InternalStreamAdapter {
+		return func() logproto.InternalStreamAdapter {
+			return logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7,
+				ResourceLogs: []logproto.ResourceLogs{{
+					Attrs: buildNestedAttrs("service", "svc-0"),
+					ScopeLogs: []logproto.ScopeLogs{{
+						Attrs:   buildNestedAttrs("scope", "scope-0-0"),
+						Entries: entries,
+					}},
+				}}}
+		}
+	}
+	at := func(d time.Duration, line string) push.Entry {
+		return push.Entry{Timestamp: shardBase().Add(d), Line: line}
+	}
+
+	for _, tc := range []struct {
+		name           string
+		stream         func() logproto.InternalStreamAdapter
+		shardLen       time.Duration
+		ignoreLogsFrom time.Time
+	}{
+		{
+			name:           "entries spread over several buckets",
+			stream:         spread(3, 2, 0, 30*time.Minute, 90*time.Minute, 3*time.Hour),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(5 * time.Hour),
+		},
+		{
+			name:           "some entries too recent to bucket",
+			stream:         spread(2, 2, 0, 90*time.Minute, 4*time.Hour+30*time.Minute, 5*time.Hour),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(4 * time.Hour),
+		},
+		{
+			name:           "one bucket only",
+			stream:         spread(4, 1, 0, 10*time.Minute, 20*time.Minute),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(3 * time.Hour),
+		},
+		{
+			name:           "a bucket straddling the recent cutoff",
+			stream:         spread(2, 1, 0, 2*time.Hour+15*time.Minute, 2*time.Hour+45*time.Minute),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(2*time.Hour + 30*time.Minute),
+		},
+		{
+			name:           "several entries in one bucket, none recent",
+			stream:         spread(1, 3, 5*time.Minute, 15*time.Minute, 25*time.Minute),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(6 * time.Hour),
+		},
+		{
+			// An entry exactly on the cutoff. The flat path trails it rather than bucketing it.
+			name:           "an entry exactly on the recent cutoff",
+			stream:         spread(2, 1, 0, 90*time.Minute, 2*time.Hour),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(2 * time.Hour),
+		},
+		{
+			// The same boundary one level up: the whole-stream shortcut turns on the oldest entry.
+			name:           "every entry at or after the cutoff, the oldest exactly on it",
+			stream:         spread(2, 1, 2*time.Hour, 3*time.Hour),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(2 * time.Hour),
+		},
+		{
+			// Not in time order. A bucket takes a group's entries as one run because groups are
+			// walked one at a time, not because anything is sorted.
+			name:           "entries given out of time order",
+			stream:         spread(3, 2, 70*time.Minute, 0, 2*time.Hour, 45*time.Minute),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(6 * time.Hour),
+		},
+		{
+			// The same entry under two different resources, which nothing about the format
+			// forbids and which the checks must not mistake for one entry duplicated.
+			name: "an identical entry in two groups",
+			stream: func() logproto.InternalStreamAdapter {
+				group := func(service string) logproto.ResourceLogs {
+					return logproto.ResourceLogs{
+						Attrs: buildNestedAttrs("service", service),
+						ScopeLogs: []logproto.ScopeLogs{{
+							Attrs: buildNestedAttrs("scope", "only"),
+							Entries: []push.Entry{
+								at(10*time.Minute, "shared-line"),
+								at(90*time.Minute, "shared-line"),
+							},
+						}},
+					}
+				}
+				return logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7,
+					ResourceLogs: []logproto.ResourceLogs{group("svc-0"), group("svc-1")}}
+			},
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(5 * time.Hour),
+		},
+		{
+			// The same line at the same instant, twice. Real traffic repeats lines, and matching
+			// entries back to their group by value rather than by line is what lets it.
+			name: "identical entries in one group",
+			stream: oneGroup(
+				at(10*time.Minute, "repeated"),
+				at(10*time.Minute, "repeated"),
+				at(90*time.Minute, "distinct"),
+			),
+			shardLen:       timeShardLen,
+			ignoreLogsFrom: shardBase().Add(5 * time.Hour),
+		},
+		{
+			// Finer than a second, which the bucket key has to keep whole: truncated to seconds,
+			// two windows would merge and a shard would advertise one excluding entries it holds.
+			name: "a shard length finer than a second",
+			stream: oneGroup(
+				at(100*time.Second, "at-000ms"),
+				at(100*time.Second+600*time.Millisecond, "at-600ms"),
+				at(100*time.Second+1200*time.Millisecond, "at-1200ms"),
+			),
+			shardLen:       500 * time.Millisecond,
+			ignoreLogsFrom: shardBase().Add(time.Hour),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			nested := tc.stream()
+			source := tc.stream()
+			got, ok := timeShardNested(&nested, tc.shardLen, tc.ignoreLogsFrom)
+			requireTimeShardsAreWellFormed(t, source, got, tc.ignoreLogsFrom)
+
+			want, wantOK := shardStreamByTime(flatten(tc.stream()), labels.FromStrings("app", "a"),
+				tc.shardLen, tc.ignoreLogsFrom)
+
+			require.Equal(t, wantOK, ok, "whether there was anything to shard")
+			require.Len(t, got, len(want), "number of time shards")
+
+			// Oldest bucket first with the trailing shard last, as the flat path returns them.
+			// Asserted here rather than left to the comparison below, which only notices a
+			// misordering when the map iteration happens to produce one.
+			for i := range got {
+				if got[i].recent() {
+					require.Equal(t, len(got)-1, i, "the trailing shard comes last")
+					continue
+				}
+				if i > 0 {
+					require.True(t, got[i-1].start.Before(got[i].start),
+						"shard %d starts before shard %d", i-1, i)
+				}
+			}
+
+			for i := range want {
+				require.Equal(t, flatLinesOf(want[i].Stream), linesOf(got[i].stream),
+					"shard %d carries the same entries", i)
+				require.Equal(t, want[i].linesTotalLen, got[i].linesTotalLen,
+					"shard %d line length", i)
+
+				// The flat path names each bucket in the label; this one reports the window.
+				if got[i].recent() {
+					require.NotContains(t, want[i].Stream.Labels, "__time_shard__",
+						"shard %d is the trailing one", i)
+					continue
+				}
+				require.Contains(t, want[i].Stream.Labels,
+					fmt.Sprintf(`__time_shard__="%d_%d"`, got[i].start.Unix(), got[i].end.Unix()),
+					"shard %d window", i)
+			}
+		})
+	}
+}
+
+func TestTimeShardNestedLeavesRecentStreamsAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stream logproto.InternalStreamAdapter
+		ignore time.Duration
+	}{
+		{
+			name:   "every entry newer than the cutoff",
+			stream: timeSpreadStream(2, 2, []time.Duration{3 * time.Hour, 4 * time.Hour}),
+			ignore: 2 * time.Hour,
+		},
+		{
+			name:   "no entries at all",
+			stream: timeSpreadStream(2, 2, nil),
+			ignore: 2 * time.Hour,
+		},
+		{
+			name:   "no groups at all",
+			stream: logproto.InternalStreamAdapter{Labels: `{app="a"}`, Hash: 7},
+			ignore: 2 * time.Hour,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := tc.stream
+			shards, ok := timeShardNested(&source, timeShardLen, shardBase().Add(tc.ignore))
+			require.False(t, ok, "nothing old enough to bucket")
+			require.Nil(t, shards)
+		})
+	}
+}
+
+// Time shards are fed to rate sharding in production, so the invariants have to survive the pair.
+func TestTimeShardsCanThemselvesBeRateSharded(t *testing.T) {
+	ignoreLogsFrom := shardBase().Add(6 * time.Hour)
+	offsets := []time.Duration{0, 30 * time.Minute, 90 * time.Minute, 2 * time.Hour}
+	nested := timeSpreadStream(3, 2, offsets)
+
+	timeShards, ok := timeShardNested(&nested, timeShardLen, ignoreLogsFrom)
+	require.True(t, ok)
+	require.NotEmpty(t, timeShards)
+
+	lines := map[string]int{}
+	for i := range timeShards {
+		for _, shards := range [][]logproto.InternalStreamAdapter{
+			shardNested(&timeShards[i].stream, 1),
+			shardNested(&timeShards[i].stream, 3),
+		} {
+			require.NotEmpty(t, shards)
+			requireShardsCarryTheStream(t, timeShards[i].stream, shards)
+		}
+		for _, shard := range shardNested(&timeShards[i].stream, 3) {
+			for j := range shard.ResourceLogs {
+				for k := range shard.ResourceLogs[j].ScopeLogs {
+					for _, entry := range shard.ResourceLogs[j].ScopeLogs[k].Entries {
+						lines[entry.Line]++
+					}
+				}
+			}
+		}
+	}
+
+	require.Len(t, lines, 3*2*len(offsets), "every entry survives both stages")
+	for line, n := range lines {
+		require.Equal(t, 1, n, "%s appears more than once across the time shards", line)
+	}
+}
+
+func BenchmarkTimeSharding(b *testing.B) {
+	const shardLen = time.Hour
+	ignoreLogsFrom := time.Unix(0, 0).UTC().Add(1000 * time.Hour)
+
+	for _, shape := range benchShapes {
+		nested, flat := benchStreams(4, 2, 1000, shape.sharedAttrs)
+		lbls := labels.FromStrings("app", "checkout", "env", "prod")
+
+		b.Run(shape.name+"/nested", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, ok := timeShardNested(&nested, shardLen, ignoreLogsFrom); !ok {
+					b.Fatal("nothing sharded")
+				}
+			}
+		})
+
+		b.Run(shape.name+"/flat", func(b *testing.B) {
+			// shardStreamByTime sorts the caller's entries in place, so each run is handed an
+			// unsorted copy. Restoring it is not what is being measured.
+			entries := make([]push.Entry, len(flat.Entries))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				copy(entries, flat.Entries)
+				subject := logproto.Stream{Labels: flat.Labels, Hash: flat.Hash, Entries: entries}
+				b.StartTimer()
+
+				if _, ok := shardStreamByTime(subject, lbls, shardLen, ignoreLogsFrom); !ok {
+					b.Fatal("nothing sharded")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the nested counterparts to the distributor's two ways of dividing a push: `shardNested` (`rate_shard_nested.go`) for rate sharding, and `timeShardNested` (`time_shard_nested.go`) for time sharding.

**Nothing calls them yet** :`KeyedStream` is still `logproto.Stream`, so this is the piece the producer will need once the write path carries `logproto.InternalStreamAdapter`.

Loki's OTLP path copies every resource and scope attribute onto every log entry. The nested proto stores each shared set once on the group that owns it. A shard carries the resources and scopes its entries came from, with their attributes repeated, so how entries are dealt out decides how often those attributes are written.

Here is how both sharding strategies are implemented:
* **Rate sharding takes contiguous runs, not round-robin.** The flat path assigns `i % shards`, which assigns entries to shards in round-robin fashion. Following the same approach with nested streams would give every shard entries from every group, so each group's attributes would be duplicated to each shard. Taking runs instead duplicates a group only where a shard boundary falls inside it. For R resources holding G scopes over S shards, that is at most `R+S-1` copies of the resource attributes and `G+S-1` of the scope attributes, against round-robin's `R*S` and `G*S`.

* **Time sharding does not sort.** Which bucket an entry belongs to depends only on its own timestamp, so the flat path's global sort exists to make its buckets contiguous sub-slices of one array, which a nested shard cannot be anyway. Groups are walked one at a time, which lets a bucket take a scope's entries in a single handful and open each group once.

**Benchmarks** (`BenchmarkRateSharding`, `BenchmarkTimeSharding`), 8,000 entries
over 4 resources of 2 scopes, split 8 ways:

##### Rate sharding

Both arms divide the stream, name every shard and take a ring token for it.

| shape | impl | ns/op | B/op | allocs/op |
|---|---|---:|---:|---:|
| attributes shared by their group | nested | 2,113 | 3,888 | 50 |
| attributes shared by their group | flat | 78,308 | 725,556 | 49 |
| no attributes to share | nested | 2,176 | 3,888 | 50 |
| no attributes to share | flat | 84,576 | 725,660 | 49 |

~37× faster with the same number of allocations, and 187× fewer bytes: a shard takes contiguous runs as subslices, while the flat path preallocates an entry slice per shard and copies every entry into it.

##### Time sharding

| shape | input | impl | ns/op | B/op | allocs/op |
|---|---|---|---:|---:|---:|
| attributes shared by their group | in order | nested | 476,846 | 7,809 | 105 |
| attributes shared by their group | in order | flat | 1,024,828 | 1,489 | 32 |
| attributes shared by their group | out of order | nested | 1,696,773 | 7,810 | 105 |
| attributes shared by their group | out of order | flat | 2,341,797 | 1,492 | 32 |
| no attributes to share | in order | nested | 473,381 | 7,810 | 105 |
| no attributes to share | in order | flat | 1,028,825 | 1,489 | 32 |
| no attributes to share | out of order | nested | 1,685,130 | 7,811 | 105 |
| no attributes to share | out of order | flat | 2,373,947 | 1,492 | 32 |

2.15× faster than flat on in-order input and 1.4× on shuffled. Both implementations sort in place, so each iteration is handed its starting order back, with the restore excluded from the timer; two input orders are reported because the sort dominates when entries arrive shuffled.

Nested allocates ~5× more than flat here (7.8KB against 1.5KB): a bucket rebuilds the resources and scopes its entries came from, whereas the flat path sub-slices one sorted array and carries no groups at all.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
