### PR TITLE
feat(query-frontend): Size queries from logline planned ranges

### DIFF
--- a/pkg/logline/queryfrontend/config.go
+++ b/pkg/logline/queryfrontend/config.go
@@ -76,10 +76,10 @@ type MiddlewareConfig struct {
 	// required before running logline index hint lookup.
 	// Set to 0 to disable stats-based gating.
 	MinQueryBytesForIndex int64 `yaml:"min_query_bytes_for_index"`
-	// MaxQueryBytesRead is copied from Loki limits_config.max_query_bytes_read
-	// (global default) at wrap time. It is not a logline YAML knob. Zero means
-	// the limit is disabled; prefetch stays async. Per-tenant overrides are
-	// used when TenantSettings implements maxQueryBytesReader.
+	// MaxQueryBytesRead is Loki's max_query_bytes_read, copied at wrap
+	// time. Not a logline YAML setting. Zero means no limit (prefetch
+	// stays async). Per-tenant overrides apply if TenantSettings
+	// implements maxQueryBytesReader.
 	MaxQueryBytesRead int64 `yaml:"-"`
 	// ShardPlanning controls optional live-query reruns that force Loki's TSDB
 	// shard planner to use a configured strategy when hints prove the request is narrow.

--- a/pkg/logline/queryfrontend/config.go
+++ b/pkg/logline/queryfrontend/config.go
@@ -76,6 +76,11 @@ type MiddlewareConfig struct {
 	// required before running logline index hint lookup.
 	// Set to 0 to disable stats-based gating.
 	MinQueryBytesForIndex int64 `yaml:"min_query_bytes_for_index"`
+	// MaxQueryBytesRead is copied from Loki limits_config.max_query_bytes_read
+	// (global default) at wrap time. It is not a logline YAML knob. Zero means
+	// the limit is disabled; prefetch stays async. Per-tenant overrides are
+	// used when TenantSettings implements maxQueryBytesReader.
+	MaxQueryBytesRead int64 `yaml:"-"`
 	// ShardPlanning controls optional live-query reruns that force Loki's TSDB
 	// shard planner to use a configured strategy when hints prove the request is narrow.
 	ShardPlanning ShardPlanningConfig `yaml:"shard_planning"`

--- a/pkg/logline/queryfrontend/integration.go
+++ b/pkg/logline/queryfrontend/integration.go
@@ -201,6 +201,9 @@ func WrapMiddlewareWithStore(
 	if cfg.QueryIngestersWithin == 0 {
 		cfg.QueryIngestersWithin = lokiCfg.Querier.QueryIngestersWithin
 	}
+	if cfg.MaxQueryBytesRead == 0 {
+		cfg.MaxQueryBytesRead = int64(lokiCfg.LimitsConfig.MaxQueryBytesRead.Val())
+	}
 
 	prefetchMW := NewLoglinePrefetchMiddleware(hp, cfg, tenantSettings, metrics, logger)
 	filterMW := NewLoglineFilterMiddleware(cfg.HintTimeout, metrics, logger)

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -33,8 +33,8 @@ import (
 //
 // 1. Prefetch MW (above SplitByInterval): parses query, kicks off async
 //    logline index lookup, stores results + ingester cutoff in context, and
-//    attaches a PlannedRangeSource. The size limiter waits on that source
-//    only when the full-span query would exceed MaxQueryBytesRead.
+//    If index-stats bytes are at or above MaxQueryBytesRead, prefetch waits
+//    for that lookup before calling next so hints are ready when Loki runs.
 //
 // 2. Filter MW (below SplitByInterval, below cache): for each interval
 //    sub-request, consults the prefetched hints to skip empty intervals
@@ -84,8 +84,7 @@ type provisionalQueryResult struct {
 // hintPrefetchResult holds pre-computed logline index lookup results, shared
 // between the prefetch and filter middleware layers via context.
 type hintPrefetchResult struct {
-	ranges         []hintprovider.HintTimeRange // normalized, sorted by start
-	planned        []querylimits.TimeRange      // query-clipped store windows + ingester
+	ranges         []hintprovider.HintTimeRange // store hits from the index
 	err            error
 	stats          *hintprovider.QueryStats
 	queryBytes     uint64
@@ -212,6 +211,25 @@ func withHintPrefetch(ctx context.Context, r *hintPrefetchResult) context.Contex
 func hintPrefetchFromContext(ctx context.Context) *hintPrefetchResult {
 	v, _ := ctx.Value(hintPrefetchKeyType{}).(*hintPrefetchResult)
 	return v
+}
+
+// waitForHints blocks until the prefetch lookup finishes, the request is
+// cancelled, or HintTimeout fires. Timeout is not an error: callers proceed
+// and the filter falls back to passthrough.
+func (h *loglinePrefetchHandler) waitForHints(ctx context.Context, result *hintPrefetchResult) error {
+	if result == nil {
+		return nil
+	}
+	timer := time.NewTimer(h.hintTimeout)
+	defer timer.Stop()
+	select {
+	case <-result.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func withShardPlanningRerunGuard(ctx context.Context) context.Context {
@@ -819,8 +837,7 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 
 	// Shared eligibility: stats-based byte threshold. Also fetch stats when
 	// MaxQueryBytesRead is set so over-limit queries still start a hint
-	// lookup (and attach a PlannedRangeSource) even if they are under
-	// min_query_bytes.
+	// lookup (and wait for it) even if they are under min_query_bytes.
 	from := lokiReq.StartTs.UTC()
 	through := lokiReq.EndTs.UTC()
 	queryBytes := uint64(0)
@@ -879,7 +896,6 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 	prefetchCtx := ctx
 	go func() {
 		defer close(result.done)
-		defer result.setPlannedRanges()
 
 		start := time.Now()
 		defer func() {
@@ -958,10 +974,12 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 	}()
 
 	ctx = withHintPrefetch(ctx, result)
-	ctx = querylimits.InjectPlannedRangeSource(ctx, &plannedRangeSource{
-		result:  result,
-		timeout: h.hintTimeout,
-	})
+	if overSizeLimit {
+		if err := h.waitForHints(ctx, result); err != nil {
+			return nil, err
+		}
+		ctx = injectPlannedQueryRanges(ctx, result)
+	}
 	if !h.shardPlanning.Enabled {
 		resp, err := h.next.Do(ctx, req)
 		if err != nil {

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -32,7 +32,9 @@ import (
 // Two-layer logline index middleware:
 //
 // 1. Prefetch MW (above SplitByInterval): parses query, kicks off async
-//    logline index lookup, stores results + ingester cutoff in context.
+//    logline index lookup, stores results + ingester cutoff in context, and
+//    attaches a PlannedRangeSource. The size limiter waits on that source
+//    only when the full-span query would exceed MaxQueryBytesRead.
 //
 // 2. Filter MW (below SplitByInterval, below cache): for each interval
 //    sub-request, consults the prefetched hints to skip empty intervals
@@ -251,6 +253,9 @@ func NewLoglinePrefetchMiddleware(
 	if tenantSettings == nil {
 		tenantSettings = staticTenantSettings{}
 	}
+	if cfg.HintTimeout <= 0 {
+		cfg.HintTimeout = defaultHintTimeout
+	}
 	if cfg.ShardPlanning == (ShardPlanningConfig{}) {
 		cfg.ShardPlanning.Enabled = defaultShardPlanningEnabled
 	}
@@ -264,6 +269,7 @@ func NewLoglinePrefetchMiddleware(
 			ngramLength:          cfg.NgramLength,
 			hintTimeout:          cfg.HintTimeout,
 			minQueryBytes:        cfg.MinQueryBytesForIndex,
+			maxQueryBytesRead:    cfg.MaxQueryBytesRead,
 			queryIngestersWithin: cfg.QueryIngestersWithin,
 			shardPlanning:        cfg.ShardPlanning,
 			tenantSettings:       tenantSettings,
@@ -282,6 +288,7 @@ type loglinePrefetchHandler struct {
 	hintTimeout          time.Duration
 	dryRunInflight       atomic.Int32
 	minQueryBytes        int64
+	maxQueryBytesRead    int64
 	queryIngestersWithin time.Duration
 	shardPlanning        ShardPlanningConfig
 	tenantSettings       TenantSettings
@@ -320,6 +327,21 @@ func resolveMode(header string, tenantMode, defaultMode Mode, requireOptInHeader
 	}
 
 	return mode, false
+}
+
+// resolveMaxQueryBytesRead is used only to decide whether to start a hint
+// lookup when the query is under min_query_bytes but would still 400.
+// The size limiter owns waiting on the resulting PlannedRangeSource.
+func (h *loglinePrefetchHandler) resolveMaxQueryBytesRead(tenant string) int64 {
+	if r, ok := h.tenantSettings.(maxQueryBytesReader); ok {
+		if v := r.MaxQueryBytesRead(tenant); v > 0 {
+			return int64(v)
+		}
+	}
+	if h.maxQueryBytesRead > 0 {
+		return h.maxQueryBytesRead
+	}
+	return 0
 }
 
 func (h *loglinePrefetchHandler) getQueryBytes(ctx context.Context, expr syntax.Expr, from, through time.Time) (uint64, error) {
@@ -765,6 +787,7 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 	tenant, _ := user.ExtractOrgID(ctx)
 	tenantMode := ModeUnset
 	minQueryBytes := h.minQueryBytes
+	maxQueryBytesRead := h.resolveMaxQueryBytesRead(tenant)
 	if h.tenantSettings != nil {
 		tenantMode = h.tenantSettings.Mode(tenant)
 		if tenantMinQueryBytes, ok := h.tenantSettings.MinQueryBytesForIndex(tenant); ok {
@@ -794,11 +817,16 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 		return h.next.Do(ctx, req)
 	}
 
-	// Shared eligibility: stats-based byte threshold.
+	// Shared eligibility: stats-based byte threshold. Also fetch stats when
+	// MaxQueryBytesRead is set so over-limit queries still start a hint
+	// lookup (and attach a PlannedRangeSource) even if they are under
+	// min_query_bytes.
 	from := lokiReq.StartTs.UTC()
 	through := lokiReq.EndTs.UTC()
 	queryBytes := uint64(0)
-	if minQueryBytes > 0 {
+	overSizeLimit := false
+	needStats := minQueryBytes > 0 || maxQueryBytesRead > 0
+	if needStats {
 		queryBytes, err = h.getQueryBytes(ctx, expr, from, through)
 		if err != nil {
 			level.Warn(logger).Log(
@@ -808,7 +836,9 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 			)
 			return h.next.Do(ctx, req)
 		}
-		if queryBytes < uint64(minQueryBytes) {
+		overSizeLimit = maxQueryBytesRead > 0 && queryBytes >= uint64(maxQueryBytesRead)
+		belowMinQueryBytes := minQueryBytes > 0 && queryBytes < uint64(minQueryBytes)
+		if belowMinQueryBytes && !overSizeLimit {
 			if h.metrics != nil && h.metrics.hintSkippedSmallQuery != nil {
 				h.metrics.hintSkippedSmallQuery.Inc()
 			}
@@ -927,6 +957,10 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 	}()
 
 	ctx = withHintPrefetch(ctx, result)
+	ctx = querylimits.InjectPlannedRangeSource(ctx, &plannedRangeSource{
+		result:  result,
+		timeout: h.hintTimeout,
+	})
 	if !h.shardPlanning.Enabled {
 		resp, err := h.next.Do(ctx, req)
 		if err != nil {

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -853,7 +853,7 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 			)
 			return h.next.Do(ctx, req)
 		}
-		overSizeLimit = maxQueryBytesRead > 0 && queryBytes >= uint64(maxQueryBytesRead)
+		overSizeLimit = maxQueryBytesRead > 0 && queryBytes > uint64(maxQueryBytesRead)
 		belowMinQueryBytes := minQueryBytes > 0 && queryBytes < uint64(minQueryBytes)
 		if belowMinQueryBytes && !overSizeLimit {
 			if h.metrics != nil && h.metrics.hintSkippedSmallQuery != nil {

--- a/pkg/logline/queryfrontend/middleware.go
+++ b/pkg/logline/queryfrontend/middleware.go
@@ -85,6 +85,7 @@ type provisionalQueryResult struct {
 // between the prefetch and filter middleware layers via context.
 type hintPrefetchResult struct {
 	ranges         []hintprovider.HintTimeRange // normalized, sorted by start
+	planned        []querylimits.TimeRange      // query-clipped store windows + ingester
 	err            error
 	stats          *hintprovider.QueryStats
 	queryBytes     uint64
@@ -329,9 +330,8 @@ func resolveMode(header string, tenantMode, defaultMode Mode, requireOptInHeader
 	return mode, false
 }
 
-// resolveMaxQueryBytesRead is used only to decide whether to start a hint
-// lookup when the query is under min_query_bytes but would still 400.
-// The size limiter owns waiting on the resulting PlannedRangeSource.
+// resolveMaxQueryBytesRead returns the tenant MaxQueryBytesRead override,
+// else the cell setting, else 0 when neither is set.
 func (h *loglinePrefetchHandler) resolveMaxQueryBytesRead(tenant string) int64 {
 	if r, ok := h.tenantSettings.(maxQueryBytesReader); ok {
 		if v := r.MaxQueryBytesRead(tenant); v > 0 {
@@ -879,6 +879,7 @@ func (h *loglinePrefetchHandler) Do(ctx context.Context, req queryrangebase.Requ
 	prefetchCtx := ctx
 	go func() {
 		defer close(result.done)
+		defer result.setPlannedRanges()
 
 		start := time.Now()
 		defer func() {

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -1311,109 +1311,23 @@ func TestPrefetchFilter_HintPrefetchCompletedLogIncludesQueryBytes(t *testing.T)
 	require.Contains(t, logLine, " +15m0s]")
 }
 
-func waitAttachedPlan(ctx context.Context) ([]querylimits.TimeRange, bool) {
-	src, ok := querylimits.ExtractPlannedRangeSource(ctx)
-	if !ok {
-		return nil, false
+func prefetchHintsReady(ctx context.Context) bool {
+	result := hintPrefetchFromContext(ctx)
+	if result == nil {
+		return false
 	}
-	return src.Wait(ctx)
-}
-
-func TestPrefetch_AttachesPlannedRangeSource(t *testing.T) {
-	now := time.Now().Truncate(time.Millisecond)
-	queryStart := now.Add(-2 * time.Hour)
-	hintStart := now.Add(-90 * time.Minute)
-	hintEnd := now.Add(-30 * time.Minute)
-	hp := &mockHintProvider{
-		hints: &hintprovider.Hints{
-			TimeRanges: []hintprovider.HintTimeRange{
-				{Start: hintStart, End: hintEnd},
-			},
-		},
+	select {
+	case <-result.done:
+		return true
+	default:
+		return false
 	}
-
-	var got []querylimits.TimeRange
-	var gotOK, snapshotOK bool
-	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-		if _, ok := req.(*logproto.IndexStatsRequest); ok {
-			return &queryrange.IndexStatsResponse{
-				Response: &logproto.IndexStatsResponse{Bytes: 5000},
-			}, nil
-		}
-		_, snapshotOK = querylimits.ExtractPlannedQueryRanges(ctx)
-		got, gotOK = waitAttachedPlan(ctx)
-		return emptyStreamResponse(), nil
-	})
-
-	cfg := MiddlewareConfig{
-		MaxQueryBytesRead: 1000,
-		HintTimeout:       time.Second,
-	}
-	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
-	req := newTestLokiRequest(`{job="test"} |= "error"`, queryStart, now)
-
-	_, err := handler.Do(testTenantContextWithLive(), req)
-	require.NoError(t, err)
-	require.Equal(t, 1, hp.Calls())
-	require.False(t, snapshotOK, "prefetch must not inject planned ranges; the limiter waits")
-	require.True(t, gotOK)
-	require.Equal(t, []querylimits.TimeRange{{Start: hintStart.UTC(), End: hintEnd.UTC()}}, got)
 }
 
-func TestPrefetch_SourceEmptyHintsAreAPresentEmptyPlan(t *testing.T) {
-	now := time.Now().Truncate(time.Millisecond)
-	hp := &mockHintProvider{hints: &hintprovider.Hints{}}
-
-	var got []querylimits.TimeRange
-	var gotOK bool
-	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-		if _, ok := req.(*logproto.IndexStatsRequest); ok {
-			return &queryrange.IndexStatsResponse{
-				Response: &logproto.IndexStatsResponse{Bytes: 5000},
-			}, nil
-		}
-		got, gotOK = waitAttachedPlan(ctx)
-		return emptyStreamResponse(), nil
-	})
-
-	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
-	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
-	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
-
-	_, err := handler.Do(testTenantContextWithLive(), req)
-	require.NoError(t, err)
-	require.True(t, gotOK)
-	require.Empty(t, got)
-}
-
-func TestPrefetch_SourceHintErrorIsAbsent(t *testing.T) {
-	now := time.Now().Truncate(time.Millisecond)
-	hp := &mockHintProvider{err: errors.New("hint backend down")}
-
-	var gotOK bool
-	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-		if _, ok := req.(*logproto.IndexStatsRequest); ok {
-			return &queryrange.IndexStatsResponse{
-				Response: &logproto.IndexStatsResponse{Bytes: 5000},
-			}, nil
-		}
-		_, gotOK = waitAttachedPlan(ctx)
-		return emptyStreamResponse(), nil
-	})
-
-	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
-	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
-	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
-
-	_, err := handler.Do(testTenantContextWithLive(), req)
-	require.NoError(t, err)
-	require.False(t, gotOK, "failed hints must leave the size limiter on the full span")
-}
-
-func TestPrefetch_SourceHintTimeoutIsAbsent(t *testing.T) {
+func TestPrefetch_OverSizeLimit_WaitsBeforeNext(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
 	hp := &mockHintProvider{
-		delay: 200 * time.Millisecond,
+		delay: 30 * time.Millisecond,
 		hints: &hintprovider.Hints{
 			TimeRanges: []hintprovider.HintTimeRange{
 				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
@@ -1421,47 +1335,87 @@ func TestPrefetch_SourceHintTimeoutIsAbsent(t *testing.T) {
 		},
 	}
 
-	var gotOK bool
+	var readyAtNext bool
+	var planned []querylimits.TimeRange
+	var plannedOK bool
 	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
 		if _, ok := req.(*logproto.IndexStatsRequest); ok {
 			return &queryrange.IndexStatsResponse{
 				Response: &logproto.IndexStatsResponse{Bytes: 5000},
 			}, nil
 		}
-		_, gotOK = waitAttachedPlan(ctx)
+		readyAtNext = prefetchHintsReady(ctx)
+		planned, plannedOK = querylimits.ExtractPlannedQueryRanges(ctx)
 		return emptyStreamResponse(), nil
 	})
 
-	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: 20 * time.Millisecond}
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
 	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
 	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
 
 	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
-	require.False(t, gotOK, "timed-out hints must leave the size limiter on the full span")
+	require.Equal(t, 1, hp.Calls())
+	require.True(t, readyAtNext, "over MaxQueryBytesRead must wait for hints before next.Do")
+	require.True(t, plannedOK)
+	require.Equal(t, []querylimits.TimeRange{{
+		Start: now.Add(-45 * time.Minute).UTC(),
+		End:   now.Add(-30 * time.Minute).UTC(),
+	}}, planned)
 }
 
-func TestPrefetch_BelowMinBytesButOverSizeLimit_StillLooksUpHints(t *testing.T) {
+func TestPrefetch_UnderSizeLimit_DoesNotWaitBeforeNext(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
-	hintStart := now.Add(-45 * time.Minute)
-	hintEnd := now.Add(-30 * time.Minute)
 	hp := &mockHintProvider{
+		delay: 50 * time.Millisecond,
 		hints: &hintprovider.Hints{
 			TimeRanges: []hintprovider.HintTimeRange{
-				{Start: hintStart, End: hintEnd},
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
 			},
 		},
 	}
 
-	var got []querylimits.TimeRange
-	var gotOK bool
+	var readyAtNext bool
+	var plannedOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 100},
+			}, nil
+		}
+		readyAtNext = prefetchHintsReady(ctx)
+		_, plannedOK = querylimits.ExtractPlannedQueryRanges(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.False(t, readyAtNext, "under MaxQueryBytesRead must not block on hints")
+	require.False(t, plannedOK, "under MaxQueryBytesRead must not inject a plan")
+}
+
+func TestPrefetch_BelowMinBytesButOverSizeLimit_StillLooksUpHints(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	var readyAtNext bool
 	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
 		if _, ok := req.(*logproto.IndexStatsRequest); ok {
 			return &queryrange.IndexStatsResponse{
 				Response: &logproto.IndexStatsResponse{Bytes: 2000},
 			}, nil
 		}
-		got, gotOK = waitAttachedPlan(ctx)
+		readyAtNext = prefetchHintsReady(ctx)
 		return emptyStreamResponse(), nil
 	})
 
@@ -1476,30 +1430,27 @@ func TestPrefetch_BelowMinBytesButOverSizeLimit_StillLooksUpHints(t *testing.T) 
 	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
 	require.Equal(t, 1, hp.Calls(), "over-limit queries must not skip hint lookup for being under min_query_bytes")
-	require.True(t, gotOK)
-	require.Equal(t, []querylimits.TimeRange{{Start: hintStart.UTC(), End: hintEnd.UTC()}}, got)
+	require.True(t, readyAtNext)
 }
 
 func TestPrefetch_TenantMaxQueryBytesReadStillStartsHints(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
-	hintStart := now.Add(-45 * time.Minute)
-	hintEnd := now.Add(-30 * time.Minute)
 	hp := &mockHintProvider{
 		hints: &hintprovider.Hints{
 			TimeRanges: []hintprovider.HintTimeRange{
-				{Start: hintStart, End: hintEnd},
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
 			},
 		},
 	}
 
-	var gotOK bool
+	var readyAtNext bool
 	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
 		if _, ok := req.(*logproto.IndexStatsRequest); ok {
 			return &queryrange.IndexStatsResponse{
 				Response: &logproto.IndexStatsResponse{Bytes: 2000},
 			}, nil
 		}
-		_, gotOK = waitAttachedPlan(ctx)
+		readyAtNext = prefetchHintsReady(ctx)
 		return emptyStreamResponse(), nil
 	})
 
@@ -1515,52 +1466,92 @@ func TestPrefetch_TenantMaxQueryBytesReadStillStartsHints(t *testing.T) {
 
 	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
-	require.True(t, gotOK, "tenant cap should still start a hint lookup")
+	require.True(t, readyAtNext, "tenant cap should still start a hint lookup and wait")
 }
 
-func TestPrefetch_OverSizeLimit_FirstDownstreamHasSourceNotSnapshot(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Millisecond)
-	hintStart := now.Add(-45 * time.Minute)
-	hintEnd := now.Add(-30 * time.Minute)
+func TestPrefetch_OverSizeLimit_TimeoutDoesNotInjectPlan(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
 	hp := &mockHintProvider{
-		delay: 20 * time.Millisecond,
+		delay: 200 * time.Millisecond,
 		hints: &hintprovider.Hints{
 			TimeRanges: []hintprovider.HintTimeRange{
-				{Start: hintStart, End: hintEnd},
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
 			},
 		},
 	}
 
-	var firstHadSnapshot, firstHadSource bool
-	lokiCalls := 0
+	var plannedOK bool
 	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
 		if _, ok := req.(*logproto.IndexStatsRequest); ok {
 			return &queryrange.IndexStatsResponse{
-				Response: &logproto.IndexStatsResponse{Bytes: 1000},
+				Response: &logproto.IndexStatsResponse{Bytes: 5000},
 			}, nil
 		}
-		lokiCalls++
-		if lokiCalls == 1 {
-			_, firstHadSnapshot = querylimits.ExtractPlannedQueryRanges(ctx)
-			_, firstHadSource = querylimits.ExtractPlannedRangeSource(ctx)
-		}
+		_, plannedOK = querylimits.ExtractPlannedQueryRanges(ctx)
 		return emptyStreamResponse(), nil
 	})
 
-	cfg := MiddlewareConfig{
-		MinQueryBytesForIndex: 500,
-		MaxQueryBytesRead:     800,
-		HintTimeout:           time.Second,
-		ShardPlanning:         ShardPlanningConfig{Enabled: true, MinTimeReductionRatio: 0.1},
-	}
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: 20 * time.Millisecond}
 	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
 	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
 
 	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, lokiCalls, 1)
-	require.False(t, firstHadSnapshot, "prefetch does not inject planned ranges before next.Do")
-	require.True(t, firstHadSource, "the size limiter waits on the attached source")
+	require.False(t, plannedOK, "timeout must leave the size limiter on the full span")
+}
+
+func TestPrefetch_OverSizeLimit_LookupErrorDoesNotInjectPlan(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		err: errors.New("hint lookup failed"),
+	}
+
+	var plannedOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 5000},
+			}, nil
+		}
+		_, plannedOK = querylimits.ExtractPlannedQueryRanges(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.False(t, plannedOK)
+}
+
+func TestPrefetch_OverSizeLimit_EmptyHintsInjectsPresentPlan(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{},
+	}
+
+	var planned []querylimits.TimeRange
+	var plannedOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 5000},
+			}, nil
+		}
+		planned, plannedOK = querylimits.ExtractPlannedQueryRanges(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.True(t, plannedOK)
+	require.Empty(t, planned)
 }
 
 func TestPrefetchFilter_SkipCacheHeaderSetsHintContext(t *testing.T) {

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -1398,6 +1398,40 @@ func TestPrefetch_UnderSizeLimit_DoesNotWaitBeforeNext(t *testing.T) {
 	require.False(t, plannedOK, "under MaxQueryBytesRead must not inject a plan")
 }
 
+func TestPrefetch_AtSizeLimit_DoesNotWaitBeforeNext(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		delay: 50 * time.Millisecond,
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	var readyAtNext bool
+	var plannedOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 1000},
+			}, nil
+		}
+		readyAtNext = prefetchHintsReady(ctx)
+		_, plannedOK = querylimits.ExtractPlannedQueryRanges(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.False(t, readyAtNext, "at MaxQueryBytesRead the limiter allows the query; do not wait")
+	require.False(t, plannedOK, "at MaxQueryBytesRead must not inject a plan")
+}
+
 func TestPrefetch_BelowMinBytesButOverSizeLimit_StillLooksUpHints(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
 	hp := &mockHintProvider{

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -1355,7 +1355,7 @@ func TestPrefetch_AttachesPlannedRangeSource(t *testing.T) {
 	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
 	require.Equal(t, 1, hp.Calls())
-	require.False(t, snapshotOK, "prefetch must not freeze a plan; the limiter waits")
+	require.False(t, snapshotOK, "prefetch must not inject planned ranges; the limiter waits")
 	require.True(t, gotOK)
 	require.Equal(t, []querylimits.TimeRange{{Start: hintStart.UTC(), End: hintEnd.UTC()}}, got)
 }
@@ -1559,7 +1559,7 @@ func TestPrefetch_OverSizeLimit_FirstDownstreamHasSourceNotSnapshot(t *testing.T
 	_, err := handler.Do(testTenantContextWithLive(), req)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, lokiCalls, 1)
-	require.False(t, firstHadSnapshot, "prefetch no longer freezes a plan before next.Do")
+	require.False(t, firstHadSnapshot, "prefetch does not inject planned ranges before next.Do")
 	require.True(t, firstHadSource, "the size limiter waits on the attached source")
 }
 

--- a/pkg/logline/queryfrontend/middleware_test.go
+++ b/pkg/logline/queryfrontend/middleware_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
 
 	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
 )
@@ -43,6 +44,7 @@ type mockHintProvider struct {
 type mockTenantSettings struct {
 	modes                 map[string]Mode
 	minQueryBytesForIndex map[string]int64
+	maxQueryBytesRead     map[string]int
 }
 
 func (m mockTenantSettings) Mode(tenant string) Mode {
@@ -62,6 +64,13 @@ func (m mockTenantSettings) MinQueryBytesForIndex(tenant string) (int64, bool) {
 	}
 	minQueryBytes, ok := m.minQueryBytesForIndex[tenant]
 	return minQueryBytes, ok
+}
+
+func (m mockTenantSettings) MaxQueryBytesRead(tenant string) int {
+	if m.maxQueryBytesRead == nil {
+		return 0
+	}
+	return m.maxQueryBytesRead[tenant]
 }
 
 func (m *mockHintProvider) ProvideHints(
@@ -1300,6 +1309,258 @@ func TestPrefetchFilter_HintPrefetchCompletedLogIncludesQueryBytes(t *testing.T)
 	require.Contains(t, logLine, "hint_total_seconds=900.0")
 	require.Contains(t, logLine, "hint_ranges_detail=")
 	require.Contains(t, logLine, " +15m0s]")
+}
+
+func waitAttachedPlan(ctx context.Context) ([]querylimits.TimeRange, bool) {
+	src, ok := querylimits.ExtractPlannedRangeSource(ctx)
+	if !ok {
+		return nil, false
+	}
+	return src.Wait(ctx)
+}
+
+func TestPrefetch_AttachesPlannedRangeSource(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	queryStart := now.Add(-2 * time.Hour)
+	hintStart := now.Add(-90 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var got []querylimits.TimeRange
+	var gotOK, snapshotOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 5000},
+			}, nil
+		}
+		_, snapshotOK = querylimits.ExtractPlannedQueryRanges(ctx)
+		got, gotOK = waitAttachedPlan(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{
+		MaxQueryBytesRead: 1000,
+		HintTimeout:       time.Second,
+	}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, queryStart, now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls())
+	require.False(t, snapshotOK, "prefetch must not freeze a plan; the limiter waits")
+	require.True(t, gotOK)
+	require.Equal(t, []querylimits.TimeRange{{Start: hintStart.UTC(), End: hintEnd.UTC()}}, got)
+}
+
+func TestPrefetch_SourceEmptyHintsAreAPresentEmptyPlan(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{hints: &hintprovider.Hints{}}
+
+	var got []querylimits.TimeRange
+	var gotOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 5000},
+			}, nil
+		}
+		got, gotOK = waitAttachedPlan(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.True(t, gotOK)
+	require.Empty(t, got)
+}
+
+func TestPrefetch_SourceHintErrorIsAbsent(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{err: errors.New("hint backend down")}
+
+	var gotOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 5000},
+			}, nil
+		}
+		_, gotOK = waitAttachedPlan(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: time.Second}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.False(t, gotOK, "failed hints must leave the size limiter on the full span")
+}
+
+func TestPrefetch_SourceHintTimeoutIsAbsent(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hp := &mockHintProvider{
+		delay: 200 * time.Millisecond,
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: now.Add(-45 * time.Minute), End: now.Add(-30 * time.Minute)},
+			},
+		},
+	}
+
+	var gotOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 5000},
+			}, nil
+		}
+		_, gotOK = waitAttachedPlan(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{MaxQueryBytesRead: 1000, HintTimeout: 20 * time.Millisecond}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.False(t, gotOK, "timed-out hints must leave the size limiter on the full span")
+}
+
+func TestPrefetch_BelowMinBytesButOverSizeLimit_StillLooksUpHints(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var got []querylimits.TimeRange
+	var gotOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 2000},
+			}, nil
+		}
+		got, gotOK = waitAttachedPlan(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{
+		MinQueryBytesForIndex: 10_000,
+		MaxQueryBytesRead:     1000,
+		HintTimeout:           time.Second,
+	}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.Equal(t, 1, hp.Calls(), "over-limit queries must not skip hint lookup for being under min_query_bytes")
+	require.True(t, gotOK)
+	require.Equal(t, []querylimits.TimeRange{{Start: hintStart.UTC(), End: hintEnd.UTC()}}, got)
+}
+
+func TestPrefetch_TenantMaxQueryBytesReadStillStartsHints(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var gotOK bool
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 2000},
+			}, nil
+		}
+		_, gotOK = waitAttachedPlan(ctx)
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{
+		MaxQueryBytesRead: 10_000,
+		HintTimeout:       time.Second,
+	}
+	settings := mockTenantSettings{
+		maxQueryBytesRead: map[string]int{"test": 1000},
+	}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, settings, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.True(t, gotOK, "tenant cap should still start a hint lookup")
+}
+
+func TestPrefetch_OverSizeLimit_FirstDownstreamHasSourceNotSnapshot(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	hintStart := now.Add(-45 * time.Minute)
+	hintEnd := now.Add(-30 * time.Minute)
+	hp := &mockHintProvider{
+		delay: 20 * time.Millisecond,
+		hints: &hintprovider.Hints{
+			TimeRanges: []hintprovider.HintTimeRange{
+				{Start: hintStart, End: hintEnd},
+			},
+		},
+	}
+
+	var firstHadSnapshot, firstHadSource bool
+	lokiCalls := 0
+	next := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return &queryrange.IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 1000},
+			}, nil
+		}
+		lokiCalls++
+		if lokiCalls == 1 {
+			_, firstHadSnapshot = querylimits.ExtractPlannedQueryRanges(ctx)
+			_, firstHadSource = querylimits.ExtractPlannedRangeSource(ctx)
+		}
+		return emptyStreamResponse(), nil
+	})
+
+	cfg := MiddlewareConfig{
+		MinQueryBytesForIndex: 500,
+		MaxQueryBytesRead:     800,
+		HintTimeout:           time.Second,
+		ShardPlanning:         ShardPlanningConfig{Enabled: true, MinTimeReductionRatio: 0.1},
+	}
+	handler := NewLoglinePrefetchMiddleware(hp, cfg, nil, newTestMetrics(), nil).Wrap(next)
+	req := newTestLokiRequest(`{job="test"} |= "error"`, now.Add(-time.Hour), now)
+
+	_, err := handler.Do(testTenantContextWithLive(), req)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, lokiCalls, 1)
+	require.False(t, firstHadSnapshot, "prefetch no longer freezes a plan before next.Do")
+	require.True(t, firstHadSource, "the size limiter waits on the attached source")
 }
 
 func TestPrefetchFilter_SkipCacheHeaderSetsHintContext(t *testing.T) {

--- a/pkg/logline/queryfrontend/planned_ranges.go
+++ b/pkg/logline/queryfrontend/planned_ranges.go
@@ -9,50 +9,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
 )
 
-// plannedRangeSource lets Loki's size limiter wait on hint prefetch only
-// when the full-span query would exceed MaxQueryBytesRead. Wait only
-// blocks; the scan plan is built when the lookup finishes.
-type plannedRangeSource struct {
-	result  *hintPrefetchResult
-	timeout time.Duration
-}
-
-func (s *plannedRangeSource) Wait(ctx context.Context) ([]querylimits.TimeRange, bool) {
-	if s == nil || s.result == nil {
-		return nil, false
-	}
-	timer := time.NewTimer(s.timeout)
-	defer timer.Stop()
-	select {
-	case <-s.result.done:
-	case <-ctx.Done():
-		return nil, false
-	case <-timer.C:
-		return nil, false
-	}
-	if s.result.err != nil {
-		return nil, false
-	}
-	return s.result.planned, true
-}
-
-// setPlannedRanges builds the Loki scan plan after the hint lookup finishes.
-// Call before closing done. A lookup error leaves planned unset so Wait is absent.
-func (r *hintPrefetchResult) setPlannedRanges() {
-	if r == nil || r.err != nil {
-		return
-	}
-	r.planned = buildPlannedQueryRanges(r.ranges, r.queryStart, r.queryEnd, r.ingesterCutoff)
-}
-
 // buildPlannedQueryRanges is the time that will actually be queried:
 // store windows from hints, plus the ingester window if the query reaches it.
 // Index-empty holes are omitted.
-//
-// hints are already sorted and adjacent-merged by the provider. Store hits are
-// intersected with [queryStart, min(queryEnd, cutoff)) the same way filter
-// clips to a shard; max(zero, queryStart) rewrites the pre-min_date sentinel.
-// Ingester time is attached after; hints never include it.
 func buildPlannedQueryRanges(
 	hints []hintprovider.HintTimeRange,
 	queryStart, queryEnd, ingesterCutoff time.Time,
@@ -79,9 +38,7 @@ func buildPlannedQueryRanges(
 }
 
 // attachIngesterRange adds [max(queryStart, cutoff), queryEnd). Hints are
-// store-only, so this window is never in the list. If the last store window
-// already touches cutoff, extend it instead of appending a twin for Loki to
-// stats separately.
+// store-only. If the last store window already touches cutoff, extend it.
 func attachIngesterRange(store []querylimits.TimeRange, queryStart, queryEnd, ingesterCutoff time.Time) []querylimits.TimeRange {
 	if !queryEnd.After(ingesterCutoff) {
 		return store
@@ -99,4 +56,21 @@ func attachIngesterRange(store []querylimits.TimeRange, queryStart, queryEnd, in
 		return store
 	}
 	return append(store, ingester)
+}
+
+// injectPlannedQueryRanges puts a finished plan on ctx when the lookup
+// completed without error. Timeout (done still open) or error leaves ctx
+// unchanged so the size limiter uses the full request range.
+func injectPlannedQueryRanges(ctx context.Context, result *hintPrefetchResult) context.Context {
+	if result == nil || result.err != nil {
+		return ctx
+	}
+	select {
+	case <-result.done:
+	default:
+		return ctx
+	}
+	return querylimits.InjectPlannedQueryRanges(ctx, buildPlannedQueryRanges(
+		result.ranges, result.queryStart, result.queryEnd, result.ingesterCutoff,
+	))
 }

--- a/pkg/logline/queryfrontend/planned_ranges.go
+++ b/pkg/logline/queryfrontend/planned_ranges.go
@@ -1,0 +1,92 @@
+package queryfrontend
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
+
+	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
+)
+
+// plannedRangeSource lets Loki's size limiter wait on hint prefetch only
+// when the full-span query would exceed MaxQueryBytesRead.
+type plannedRangeSource struct {
+	result  *hintPrefetchResult
+	timeout time.Duration
+}
+
+func (s *plannedRangeSource) Wait(ctx context.Context) ([]querylimits.TimeRange, bool) {
+	if s == nil || s.result == nil {
+		return nil, false
+	}
+	timer := time.NewTimer(s.timeout)
+	defer timer.Stop()
+	select {
+	case <-s.result.done:
+	case <-ctx.Done():
+		return nil, false
+	case <-timer.C:
+		return nil, false
+	}
+	if s.result.err != nil {
+		return nil, false
+	}
+	return buildPlannedQueryRanges(s.result.ranges, s.result.queryStart, s.result.queryEnd, s.result.ingesterCutoff), true
+}
+
+// buildPlannedQueryRanges is the time that will actually be queried:
+// store windows from hints, plus the ingester window if the query reaches it.
+// Index-empty holes are omitted.
+//
+// hints are already sorted and adjacent-merged by the provider. Store hits are
+// intersected with [queryStart, min(queryEnd, cutoff)) the same way filter
+// clips to a shard; max(zero, queryStart) rewrites the pre-min_date sentinel.
+// Ingester time is attached after; hints never include it.
+func buildPlannedQueryRanges(
+	hints []hintprovider.HintTimeRange,
+	queryStart, queryEnd, ingesterCutoff time.Time,
+) []querylimits.TimeRange {
+	queryStart = queryStart.UTC()
+	queryEnd = queryEnd.UTC()
+	ingesterCutoff = ingesterCutoff.UTC()
+	storeEnd := minTime(queryEnd, ingesterCutoff)
+
+	out := make([]querylimits.TimeRange, 0, len(hints)+1)
+	for _, hint := range hints {
+		start := maxTime(hint.Start.UTC(), queryStart)
+		end := minTime(hint.End.UTC(), storeEnd)
+		if start.Before(end) {
+			out = append(out, querylimits.TimeRange{Start: start, End: end})
+		}
+	}
+
+	out = attachIngesterRange(out, queryStart, queryEnd, ingesterCutoff)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// attachIngesterRange adds [max(queryStart, cutoff), queryEnd). Hints are
+// store-only, so this window is never in the list. If the last store window
+// already touches cutoff, extend it instead of appending a twin for Loki to
+// stats separately.
+func attachIngesterRange(store []querylimits.TimeRange, queryStart, queryEnd, ingesterCutoff time.Time) []querylimits.TimeRange {
+	if !queryEnd.After(ingesterCutoff) {
+		return store
+	}
+	ingester := querylimits.TimeRange{
+		Start: maxTime(queryStart, ingesterCutoff),
+		End:   queryEnd,
+	}
+	if len(store) == 0 {
+		return append(store, ingester)
+	}
+	last := &store[len(store)-1]
+	if !ingester.Start.After(last.End) {
+		last.End = ingester.End
+		return store
+	}
+	return append(store, ingester)
+}

--- a/pkg/logline/queryfrontend/planned_ranges.go
+++ b/pkg/logline/queryfrontend/planned_ranges.go
@@ -10,7 +10,8 @@ import (
 )
 
 // plannedRangeSource lets Loki's size limiter wait on hint prefetch only
-// when the full-span query would exceed MaxQueryBytesRead.
+// when the full-span query would exceed MaxQueryBytesRead. Wait only
+// blocks; the scan plan is built when the lookup finishes.
 type plannedRangeSource struct {
 	result  *hintPrefetchResult
 	timeout time.Duration
@@ -32,7 +33,16 @@ func (s *plannedRangeSource) Wait(ctx context.Context) ([]querylimits.TimeRange,
 	if s.result.err != nil {
 		return nil, false
 	}
-	return buildPlannedQueryRanges(s.result.ranges, s.result.queryStart, s.result.queryEnd, s.result.ingesterCutoff), true
+	return s.result.planned, true
+}
+
+// setPlannedRanges builds the Loki scan plan after the hint lookup finishes.
+// Call before closing done. A lookup error leaves planned unset so Wait is absent.
+func (r *hintPrefetchResult) setPlannedRanges() {
+	if r == nil || r.err != nil {
+		return
+	}
+	r.planned = buildPlannedQueryRanges(r.ranges, r.queryStart, r.queryEnd, r.ingesterCutoff)
 }
 
 // buildPlannedQueryRanges is the time that will actually be queried:

--- a/pkg/logline/queryfrontend/planned_ranges_test.go
+++ b/pkg/logline/queryfrontend/planned_ranges_test.go
@@ -1,0 +1,178 @@
+package queryfrontend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
+
+	"github.com/grafana/loki/v3/pkg/logline/hintprovider"
+)
+
+func TestBuildPlannedQueryRanges(t *testing.T) {
+	queryStart := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	queryEnd := queryStart.Add(4 * time.Hour)
+	cutoff := queryStart.Add(3 * time.Hour)
+
+	for _, tc := range []struct {
+		desc   string
+		hints  []hintprovider.HintTimeRange
+		start  time.Time
+		end    time.Time
+		cutoff time.Time
+		want   []querylimits.TimeRange
+	}{
+		{
+			desc:   "no hints and no ingester window",
+			start:  queryStart,
+			end:    cutoff,
+			cutoff: cutoff,
+			want:   nil,
+		},
+		{
+			desc:   "no hints attaches the ingester window",
+			start:  queryStart,
+			end:    queryEnd,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: cutoff, End: queryEnd},
+			},
+		},
+		{
+			desc: "store hints are clipped to the query and cutoff",
+			hints: []hintprovider.HintTimeRange{
+				{Start: queryStart.Add(-time.Hour), End: queryStart.Add(30 * time.Minute)},
+				{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
+			},
+			start:  queryStart,
+			end:    queryEnd,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: queryStart, End: queryStart.Add(30 * time.Minute)},
+				{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
+			},
+		},
+		{
+			desc: "zero-start passthrough is rewritten to query start",
+			hints: []hintprovider.HintTimeRange{
+				{Start: time.Time{}, End: queryStart.Add(time.Hour)},
+			},
+			start:  queryStart,
+			end:    cutoff,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: queryStart, End: queryStart.Add(time.Hour)},
+			},
+		},
+		{
+			desc: "hint after store end is dropped",
+			hints: []hintprovider.HintTimeRange{
+				{Start: cutoff.Add(time.Minute), End: queryEnd},
+			},
+			start:  queryStart,
+			end:    queryEnd,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: cutoff, End: queryEnd},
+			},
+		},
+		{
+			desc: "store window that touches cutoff is extended through the ingester",
+			hints: []hintprovider.HintTimeRange{
+				{Start: queryStart.Add(2 * time.Hour), End: cutoff},
+			},
+			start:  queryStart,
+			end:    queryEnd,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
+			},
+		},
+		{
+			desc:   "entire query in the ingester window is one planned range",
+			start:  cutoff,
+			end:    queryEnd,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: cutoff, End: queryEnd},
+			},
+		},
+		{
+			desc: "pre-min-date sentinel and a store hit plus the ingester window",
+			hints: []hintprovider.HintTimeRange{
+				{Start: time.Time{}, End: queryStart.Add(time.Hour), Source: hintprovider.HintSourcePreMinDate},
+				{Start: queryStart.Add(90 * time.Minute), End: queryStart.Add(2 * time.Hour)},
+			},
+			start:  queryStart,
+			end:    queryEnd,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: queryStart, End: queryStart.Add(time.Hour)},
+				{Start: queryStart.Add(90 * time.Minute), End: queryStart.Add(2 * time.Hour)},
+				{Start: cutoff, End: queryEnd},
+			},
+		},
+		{
+			desc: "index-empty holes are omitted",
+			hints: []hintprovider.HintTimeRange{
+				{Start: queryStart.Add(2 * time.Hour), End: queryStart.Add(2*time.Hour + time.Minute)},
+			},
+			start:  queryStart,
+			end:    cutoff,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: queryStart.Add(2 * time.Hour), End: queryStart.Add(2*time.Hour + time.Minute)},
+			},
+		},
+		{
+			desc: "a hint that ends before cutoff leaves a separate ingester window",
+			hints: []hintprovider.HintTimeRange{
+				{Start: queryStart, End: queryStart.Add(time.Hour)},
+			},
+			start:  queryStart,
+			end:    queryEnd,
+			cutoff: cutoff,
+			want: []querylimits.TimeRange{
+				{Start: queryStart, End: queryStart.Add(time.Hour)},
+				{Start: cutoff, End: queryEnd},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := buildPlannedQueryRanges(tc.hints, tc.start, tc.end, tc.cutoff)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPlannedRangeSource_Wait_EmptyIsPresent(t *testing.T) {
+	queryStart := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	queryEnd := queryStart.Add(24 * time.Hour)
+	result := &hintPrefetchResult{
+		queryStart:     queryStart,
+		queryEnd:       queryEnd,
+		ingesterCutoff: queryEnd,
+		done:           make(chan struct{}),
+	}
+	close(result.done)
+
+	src := &plannedRangeSource{result: result, timeout: time.Second}
+	got, ok := src.Wait(t.Context())
+	require.True(t, ok, "empty plan must be distinct from missing")
+	require.Empty(t, got)
+}
+
+func TestPlannedRangeSource_Wait_ErrorIsAbsent(t *testing.T) {
+	result := &hintPrefetchResult{
+		err:  context.Canceled,
+		done: make(chan struct{}),
+	}
+	close(result.done)
+
+	src := &plannedRangeSource{result: result, timeout: time.Second}
+	_, ok := src.Wait(t.Context())
+	require.False(t, ok)
+}

--- a/pkg/logline/queryfrontend/planned_ranges_test.go
+++ b/pkg/logline/queryfrontend/planned_ranges_test.go
@@ -157,6 +157,7 @@ func TestPlannedRangeSource_Wait_EmptyIsPresent(t *testing.T) {
 		ingesterCutoff: queryEnd,
 		done:           make(chan struct{}),
 	}
+	result.setPlannedRanges()
 	close(result.done)
 
 	src := &plannedRangeSource{result: result, timeout: time.Second}

--- a/pkg/logline/queryfrontend/planned_ranges_test.go
+++ b/pkg/logline/queryfrontend/planned_ranges_test.go
@@ -17,163 +17,68 @@ func TestBuildPlannedQueryRanges(t *testing.T) {
 	queryEnd := queryStart.Add(4 * time.Hour)
 	cutoff := queryStart.Add(3 * time.Hour)
 
-	for _, tc := range []struct {
-		desc   string
-		hints  []hintprovider.HintTimeRange
-		start  time.Time
-		end    time.Time
-		cutoff time.Time
-		want   []querylimits.TimeRange
-	}{
-		{
-			desc:   "no hints and no ingester window",
-			start:  queryStart,
-			end:    cutoff,
-			cutoff: cutoff,
-			want:   nil,
+	got := buildPlannedQueryRanges(
+		[]hintprovider.HintTimeRange{
+			{Start: queryStart.Add(-time.Hour), End: queryStart.Add(30 * time.Minute)},
+			{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
 		},
-		{
-			desc:   "no hints attaches the ingester window",
-			start:  queryStart,
-			end:    queryEnd,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: cutoff, End: queryEnd},
-			},
-		},
-		{
-			desc: "store hints are clipped to the query and cutoff",
-			hints: []hintprovider.HintTimeRange{
-				{Start: queryStart.Add(-time.Hour), End: queryStart.Add(30 * time.Minute)},
-				{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
-			},
-			start:  queryStart,
-			end:    queryEnd,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: queryStart, End: queryStart.Add(30 * time.Minute)},
-				{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
-			},
-		},
-		{
-			desc: "zero-start passthrough is rewritten to query start",
-			hints: []hintprovider.HintTimeRange{
-				{Start: time.Time{}, End: queryStart.Add(time.Hour)},
-			},
-			start:  queryStart,
-			end:    cutoff,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: queryStart, End: queryStart.Add(time.Hour)},
-			},
-		},
-		{
-			desc: "hint after store end is dropped",
-			hints: []hintprovider.HintTimeRange{
-				{Start: cutoff.Add(time.Minute), End: queryEnd},
-			},
-			start:  queryStart,
-			end:    queryEnd,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: cutoff, End: queryEnd},
-			},
-		},
-		{
-			desc: "store window that touches cutoff is extended through the ingester",
-			hints: []hintprovider.HintTimeRange{
-				{Start: queryStart.Add(2 * time.Hour), End: cutoff},
-			},
-			start:  queryStart,
-			end:    queryEnd,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
-			},
-		},
-		{
-			desc:   "entire query in the ingester window is one planned range",
-			start:  cutoff,
-			end:    queryEnd,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: cutoff, End: queryEnd},
-			},
-		},
-		{
-			desc: "pre-min-date sentinel and a store hit plus the ingester window",
-			hints: []hintprovider.HintTimeRange{
-				{Start: time.Time{}, End: queryStart.Add(time.Hour), Source: hintprovider.HintSourcePreMinDate},
-				{Start: queryStart.Add(90 * time.Minute), End: queryStart.Add(2 * time.Hour)},
-			},
-			start:  queryStart,
-			end:    queryEnd,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: queryStart, End: queryStart.Add(time.Hour)},
-				{Start: queryStart.Add(90 * time.Minute), End: queryStart.Add(2 * time.Hour)},
-				{Start: cutoff, End: queryEnd},
-			},
-		},
-		{
-			desc: "index-empty holes are omitted",
-			hints: []hintprovider.HintTimeRange{
-				{Start: queryStart.Add(2 * time.Hour), End: queryStart.Add(2*time.Hour + time.Minute)},
-			},
-			start:  queryStart,
-			end:    cutoff,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: queryStart.Add(2 * time.Hour), End: queryStart.Add(2*time.Hour + time.Minute)},
-			},
-		},
-		{
-			desc: "a hint that ends before cutoff leaves a separate ingester window",
-			hints: []hintprovider.HintTimeRange{
-				{Start: queryStart, End: queryStart.Add(time.Hour)},
-			},
-			start:  queryStart,
-			end:    queryEnd,
-			cutoff: cutoff,
-			want: []querylimits.TimeRange{
-				{Start: queryStart, End: queryStart.Add(time.Hour)},
-				{Start: cutoff, End: queryEnd},
-			},
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			got := buildPlannedQueryRanges(tc.hints, tc.start, tc.end, tc.cutoff)
-			require.Equal(t, tc.want, got)
-		})
-	}
+		queryStart, queryEnd, cutoff,
+	)
+	require.Equal(t, []querylimits.TimeRange{
+		{Start: queryStart, End: queryStart.Add(30 * time.Minute)},
+		{Start: queryStart.Add(2 * time.Hour), End: queryEnd},
+	}, got)
 }
 
-func TestPlannedRangeSource_Wait_EmptyIsPresent(t *testing.T) {
-	queryStart := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-	queryEnd := queryStart.Add(24 * time.Hour)
-	result := &hintPrefetchResult{
-		queryStart:     queryStart,
-		queryEnd:       queryEnd,
-		ingesterCutoff: queryEnd,
-		done:           make(chan struct{}),
-	}
-	result.setPlannedRanges()
-	close(result.done)
+func TestBuildPlannedQueryRanges_PreMinDateRewritesToQueryStart(t *testing.T) {
+	queryStart := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	queryEnd := queryStart.Add(2 * time.Hour)
+	minDate := queryStart.Add(time.Hour)
 
-	src := &plannedRangeSource{result: result, timeout: time.Second}
-	got, ok := src.Wait(t.Context())
-	require.True(t, ok, "empty plan must be distinct from missing")
+	got := buildPlannedQueryRanges(
+		[]hintprovider.HintTimeRange{
+			{Start: time.Time{}, End: minDate, Source: hintprovider.HintSourcePreMinDate},
+		},
+		queryStart, queryEnd, queryEnd,
+	)
+	require.Equal(t, []querylimits.TimeRange{
+		{Start: queryStart, End: minDate},
+	}, got)
+}
+
+func TestInjectPlannedQueryRanges_SkipsWhenLookupFailed(t *testing.T) {
+	ctx := injectPlannedQueryRanges(context.Background(), &hintPrefetchResult{
+		err:  context.Canceled,
+		done: closedDone(),
+	})
+	_, ok := querylimits.ExtractPlannedQueryRanges(ctx)
+	require.False(t, ok)
+}
+
+func TestInjectPlannedQueryRanges_SkipsWhenStillInFlight(t *testing.T) {
+	ctx := injectPlannedQueryRanges(context.Background(), &hintPrefetchResult{
+		done: make(chan struct{}),
+	})
+	_, ok := querylimits.ExtractPlannedQueryRanges(ctx)
+	require.False(t, ok)
+}
+
+func TestInjectPlannedQueryRanges_EmptyPlanIsPresent(t *testing.T) {
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	ctx := injectPlannedQueryRanges(context.Background(), &hintPrefetchResult{
+		queryStart:     start,
+		queryEnd:       end,
+		ingesterCutoff: end,
+		done:           closedDone(),
+	})
+	got, ok := querylimits.ExtractPlannedQueryRanges(ctx)
+	require.True(t, ok)
 	require.Empty(t, got)
 }
 
-func TestPlannedRangeSource_Wait_ErrorIsAbsent(t *testing.T) {
-	result := &hintPrefetchResult{
-		err:  context.Canceled,
-		done: make(chan struct{}),
-	}
-	close(result.done)
-
-	src := &plannedRangeSource{result: result, timeout: time.Second}
-	_, ok := src.Wait(t.Context())
-	require.False(t, ok)
+func closedDone() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }

--- a/pkg/logline/queryfrontend/tenant_settings.go
+++ b/pkg/logline/queryfrontend/tenant_settings.go
@@ -19,6 +19,14 @@ type TenantSettings interface {
 	MinQueryBytesForIndex(tenant string) (int64, bool)
 }
 
+// maxQueryBytesReader is an optional TenantSettings extension. GEL can
+// implement this (wrapping Loki overrides) without changing
+// WrapMiddleware's signature. When absent, prefetch uses
+// MiddlewareConfig.MaxQueryBytesRead.
+type maxQueryBytesReader interface {
+	MaxQueryBytesRead(tenant string) int
+}
+
 type staticTenantSettings struct{}
 
 func (staticTenantSettings) Mode(string) Mode { return ModeUnset }

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -61,8 +61,7 @@ type querySizeLimitSpec struct {
 	// errorTmpl is the client-facing message template. It takes two strings: the
 	// bytes the query would read and the configured limit.
 	errorTmpl string
-	// applyPlannedRanges lets MaxQueryBytesRead size from planned windows and
-	// wait on hints when the full span would exceed the limit.
+	// applyPlannedRanges sizes MaxQueryBytesRead from an injected plan.
 	// MaxQuerierBytesRead leaves this false and keeps using the split range.
 	applyPlannedRanges bool
 }
@@ -314,13 +313,9 @@ func NewQuerySizeLimiterMiddleware(
 //   - {job="foo"}
 //   - {job="bar"}
 //
-// If planned ranges are already on the context, MaxQueryBytesRead sizes those
-// windows instead of req.GetStart()/GetEnd() and does not use
-// QueryLimitsContext as a floor. A present empty plan is 0 bytes, not a
-// fallback to the full span. This method never waits on hints;
-// waitForPlannedRanges does that only after a full-span oversize.
-// MaxQuerierBytesRead ignores the plan and keeps using the split/shard
-// request range.
+// If a plan is on the context, MaxQueryBytesRead sizes those windows and
+// does not use QueryLimitsContext as a floor. A present empty plan is 0
+// bytes. MaxQuerierBytesRead ignores the plan.
 func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryrangebase.Request) (uint64, error) {
 	ctx, sp := tracer.Start(ctx, "querySizeLimiter.getBytesReadForRequest")
 	defer sp.End()
@@ -362,11 +357,7 @@ func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryra
 	return queryBytes, nil
 }
 
-// getBytesForPlannedRanges sizes the query over each planned window. The plan
-// is the final scan set: windows are not clipped to the request range, and
-// QueryLimitsContext is not applied as a floor. Matcher offsets and lookback
-// are still applied inside getBytesForQueryAndRange. Callers should merge
-// adjacent ranges before injecting.
+// getBytesForPlannedRanges sizes the query over each planned window.
 func (q *querySizeLimiter) getBytesForPlannedRanges(ctx context.Context, r queryrangebase.Request, planned []querylimits.TimeRange) (uint64, error) {
 	var total uint64
 	for _, window := range planned {
@@ -444,14 +435,6 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get bytes read stats for query: %s", err.Error())
 		}
 
-		// Full span is over the cap. This is the only place we block on hints.
-		if bytesRead > uint64(maxBytesRead) && q.spec.applyPlannedRanges {
-			ctx, bytesRead, err = q.waitForPlannedRanges(ctx, r, bytesRead)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		statsBytesStr := humanize.IBytes(bytesRead)
 		maxBytesReadStr := humanize.IBytes(uint64(maxBytesRead))
 
@@ -462,44 +445,6 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 	}
 
 	return q.next.Do(ctx, r)
-}
-
-// waitForPlannedRanges is the only place MaxQueryBytesRead blocks on the
-// logline hint future. Call it only after a full-span size would reject.
-//
-// A plan already on the context is a no-op: getBytesReadForRequest already
-// sized those windows. No source, timeout, or error leaves bytesRead
-// unchanged so the caller still 400s on the full span.
-func (q *querySizeLimiter) waitForPlannedRanges(ctx context.Context, r queryrangebase.Request, bytesRead uint64) (context.Context, uint64, error) {
-	if _, hasPlan := querylimits.ExtractPlannedQueryRanges(ctx); hasPlan {
-		return ctx, bytesRead, nil
-	}
-
-	src, ok := querylimits.ExtractPlannedRangeSource(ctx)
-	if !ok {
-		return ctx, bytesRead, nil
-	}
-
-	planned, ready := src.Wait(ctx)
-	if err := ctx.Err(); err != nil {
-		return ctx, bytesRead, err
-	}
-	if !ready {
-		return ctx, bytesRead, nil
-	}
-
-	ctx = querylimits.InjectPlannedQueryRanges(ctx, planned)
-	plannedBytes, err := q.getBytesForPlannedRanges(ctx, r, planned)
-	if err != nil {
-		return ctx, bytesRead, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get bytes read stats for query: %s", err.Error())
-	}
-	level.Debug(spanlogger.FromContext(ctx, q.logger)).Log(
-		"msg", "sized query after waiting on hints",
-		"windows", len(planned),
-		"bytes", plannedBytes,
-		"limit_name", q.spec.limitName,
-	)
-	return ctx, plannedBytes, nil
 }
 
 type seriesLimiter struct {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -61,7 +61,8 @@ type querySizeLimitSpec struct {
 	// errorTmpl is the client-facing message template. It takes two strings: the
 	// bytes the query would read and the configured limit.
 	errorTmpl string
-	// applyPlannedRanges sizes MaxQueryBytesRead from injected planned windows.
+	// applyPlannedRanges lets MaxQueryBytesRead size from planned windows and
+	// wait on hints when the full span would exceed the limit.
 	// MaxQuerierBytesRead leaves this false and keeps using the split range.
 	applyPlannedRanges bool
 }
@@ -313,11 +314,11 @@ func NewQuerySizeLimiterMiddleware(
 //   - {job="foo"}
 //   - {job="bar"}
 //
-// If a frozen plan is already on the context, MaxQueryBytesRead sizes those
+// If planned ranges are already on the context, MaxQueryBytesRead sizes those
 // windows instead of req.GetStart()/GetEnd() and does not use
 // QueryLimitsContext as a floor. A present empty plan is 0 bytes, not a
-// fallback to the full span. A PlannedRangeSource is not waited on here;
-// Do() waits only when the full-span size would exceed the limit.
+// fallback to the full span. This method never waits on hints;
+// waitForPlannedRanges does that only after a full-span oversize.
 // MaxQuerierBytesRead ignores the plan and keeps using the split/shard
 // request range.
 func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryrangebase.Request) (uint64, error) {
@@ -443,25 +444,11 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get bytes read stats for query: %s", err.Error())
 		}
 
+		// Full span is over the cap. This is the only place we block on hints.
 		if bytesRead > uint64(maxBytesRead) && q.spec.applyPlannedRanges {
-			if _, frozen := querylimits.ExtractPlannedQueryRanges(ctx); !frozen {
-				planned, ready, waitErr := q.waitForPlannedRanges(ctx)
-				if waitErr != nil {
-					return nil, waitErr
-				}
-				if ready {
-					ctx = querylimits.InjectPlannedQueryRanges(ctx, planned)
-					bytesRead, err = q.getBytesForPlannedRanges(ctx, r, planned)
-					if err != nil {
-						return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get bytes read stats for query: %s", err.Error())
-					}
-					level.Debug(log).Log(
-						"msg", "sized query using waited planned ranges",
-						"windows", len(planned),
-						"bytes", bytesRead,
-						"limit_name", q.spec.limitName,
-					)
-				}
+			ctx, bytesRead, err = q.waitForPlannedRanges(ctx, r, bytesRead)
+			if err != nil {
+				return nil, err
 			}
 		}
 
@@ -477,18 +464,42 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 	return q.next.Do(ctx, r)
 }
 
-// waitForPlannedRanges waits on a PlannedRangeSource. ok=false means keep
-// the full-span size. A frozen snapshot is handled by getBytesReadForRequest.
-func (q *querySizeLimiter) waitForPlannedRanges(ctx context.Context) ([]querylimits.TimeRange, bool, error) {
+// waitForPlannedRanges is the only place MaxQueryBytesRead blocks on the
+// logline hint future. Call it only after a full-span size would reject.
+//
+// A plan already on the context is a no-op: getBytesReadForRequest already
+// sized those windows. No source, timeout, or error leaves bytesRead
+// unchanged so the caller still 400s on the full span.
+func (q *querySizeLimiter) waitForPlannedRanges(ctx context.Context, r queryrangebase.Request, bytesRead uint64) (context.Context, uint64, error) {
+	if _, hasPlan := querylimits.ExtractPlannedQueryRanges(ctx); hasPlan {
+		return ctx, bytesRead, nil
+	}
+
 	src, ok := querylimits.ExtractPlannedRangeSource(ctx)
 	if !ok {
-		return nil, false, nil
+		return ctx, bytesRead, nil
 	}
+
 	planned, ready := src.Wait(ctx)
 	if err := ctx.Err(); err != nil {
-		return nil, false, err
+		return ctx, bytesRead, err
 	}
-	return planned, ready, nil
+	if !ready {
+		return ctx, bytesRead, nil
+	}
+
+	ctx = querylimits.InjectPlannedQueryRanges(ctx, planned)
+	plannedBytes, err := q.getBytesForPlannedRanges(ctx, r, planned)
+	if err != nil {
+		return ctx, bytesRead, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get bytes read stats for query: %s", err.Error())
+	}
+	level.Debug(spanlogger.FromContext(ctx, q.logger)).Log(
+		"msg", "sized query after waiting on hints",
+		"windows", len(planned),
+		"bytes", plannedBytes,
+		"limit_name", q.spec.limitName,
+	)
+	return ctx, plannedBytes, nil
 }
 
 type seriesLimiter struct {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -61,13 +61,17 @@ type querySizeLimitSpec struct {
 	// errorTmpl is the client-facing message template. It takes two strings: the
 	// bytes the query would read and the configured limit.
 	errorTmpl string
+	// applyPlannedRanges sizes MaxQueryBytesRead from injected planned windows.
+	// MaxQuerierBytesRead leaves this false and keeps using the split range.
+	applyPlannedRanges bool
 }
 
 var (
 	maxQueryBytesReadSpec = querySizeLimitSpec{
-		limitName: "MaxQueryBytesRead",
-		sentinel:  logqlmodel.ErrMaxQueryBytesRead,
-		errorTmpl: limErrQueryTooManyBytesTmpl,
+		limitName:          "MaxQueryBytesRead",
+		sentinel:           logqlmodel.ErrMaxQueryBytesRead,
+		errorTmpl:          limErrQueryTooManyBytesTmpl,
+		applyPlannedRanges: true,
 	}
 	maxQuerierBytesReadSpec = querySizeLimitSpec{
 		limitName: "MaxQuerierBytesRead",
@@ -308,9 +312,32 @@ func NewQuerySizeLimiterMiddleware(
 // individual intervals and offsets
 //   - {job="foo"}
 //   - {job="bar"}
+//
+// If a frozen plan is already on the context, MaxQueryBytesRead sizes those
+// windows instead of req.GetStart()/GetEnd() and does not use
+// QueryLimitsContext as a floor. A present empty plan is 0 bytes, not a
+// fallback to the full span. A PlannedRangeSource is not waited on here;
+// Do() waits only when the full-span size would exceed the limit.
+// MaxQuerierBytesRead ignores the plan and keeps using the split/shard
+// request range.
 func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryrangebase.Request) (uint64, error) {
 	ctx, sp := tracer.Start(ctx, "querySizeLimiter.getBytesReadForRequest")
 	defer sp.End()
+
+	if q.spec.applyPlannedRanges {
+		if planned, ok := querylimits.ExtractPlannedQueryRanges(ctx); ok {
+			bytesRead, err := q.getBytesForPlannedRanges(ctx, r, planned)
+			if err == nil {
+				level.Debug(q.logger).Log(
+					"msg", "sized query using planned ranges",
+					"windows", len(planned),
+					"bytes", bytesRead,
+					"limit_name", q.spec.limitName,
+				)
+			}
+			return bytesRead, err
+		}
+	}
 
 	queryLimitCtx := querylimits.ExtractQueryLimitsContextFromContext(ctx)
 	fullCtxBytes := uint64(0)
@@ -332,6 +359,28 @@ func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryra
 	}
 
 	return queryBytes, nil
+}
+
+// getBytesForPlannedRanges sizes the query over each planned window. The plan
+// is the final scan set: windows are not clipped to the request range, and
+// QueryLimitsContext is not applied as a floor. Matcher offsets and lookback
+// are still applied inside getBytesForQueryAndRange. Callers should merge
+// adjacent ranges before injecting.
+func (q *querySizeLimiter) getBytesForPlannedRanges(ctx context.Context, r queryrangebase.Request, planned []querylimits.TimeRange) (uint64, error) {
+	var total uint64
+	for _, window := range planned {
+		if !window.Start.Before(window.End) {
+			continue
+		}
+
+		bytesRead, err := q.getBytesForQueryAndRange(ctx, r.GetQuery(), window.Start, window.End)
+		if err != nil {
+			return 0, nil
+		}
+		total += bytesRead
+	}
+
+	return total, nil
 }
 
 func (q *querySizeLimiter) getBytesForQueryAndRange(ctx context.Context, query string, from, to time.Time) (uint64, error) {
@@ -394,6 +443,28 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get bytes read stats for query: %s", err.Error())
 		}
 
+		if bytesRead > uint64(maxBytesRead) && q.spec.applyPlannedRanges {
+			if _, frozen := querylimits.ExtractPlannedQueryRanges(ctx); !frozen {
+				planned, ready, waitErr := q.waitForPlannedRanges(ctx)
+				if waitErr != nil {
+					return nil, waitErr
+				}
+				if ready {
+					ctx = querylimits.InjectPlannedQueryRanges(ctx, planned)
+					bytesRead, err = q.getBytesForPlannedRanges(ctx, r, planned)
+					if err != nil {
+						return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get bytes read stats for query: %s", err.Error())
+					}
+					level.Debug(log).Log(
+						"msg", "sized query using waited planned ranges",
+						"windows", len(planned),
+						"bytes", bytesRead,
+						"limit_name", q.spec.limitName,
+					)
+				}
+			}
+		}
+
 		statsBytesStr := humanize.IBytes(bytesRead)
 		maxBytesReadStr := humanize.IBytes(uint64(maxBytesRead))
 
@@ -404,6 +475,20 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 	}
 
 	return q.next.Do(ctx, r)
+}
+
+// waitForPlannedRanges waits on a PlannedRangeSource. ok=false means keep
+// the full-span size. A frozen snapshot is handled by getBytesReadForRequest.
+func (q *querySizeLimiter) waitForPlannedRanges(ctx context.Context) ([]querylimits.TimeRange, bool, error) {
+	src, ok := querylimits.ExtractPlannedRangeSource(ctx)
+	if !ok {
+		return nil, false, nil
+	}
+	planned, ready := src.Wait(ctx)
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	return planned, ready, nil
 }
 
 type seriesLimiter struct {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -61,8 +61,10 @@ type querySizeLimitSpec struct {
 	// errorTmpl is the client-facing message template. It takes two strings: the
 	// bytes the query would read and the configured limit.
 	errorTmpl string
-	// applyPlannedRanges sizes MaxQueryBytesRead from an injected plan.
-	// MaxQuerierBytesRead leaves this false and keeps using the split range.
+	// applyPlannedRanges sizes the limit from an injected plan, clipped
+	// to the request range. Used by MaxQueryBytesRead and the sharding-off
+	// MaxQuerierBytesRead middleware. The shard mapper applies the same
+	// plan only to the limit check, not to the shard factor.
 	applyPlannedRanges bool
 }
 
@@ -74,9 +76,10 @@ var (
 		applyPlannedRanges: true,
 	}
 	maxQuerierBytesReadSpec = querySizeLimitSpec{
-		limitName: "MaxQuerierBytesRead",
-		sentinel:  logqlmodel.ErrQuerierTooManyBytes,
-		errorTmpl: limErrQuerierTooManyBytesTmpl,
+		limitName:          "MaxQuerierBytesRead",
+		sentinel:           logqlmodel.ErrQuerierTooManyBytes,
+		errorTmpl:          limErrQuerierTooManyBytesTmpl,
+		applyPlannedRanges: true,
 	}
 	maxQuerierBytesReadShardableSpec = querySizeLimitSpec{
 		limitName: "MaxQuerierBytesRead",
@@ -313,9 +316,11 @@ func NewQuerySizeLimiterMiddleware(
 //   - {job="foo"}
 //   - {job="bar"}
 //
-// If a plan is on the context, MaxQueryBytesRead sizes those windows and
-// does not use QueryLimitsContext as a floor. A present empty plan is 0
-// bytes. MaxQuerierBytesRead ignores the plan.
+// If a plan is on the context, MaxQueryBytesRead and the sharding-off
+// MaxQuerierBytesRead middleware size the planned windows clipped to the
+// request. They do not use QueryLimitsContext as a floor. A present empty
+// plan is 0 bytes. The shard mapper still picks a factor from the full
+// split and only uses the plan for the limit number.
 func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryrangebase.Request) (uint64, error) {
 	ctx, sp := tracer.Start(ctx, "querySizeLimiter.getBytesReadForRequest")
 	defer sp.End()
@@ -357,14 +362,11 @@ func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryra
 	return queryBytes, nil
 }
 
-// getBytesForPlannedRanges sizes the query over each planned window.
+// getBytesForPlannedRanges sizes the query over each planned window
+// that overlaps [r.Start, r.End).
 func (q *querySizeLimiter) getBytesForPlannedRanges(ctx context.Context, r queryrangebase.Request, planned []querylimits.TimeRange) (uint64, error) {
 	var total uint64
-	for _, window := range planned {
-		if !window.Start.Before(window.End) {
-			continue
-		}
-
+	for _, window := range clipPlannedQueryRanges(planned, r.GetStart(), r.GetEnd()) {
 		bytesRead, err := q.getBytesForQueryAndRange(ctx, r.GetQuery(), window.Start, window.End)
 		if err != nil {
 			return 0, nil
@@ -373,6 +375,37 @@ func (q *querySizeLimiter) getBytesForPlannedRanges(ctx context.Context, r query
 	}
 
 	return total, nil
+}
+
+// clipPlannedQueryRanges returns planned windows overlapping [from, to).
+func clipPlannedQueryRanges(planned []querylimits.TimeRange, from, to time.Time) []querylimits.TimeRange {
+	if !from.Before(to) {
+		return nil
+	}
+	out := make([]querylimits.TimeRange, 0, len(planned))
+	for _, window := range planned {
+		start := window.Start
+		if start.Before(from) {
+			start = from
+		}
+		end := window.End
+		if end.After(to) {
+			end = to
+		}
+		if start.Before(end) {
+			out = append(out, querylimits.TimeRange{Start: start, End: end})
+		}
+	}
+	return out
+}
+
+// scaleBytesToShard scales part/total onto an already-computed per-shard
+// estimate so the shard factor is unchanged.
+func scaleBytesToShard(part, total, bytesPerShard uint64) uint64 {
+	if total == 0 {
+		return 0
+	}
+	return uint64(float64(part) / float64(total) * float64(bytesPerShard))
 }
 
 func (q *querySizeLimiter) getBytesForQueryAndRange(ctx context.Context, query string, from, to time.Time) (uint64, error) {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -61,25 +61,18 @@ type querySizeLimitSpec struct {
 	// errorTmpl is the client-facing message template. It takes two strings: the
 	// bytes the query would read and the configured limit.
 	errorTmpl string
-	// applyPlannedRanges sizes the limit from an injected plan, clipped
-	// to the request range. Used by MaxQueryBytesRead and the sharding-off
-	// MaxQuerierBytesRead middleware. The shard mapper applies the same
-	// plan only to the limit check, not to the shard factor.
-	applyPlannedRanges bool
 }
 
 var (
 	maxQueryBytesReadSpec = querySizeLimitSpec{
-		limitName:          "MaxQueryBytesRead",
-		sentinel:           logqlmodel.ErrMaxQueryBytesRead,
-		errorTmpl:          limErrQueryTooManyBytesTmpl,
-		applyPlannedRanges: true,
+		limitName: "MaxQueryBytesRead",
+		sentinel:  logqlmodel.ErrMaxQueryBytesRead,
+		errorTmpl: limErrQueryTooManyBytesTmpl,
 	}
 	maxQuerierBytesReadSpec = querySizeLimitSpec{
-		limitName:          "MaxQuerierBytesRead",
-		sentinel:           logqlmodel.ErrQuerierTooManyBytes,
-		errorTmpl:          limErrQuerierTooManyBytesTmpl,
-		applyPlannedRanges: true,
+		limitName: "MaxQuerierBytesRead",
+		sentinel:  logqlmodel.ErrQuerierTooManyBytes,
+		errorTmpl: limErrQuerierTooManyBytesTmpl,
 	}
 	maxQuerierBytesReadShardableSpec = querySizeLimitSpec{
 		limitName: "MaxQuerierBytesRead",
@@ -316,28 +309,27 @@ func NewQuerySizeLimiterMiddleware(
 //   - {job="foo"}
 //   - {job="bar"}
 //
-// If a plan is on the context, MaxQueryBytesRead and the sharding-off
-// MaxQuerierBytesRead middleware size the planned windows clipped to the
-// request. They do not use QueryLimitsContext as a floor. A present empty
-// plan is 0 bytes. The shard mapper still picks a factor from the full
-// split and only uses the plan for the limit number.
+// If a plan is on the context, size the planned windows clipped to the
+// request. Do not use QueryLimitsContext as a floor. A present empty
+// plan is 0 bytes. Stats errors are ignored so the query proceeds
+// (same as the no-plan path). The shard mapper still picks a factor
+// from the full split and only uses the plan for the limit number.
 func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryrangebase.Request) (uint64, error) {
 	ctx, sp := tracer.Start(ctx, "querySizeLimiter.getBytesReadForRequest")
 	defer sp.End()
 
-	if q.spec.applyPlannedRanges {
-		if planned, ok := querylimits.ExtractPlannedQueryRanges(ctx); ok {
-			bytesRead, err := q.getBytesForPlannedRanges(ctx, r, planned)
-			if err == nil {
-				level.Debug(q.logger).Log(
-					"msg", "sized query using planned ranges",
-					"windows", len(planned),
-					"bytes", bytesRead,
-					"limit_name", q.spec.limitName,
-				)
-			}
-			return bytesRead, err
+	if planned, ok := querylimits.ExtractPlannedQueryRanges(ctx); ok {
+		bytesRead, err := q.getBytesForPlannedRanges(ctx, r, planned)
+		if err != nil {
+			return 0, nil
 		}
+		level.Debug(q.logger).Log(
+			"msg", "sized query using planned ranges",
+			"windows", len(planned),
+			"bytes", bytesRead,
+			"limit_name", q.spec.limitName,
+		)
+		return bytesRead, nil
 	}
 
 	queryLimitCtx := querylimits.ExtractQueryLimitsContextFromContext(ctx)
@@ -363,13 +355,15 @@ func (q *querySizeLimiter) getBytesReadForRequest(ctx context.Context, r queryra
 }
 
 // getBytesForPlannedRanges sizes the query over each planned window
-// that overlaps [r.Start, r.End).
+// that overlaps [r.Start, r.End). The caller handles stats errors:
+// the size-limiter middleware ignores them (query proceeds); the shard
+// mapper keeps the full-range estimate.
 func (q *querySizeLimiter) getBytesForPlannedRanges(ctx context.Context, r queryrangebase.Request, planned []querylimits.TimeRange) (uint64, error) {
 	var total uint64
 	for _, window := range clipPlannedQueryRanges(planned, r.GetStart(), r.GetEnd()) {
 		bytesRead, err := q.getBytesForQueryAndRange(ctx, r.GetQuery(), window.Start, window.End)
 		if err != nil {
-			return 0, nil
+			return 0, err
 		}
 		total += bytesRead
 	}

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -1190,14 +1190,19 @@ func Test_MaxQuerySize_PlannedRanges(t *testing.T) {
 		require.Equal(t, int32(1), hits.Load())
 	})
 
-	t.Run("MaxQuerierBytesRead ignores the plan", func(t *testing.T) {
+	t.Run("MaxQuerierBytesRead sizes plan clipped to the request", func(t *testing.T) {
 		queryHits := atomic.NewInt32(0)
 		querierHits := atomic.NewInt32(0)
 		ctx := user.InjectOrgID(context.Background(), "foo")
-		ctx = querylimits.InjectPlannedQueryRanges(ctx, []querylimits.TimeRange{{
-			Start: testTime.Add(-30 * time.Minute),
-			End:   testTime,
-		}})
+		ctx = querylimits.InjectPlannedQueryRanges(ctx, []querylimits.TimeRange{
+			{Start: testTime.Add(-48 * time.Hour), End: testTime.Add(-47 * time.Hour)},
+			{Start: testTime.Add(-30 * time.Minute), End: testTime},
+		})
+
+		// A 1h split: only the second window overlaps. Without clipping,
+		// the first window would be sized as 10_000 bytes and 400.
+		splitReq := *lokiReq
+		splitReq.StartTs = testTime.Add(-time.Hour)
 
 		middlewares := []queryrangebase.Middleware{
 			NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
@@ -1207,8 +1212,8 @@ func Test_MaxQuerySize_PlannedRanges(t *testing.T) {
 				maxQuerierBytesRead: 500,
 			}, statsForDuration(querierHits)),
 		}
-		_, err := queryrangebase.MergeMiddlewares(middlewares...).Wrap(promHandler).Do(ctx, lokiReq)
-		require.Error(t, err)
+		_, err := queryrangebase.MergeMiddlewares(middlewares...).Wrap(promHandler).Do(ctx, &splitReq)
+		require.NoError(t, err)
 		require.Equal(t, int32(1), queryHits.Load())
 		require.Equal(t, int32(1), querierHits.Load())
 	})

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -1002,386 +1002,6 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 	}
 }
 
-func Test_MaxQuerySize_WithPlannedRanges(t *testing.T) {
-	query := `{app="foo"} |= "foo"`
-	reqStart := testTime.Add(-24 * time.Hour)
-	reqEnd := testTime
-	smallWindow := querylimits.TimeRange{Start: testTime.Add(-30 * time.Minute), End: testTime}
-	disjointWindows := []querylimits.TimeRange{
-		{Start: testTime.Add(-2 * time.Hour), End: testTime.Add(-time.Hour)},
-		{Start: testTime.Add(-30 * time.Minute), End: testTime},
-	}
-
-	for _, tc := range []struct {
-		desc              string
-		planned           []querylimits.TimeRange
-		injectPlan        bool
-		withParentRange   bool
-		queryBytes        uint64
-		limit             int
-		shouldErr         bool
-		expectedStatsHits int
-		expectStatsRanges []querylimits.TimeRange
-	}{
-		{
-			desc:              "absent plan uses the request range",
-			injectPlan:        false,
-			queryBytes:        500,
-			limit:             1000,
-			shouldErr:         false,
-			expectedStatsHits: 1,
-		},
-		{
-			desc:              "absent plan still uses QueryLimitsContext as a floor",
-			injectPlan:        false,
-			withParentRange:   true,
-			queryBytes:        500,
-			limit:             1000,
-			shouldErr:         false,
-			expectedStatsHits: 2,
-		},
-		{
-			desc:              "present empty plan is zero bytes and does not query stats",
-			injectPlan:        true,
-			planned:           nil,
-			queryBytes:        5000,
-			limit:             1,
-			shouldErr:         false,
-			expectedStatsHits: 0,
-		},
-		{
-			desc:              "one planned window replaces the request span",
-			injectPlan:        true,
-			planned:           []querylimits.TimeRange{smallWindow},
-			queryBytes:        200,
-			limit:             1000,
-			shouldErr:         false,
-			expectedStatsHits: 1,
-			expectStatsRanges: []querylimits.TimeRange{smallWindow},
-		},
-		{
-			desc:              "disjoint planned windows are summed not covered",
-			injectPlan:        true,
-			planned:           disjointWindows,
-			queryBytes:        400,
-			limit:             1000,
-			shouldErr:         false,
-			expectedStatsHits: 2,
-			expectStatsRanges: disjointWindows,
-		},
-		{
-			desc:              "sum of planned windows can still exceed the limit",
-			injectPlan:        true,
-			planned:           disjointWindows,
-			queryBytes:        400,
-			limit:             700,
-			shouldErr:         true,
-			expectedStatsHits: 2,
-			expectStatsRanges: disjointWindows,
-		},
-		{
-			desc:              "parent QueryLimitsContext is not a floor once a plan is present",
-			injectPlan:        true,
-			withParentRange:   true,
-			planned:           []querylimits.TimeRange{smallWindow},
-			queryBytes:        200,
-			limit:             1000,
-			shouldErr:         false,
-			expectedStatsHits: 1,
-			expectStatsRanges: []querylimits.TimeRange{smallWindow},
-		},
-		{
-			desc:              "empty plan ignores a parent range that would have exceeded the limit",
-			injectPlan:        true,
-			withParentRange:   true,
-			planned:           []querylimits.TimeRange{},
-			queryBytes:        5000,
-			limit:             1,
-			shouldErr:         false,
-			expectedStatsHits: 0,
-		},
-		{
-			desc:       "empty planned windows are skipped",
-			injectPlan: true,
-			planned: []querylimits.TimeRange{
-				{Start: testTime, End: testTime},
-				smallWindow,
-			},
-			queryBytes:        200,
-			limit:             1000,
-			shouldErr:         false,
-			expectedStatsHits: 1,
-			expectStatsRanges: []querylimits.TimeRange{smallWindow},
-		},
-		{
-			desc:       "query limiter does not clip planned windows to the request range",
-			injectPlan: true,
-			planned: []querylimits.TimeRange{
-				{Start: testTime.Add(-48 * time.Hour), End: testTime.Add(-36 * time.Hour)},
-			},
-			queryBytes:        200,
-			limit:             1000,
-			shouldErr:         false,
-			expectedStatsHits: 1,
-			expectStatsRanges: []querylimits.TimeRange{
-				{Start: testTime.Add(-48 * time.Hour), End: testTime.Add(-36 * time.Hour)},
-			},
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			statsHits := atomic.NewInt32(0)
-			var gotStatsRanges []querylimits.TimeRange
-
-			statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-				statsHits.Inc()
-				gotStatsRanges = append(gotStatsRanges, querylimits.TimeRange{
-					Start: req.GetStart(),
-					End:   req.GetEnd(),
-				})
-				return &IndexStatsResponse{
-					Response: &logproto.IndexStatsResponse{
-						Bytes: tc.queryBytes,
-					},
-				}, nil
-			})
-
-			promHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-				require.Equal(t, reqStart.UnixMilli(), req.GetStart().UnixMilli())
-				require.Equal(t, reqEnd.UnixMilli(), req.GetEnd().UnixMilli())
-				return &LokiPromResponse{
-					Response: &queryrangebase.PrometheusResponse{
-						Status: "success",
-					},
-				}, nil
-			})
-
-			lokiReq := &LokiRequest{
-				Query:     query,
-				StartTs:   reqStart,
-				EndTs:     reqEnd,
-				Direction: logproto.FORWARD,
-				Path:      "/query_range",
-				Plan:      testutil.MustPlan(query),
-			}
-
-			ctx := user.InjectOrgID(context.Background(), "foo")
-			if tc.withParentRange {
-				ctx = querylimits.InjectQueryLimitsContextIntoContext(ctx, querylimits.Context{
-					Expr: `{context="true"}`,
-					From: testTime.Add(-7 * 24 * time.Hour),
-					To:   testTime,
-				})
-			}
-			if tc.injectPlan {
-				ctx = querylimits.InjectPlannedQueryRanges(ctx, tc.planned)
-			}
-
-			handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
-				maxQueryBytesRead: tc.limit,
-			}, statsHandler).Wrap(promHandler)
-
-			_, err := handler.Do(ctx, lokiReq)
-			if tc.shouldErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			require.Equal(t, tc.expectedStatsHits, int(statsHits.Load()))
-
-			if tc.expectStatsRanges != nil {
-				require.Equal(t, len(tc.expectStatsRanges), len(gotStatsRanges))
-				lookback := testEngineOpts.MaxLookBackPeriod
-				for i, want := range tc.expectStatsRanges {
-					// Log selectors have Interval=0, so getStatsForMatchers applies MaxLookBackPeriod.
-					require.Equal(t, want.Start.Add(-lookback).UnixMilli(), gotStatsRanges[i].Start.UnixMilli())
-					require.Equal(t, want.End.UnixMilli(), gotStatsRanges[i].End.UnixMilli())
-				}
-			}
-		})
-	}
-}
-
-type countingPlanSource struct {
-	ranges []querylimits.TimeRange
-	ok     bool
-	waits  atomic.Int32
-}
-
-func (s *countingPlanSource) Wait(context.Context) ([]querylimits.TimeRange, bool) {
-	s.waits.Add(1)
-	return s.ranges, s.ok
-}
-
-func Test_MaxQuerySize_WaitsOnPlannedRangeSource(t *testing.T) {
-	query := `{app="foo"} |= "foo"`
-	reqStart := testTime.Add(-24 * time.Hour)
-	reqEnd := testTime
-	smallWindow := querylimits.TimeRange{Start: testTime.Add(-30 * time.Minute), End: testTime}
-
-	newReq := func() *LokiRequest {
-		return &LokiRequest{
-			Query:     query,
-			StartTs:   reqStart,
-			EndTs:     reqEnd,
-			Direction: logproto.FORWARD,
-			Path:      "/query_range",
-			Plan:      testutil.MustPlan(query),
-		}
-	}
-
-	t.Run("does not wait when the full span is under the limit", func(t *testing.T) {
-		src := &countingPlanSource{ranges: []querylimits.TimeRange{smallWindow}, ok: true}
-		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 200}}, nil
-		})
-		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
-			maxQueryBytesRead: 1000,
-		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
-		}))
-
-		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
-		_, err := handler.Do(ctx, newReq())
-		require.NoError(t, err)
-		require.Equal(t, int32(0), src.waits.Load())
-	})
-
-	t.Run("waits and injects a snapshot when the full span would 400", func(t *testing.T) {
-		src := &countingPlanSource{ranges: []querylimits.TimeRange{smallWindow}, ok: true}
-		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-			bytes := uint64(5000)
-			if req.GetEnd().Sub(req.GetStart()) <= time.Hour {
-				bytes = 100
-			}
-			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: bytes}}, nil
-		})
-		var got []querylimits.TimeRange
-		var gotOK bool
-		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
-			maxQueryBytesRead: 1000,
-		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-			got, gotOK = querylimits.ExtractPlannedQueryRanges(ctx)
-			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
-		}))
-
-		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
-		_, err := handler.Do(ctx, newReq())
-		require.NoError(t, err)
-		require.Equal(t, int32(1), src.waits.Load())
-		require.True(t, gotOK)
-		require.Equal(t, []querylimits.TimeRange{smallWindow}, got)
-	})
-
-	t.Run("absent source result still 400s on the full span", func(t *testing.T) {
-		src := &countingPlanSource{ok: false}
-		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 5000}}, nil
-		})
-		nextCalled := false
-		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
-			maxQueryBytesRead: 1000,
-		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-			nextCalled = true
-			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
-		}))
-
-		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
-		_, err := handler.Do(ctx, newReq())
-		require.Error(t, err)
-		require.Equal(t, int32(1), src.waits.Load())
-		require.False(t, nextCalled)
-	})
-
-	t.Run("present empty source plan is zero bytes", func(t *testing.T) {
-		src := &countingPlanSource{ranges: nil, ok: true}
-		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 5000}}, nil
-		})
-		var gotOK bool
-		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
-			maxQueryBytesRead: 1,
-		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-			_, gotOK = querylimits.ExtractPlannedQueryRanges(ctx)
-			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
-		}))
-
-		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
-		_, err := handler.Do(ctx, newReq())
-		require.NoError(t, err)
-		require.True(t, gotOK)
-	})
-}
-
-func Test_MaxQuerierSize_IgnoresPlannedRangeSource(t *testing.T) {
-	query := `{app="foo"} |= "foo"`
-	src := &countingPlanSource{ranges: nil, ok: true}
-	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 5000}}, nil
-	})
-	handler := NewQuerierSizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
-		maxQuerierBytesRead: 1,
-	}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
-	}))
-
-	ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
-	_, err := handler.Do(ctx, &LokiRequest{
-		Query:     query,
-		StartTs:   testTime.Add(-time.Hour),
-		EndTs:     testTime,
-		Direction: logproto.FORWARD,
-		Path:      "/query_range",
-		Plan:      testutil.MustPlan(query),
-	})
-	require.Error(t, err)
-	require.Equal(t, int32(0), src.waits.Load())
-}
-
-func Test_MaxQuerierSize_IgnoresPlannedRanges(t *testing.T) {
-	query := `{app="foo"} |= "foo"`
-	splitStart := testTime.Add(-time.Hour)
-	splitEnd := testTime
-	// A plan that would be 0 bytes if applied. The querier limiter must still
-	// size the split range and reject.
-	planned := []querylimits.TimeRange{}
-
-	statsHits := atomic.NewInt32(0)
-	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-		statsHits.Inc()
-		require.Equal(t, splitStart.Add(-testEngineOpts.MaxLookBackPeriod).UnixMilli(), req.GetStart().UnixMilli())
-		require.Equal(t, splitEnd.UnixMilli(), req.GetEnd().UnixMilli())
-		return &IndexStatsResponse{
-			Response: &logproto.IndexStatsResponse{Bytes: 5000},
-		}, nil
-	})
-
-	lokiReq := &LokiRequest{
-		Query:     query,
-		StartTs:   splitStart,
-		EndTs:     splitEnd,
-		Direction: logproto.FORWARD,
-		Path:      "/query_range",
-		Plan:      testutil.MustPlan(query),
-	}
-
-	ctx := querylimits.InjectPlannedQueryRanges(
-		user.InjectOrgID(context.Background(), "foo"),
-		planned,
-	)
-
-	handler := NewQuerierSizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
-		maxQuerierBytesRead: 1,
-	}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		return &LokiPromResponse{
-			Response: &queryrangebase.PrometheusResponse{Status: "success"},
-		}, nil
-	}))
-
-	_, err := handler.Do(ctx, lokiReq)
-	require.Error(t, err)
-	require.Equal(t, int32(1), statsHits.Load())
-}
-
 func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {
 	engineOpts := testEngineOpts
 	engineOpts.MaxLookBackPeriod = 1 * time.Hour
@@ -1490,4 +1110,106 @@ func TestAcquireWithTiming(t *testing.T) {
 	// Check that the waiting time for the third request is larger than 0 milliseconds and less than 10 milliseconds
 	require.Greater(t, waiting3, 0*time.Nanosecond)
 	require.Less(t, waiting3, 10*time.Millisecond)
+}
+
+func Test_MaxQuerySize_PlannedRanges(t *testing.T) {
+	query := `{app="foo"} |= "foo"`
+	lokiReq := &LokiRequest{
+		Query:     query,
+		Limit:     1000,
+		StartTs:   testTime.Add(-48 * time.Hour),
+		EndTs:     testTime,
+		Direction: logproto.FORWARD,
+		Path:      "/query_range",
+		Plan:      testutil.MustPlan(query),
+	}
+	promHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &LokiPromResponse{
+			Response: &queryrangebase.PrometheusResponse{Status: "success"},
+		}, nil
+	})
+	statsForDuration := func(hits *atomic.Int32) queryrangebase.Handler {
+		return queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+			hits.Inc()
+			bytes := uint64(10_000)
+			// Planned windows in these cases start near testTime; the full
+			// request (and QueryLimitsContext) starts 48h earlier.
+			if req.GetStart().After(testTime.Add(-2 * time.Hour)) {
+				bytes = 100
+			}
+			return &IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: bytes},
+			}, nil
+		})
+	}
+
+	t.Run("empty plan is zero bytes", func(t *testing.T) {
+		hits := atomic.NewInt32(0)
+		ctx := user.InjectOrgID(context.Background(), "foo")
+		ctx = querylimits.InjectPlannedQueryRanges(ctx, nil)
+
+		_, err := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+			maxQueryBytesRead: 1,
+		}, statsForDuration(hits)).Wrap(promHandler).Do(ctx, lokiReq)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), hits.Load())
+	})
+
+	t.Run("sizes planned windows instead of the request span", func(t *testing.T) {
+		hits := atomic.NewInt32(0)
+		ctx := user.InjectOrgID(context.Background(), "foo")
+		ctx = querylimits.InjectPlannedQueryRanges(ctx, []querylimits.TimeRange{{
+			Start: testTime.Add(-30 * time.Minute),
+			End:   testTime,
+		}})
+
+		_, err := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+			maxQueryBytesRead: 500,
+		}, statsForDuration(hits)).Wrap(promHandler).Do(ctx, lokiReq)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), hits.Load())
+	})
+
+	t.Run("present plan is not floored by QueryLimitsContext", func(t *testing.T) {
+		hits := atomic.NewInt32(0)
+		ctx := user.InjectOrgID(context.Background(), "foo")
+		ctx = querylimits.InjectPlannedQueryRanges(ctx, []querylimits.TimeRange{{
+			Start: testTime.Add(-30 * time.Minute),
+			End:   testTime,
+		}})
+		ctx = querylimits.InjectQueryLimitsContextIntoContext(ctx, querylimits.Context{
+			Expr: query,
+			From: testTime.Add(-48 * time.Hour),
+			To:   testTime,
+		})
+
+		_, err := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+			maxQueryBytesRead: 500,
+		}, statsForDuration(hits)).Wrap(promHandler).Do(ctx, lokiReq)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), hits.Load())
+	})
+
+	t.Run("MaxQuerierBytesRead ignores the plan", func(t *testing.T) {
+		queryHits := atomic.NewInt32(0)
+		querierHits := atomic.NewInt32(0)
+		ctx := user.InjectOrgID(context.Background(), "foo")
+		ctx = querylimits.InjectPlannedQueryRanges(ctx, []querylimits.TimeRange{{
+			Start: testTime.Add(-30 * time.Minute),
+			End:   testTime,
+		}})
+
+		middlewares := []queryrangebase.Middleware{
+			NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+				maxQueryBytesRead: 500,
+			}, statsForDuration(queryHits)),
+			NewQuerierSizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+				maxQuerierBytesRead: 500,
+			}, statsForDuration(querierHits)),
+		}
+		_, err := queryrangebase.MergeMiddlewares(middlewares...).Wrap(promHandler).Do(ctx, lokiReq)
+		require.Error(t, err)
+		require.Equal(t, int32(1), queryHits.Load())
+		require.Equal(t, int32(1), querierHits.Load())
+	})
 }

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -1002,6 +1002,386 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 	}
 }
 
+func Test_MaxQuerySize_WithPlannedRanges(t *testing.T) {
+	query := `{app="foo"} |= "foo"`
+	reqStart := testTime.Add(-24 * time.Hour)
+	reqEnd := testTime
+	smallWindow := querylimits.TimeRange{Start: testTime.Add(-30 * time.Minute), End: testTime}
+	disjointWindows := []querylimits.TimeRange{
+		{Start: testTime.Add(-2 * time.Hour), End: testTime.Add(-time.Hour)},
+		{Start: testTime.Add(-30 * time.Minute), End: testTime},
+	}
+
+	for _, tc := range []struct {
+		desc              string
+		planned           []querylimits.TimeRange
+		injectPlan        bool
+		withParentRange   bool
+		queryBytes        uint64
+		limit             int
+		shouldErr         bool
+		expectedStatsHits int
+		expectStatsRanges []querylimits.TimeRange
+	}{
+		{
+			desc:              "absent plan uses the request range",
+			injectPlan:        false,
+			queryBytes:        500,
+			limit:             1000,
+			shouldErr:         false,
+			expectedStatsHits: 1,
+		},
+		{
+			desc:              "absent plan still uses QueryLimitsContext as a floor",
+			injectPlan:        false,
+			withParentRange:   true,
+			queryBytes:        500,
+			limit:             1000,
+			shouldErr:         false,
+			expectedStatsHits: 2,
+		},
+		{
+			desc:              "present empty plan is zero bytes and does not query stats",
+			injectPlan:        true,
+			planned:           nil,
+			queryBytes:        5000,
+			limit:             1,
+			shouldErr:         false,
+			expectedStatsHits: 0,
+		},
+		{
+			desc:              "one planned window replaces the request span",
+			injectPlan:        true,
+			planned:           []querylimits.TimeRange{smallWindow},
+			queryBytes:        200,
+			limit:             1000,
+			shouldErr:         false,
+			expectedStatsHits: 1,
+			expectStatsRanges: []querylimits.TimeRange{smallWindow},
+		},
+		{
+			desc:              "disjoint planned windows are summed not covered",
+			injectPlan:        true,
+			planned:           disjointWindows,
+			queryBytes:        400,
+			limit:             1000,
+			shouldErr:         false,
+			expectedStatsHits: 2,
+			expectStatsRanges: disjointWindows,
+		},
+		{
+			desc:              "sum of planned windows can still exceed the limit",
+			injectPlan:        true,
+			planned:           disjointWindows,
+			queryBytes:        400,
+			limit:             700,
+			shouldErr:         true,
+			expectedStatsHits: 2,
+			expectStatsRanges: disjointWindows,
+		},
+		{
+			desc:              "parent QueryLimitsContext is not a floor once a plan is present",
+			injectPlan:        true,
+			withParentRange:   true,
+			planned:           []querylimits.TimeRange{smallWindow},
+			queryBytes:        200,
+			limit:             1000,
+			shouldErr:         false,
+			expectedStatsHits: 1,
+			expectStatsRanges: []querylimits.TimeRange{smallWindow},
+		},
+		{
+			desc:              "empty plan ignores a parent range that would have exceeded the limit",
+			injectPlan:        true,
+			withParentRange:   true,
+			planned:           []querylimits.TimeRange{},
+			queryBytes:        5000,
+			limit:             1,
+			shouldErr:         false,
+			expectedStatsHits: 0,
+		},
+		{
+			desc:       "empty planned windows are skipped",
+			injectPlan: true,
+			planned: []querylimits.TimeRange{
+				{Start: testTime, End: testTime},
+				smallWindow,
+			},
+			queryBytes:        200,
+			limit:             1000,
+			shouldErr:         false,
+			expectedStatsHits: 1,
+			expectStatsRanges: []querylimits.TimeRange{smallWindow},
+		},
+		{
+			desc:       "query limiter does not clip planned windows to the request range",
+			injectPlan: true,
+			planned: []querylimits.TimeRange{
+				{Start: testTime.Add(-48 * time.Hour), End: testTime.Add(-36 * time.Hour)},
+			},
+			queryBytes:        200,
+			limit:             1000,
+			shouldErr:         false,
+			expectedStatsHits: 1,
+			expectStatsRanges: []querylimits.TimeRange{
+				{Start: testTime.Add(-48 * time.Hour), End: testTime.Add(-36 * time.Hour)},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			statsHits := atomic.NewInt32(0)
+			var gotStatsRanges []querylimits.TimeRange
+
+			statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+				statsHits.Inc()
+				gotStatsRanges = append(gotStatsRanges, querylimits.TimeRange{
+					Start: req.GetStart(),
+					End:   req.GetEnd(),
+				})
+				return &IndexStatsResponse{
+					Response: &logproto.IndexStatsResponse{
+						Bytes: tc.queryBytes,
+					},
+				}, nil
+			})
+
+			promHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+				require.Equal(t, reqStart.UnixMilli(), req.GetStart().UnixMilli())
+				require.Equal(t, reqEnd.UnixMilli(), req.GetEnd().UnixMilli())
+				return &LokiPromResponse{
+					Response: &queryrangebase.PrometheusResponse{
+						Status: "success",
+					},
+				}, nil
+			})
+
+			lokiReq := &LokiRequest{
+				Query:     query,
+				StartTs:   reqStart,
+				EndTs:     reqEnd,
+				Direction: logproto.FORWARD,
+				Path:      "/query_range",
+				Plan:      testutil.MustPlan(query),
+			}
+
+			ctx := user.InjectOrgID(context.Background(), "foo")
+			if tc.withParentRange {
+				ctx = querylimits.InjectQueryLimitsContextIntoContext(ctx, querylimits.Context{
+					Expr: `{context="true"}`,
+					From: testTime.Add(-7 * 24 * time.Hour),
+					To:   testTime,
+				})
+			}
+			if tc.injectPlan {
+				ctx = querylimits.InjectPlannedQueryRanges(ctx, tc.planned)
+			}
+
+			handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+				maxQueryBytesRead: tc.limit,
+			}, statsHandler).Wrap(promHandler)
+
+			_, err := handler.Do(ctx, lokiReq)
+			if tc.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedStatsHits, int(statsHits.Load()))
+
+			if tc.expectStatsRanges != nil {
+				require.Equal(t, len(tc.expectStatsRanges), len(gotStatsRanges))
+				lookback := testEngineOpts.MaxLookBackPeriod
+				for i, want := range tc.expectStatsRanges {
+					// Log selectors have Interval=0, so getStatsForMatchers applies MaxLookBackPeriod.
+					require.Equal(t, want.Start.Add(-lookback).UnixMilli(), gotStatsRanges[i].Start.UnixMilli())
+					require.Equal(t, want.End.UnixMilli(), gotStatsRanges[i].End.UnixMilli())
+				}
+			}
+		})
+	}
+}
+
+type countingPlanSource struct {
+	ranges []querylimits.TimeRange
+	ok     bool
+	waits  atomic.Int32
+}
+
+func (s *countingPlanSource) Wait(context.Context) ([]querylimits.TimeRange, bool) {
+	s.waits.Add(1)
+	return s.ranges, s.ok
+}
+
+func Test_MaxQuerySize_WaitsOnPlannedRangeSource(t *testing.T) {
+	query := `{app="foo"} |= "foo"`
+	reqStart := testTime.Add(-24 * time.Hour)
+	reqEnd := testTime
+	smallWindow := querylimits.TimeRange{Start: testTime.Add(-30 * time.Minute), End: testTime}
+
+	newReq := func() *LokiRequest {
+		return &LokiRequest{
+			Query:     query,
+			StartTs:   reqStart,
+			EndTs:     reqEnd,
+			Direction: logproto.FORWARD,
+			Path:      "/query_range",
+			Plan:      testutil.MustPlan(query),
+		}
+	}
+
+	t.Run("does not wait when the full span is under the limit", func(t *testing.T) {
+		src := &countingPlanSource{ranges: []querylimits.TimeRange{smallWindow}, ok: true}
+		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 200}}, nil
+		})
+		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+			maxQueryBytesRead: 1000,
+		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
+		}))
+
+		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
+		_, err := handler.Do(ctx, newReq())
+		require.NoError(t, err)
+		require.Equal(t, int32(0), src.waits.Load())
+	})
+
+	t.Run("waits and injects a snapshot when the full span would 400", func(t *testing.T) {
+		src := &countingPlanSource{ranges: []querylimits.TimeRange{smallWindow}, ok: true}
+		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+			bytes := uint64(5000)
+			if req.GetEnd().Sub(req.GetStart()) <= time.Hour {
+				bytes = 100
+			}
+			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: bytes}}, nil
+		})
+		var got []querylimits.TimeRange
+		var gotOK bool
+		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+			maxQueryBytesRead: 1000,
+		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+			got, gotOK = querylimits.ExtractPlannedQueryRanges(ctx)
+			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
+		}))
+
+		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
+		_, err := handler.Do(ctx, newReq())
+		require.NoError(t, err)
+		require.Equal(t, int32(1), src.waits.Load())
+		require.True(t, gotOK)
+		require.Equal(t, []querylimits.TimeRange{smallWindow}, got)
+	})
+
+	t.Run("absent source result still 400s on the full span", func(t *testing.T) {
+		src := &countingPlanSource{ok: false}
+		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 5000}}, nil
+		})
+		nextCalled := false
+		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+			maxQueryBytesRead: 1000,
+		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+			nextCalled = true
+			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
+		}))
+
+		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
+		_, err := handler.Do(ctx, newReq())
+		require.Error(t, err)
+		require.Equal(t, int32(1), src.waits.Load())
+		require.False(t, nextCalled)
+	})
+
+	t.Run("present empty source plan is zero bytes", func(t *testing.T) {
+		src := &countingPlanSource{ranges: nil, ok: true}
+		statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+			return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 5000}}, nil
+		})
+		var gotOK bool
+		handler := NewQuerySizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+			maxQueryBytesRead: 1,
+		}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+			_, gotOK = querylimits.ExtractPlannedQueryRanges(ctx)
+			return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
+		}))
+
+		ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
+		_, err := handler.Do(ctx, newReq())
+		require.NoError(t, err)
+		require.True(t, gotOK)
+	})
+}
+
+func Test_MaxQuerierSize_IgnoresPlannedRangeSource(t *testing.T) {
+	query := `{app="foo"} |= "foo"`
+	src := &countingPlanSource{ranges: nil, ok: true}
+	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{Bytes: 5000}}, nil
+	})
+	handler := NewQuerierSizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+		maxQuerierBytesRead: 1,
+	}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &LokiPromResponse{Response: &queryrangebase.PrometheusResponse{Status: "success"}}, nil
+	}))
+
+	ctx := querylimits.InjectPlannedRangeSource(user.InjectOrgID(context.Background(), "foo"), src)
+	_, err := handler.Do(ctx, &LokiRequest{
+		Query:     query,
+		StartTs:   testTime.Add(-time.Hour),
+		EndTs:     testTime,
+		Direction: logproto.FORWARD,
+		Path:      "/query_range",
+		Plan:      testutil.MustPlan(query),
+	})
+	require.Error(t, err)
+	require.Equal(t, int32(0), src.waits.Load())
+}
+
+func Test_MaxQuerierSize_IgnoresPlannedRanges(t *testing.T) {
+	query := `{app="foo"} |= "foo"`
+	splitStart := testTime.Add(-time.Hour)
+	splitEnd := testTime
+	// A plan that would be 0 bytes if applied. The querier limiter must still
+	// size the split range and reject.
+	planned := []querylimits.TimeRange{}
+
+	statsHits := atomic.NewInt32(0)
+	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		statsHits.Inc()
+		require.Equal(t, splitStart.Add(-testEngineOpts.MaxLookBackPeriod).UnixMilli(), req.GetStart().UnixMilli())
+		require.Equal(t, splitEnd.UnixMilli(), req.GetEnd().UnixMilli())
+		return &IndexStatsResponse{
+			Response: &logproto.IndexStatsResponse{Bytes: 5000},
+		}, nil
+	})
+
+	lokiReq := &LokiRequest{
+		Query:     query,
+		StartTs:   splitStart,
+		EndTs:     splitEnd,
+		Direction: logproto.FORWARD,
+		Path:      "/query_range",
+		Plan:      testutil.MustPlan(query),
+	}
+
+	ctx := querylimits.InjectPlannedQueryRanges(
+		user.InjectOrgID(context.Background(), "foo"),
+		planned,
+	)
+
+	handler := NewQuerierSizeLimiterMiddleware(testEngineOpts, util_log.Logger, fakeLimits{
+		maxQuerierBytesRead: 1,
+	}, statsHandler).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &LokiPromResponse{
+			Response: &queryrangebase.PrometheusResponse{Status: "success"},
+		}, nil
+	}))
+
+	_, err := handler.Do(ctx, lokiReq)
+	require.Error(t, err)
+	require.Equal(t, int32(1), statsHits.Load())
+}
+
 func Test_MaxQuerySize_MaxLookBackPeriod(t *testing.T) {
 	engineOpts := testEngineOpts
 	engineOpts.MaxLookBackPeriod = 1 * time.Hour

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 	"github.com/grafana/loki/v3/pkg/util/validation"
 )
@@ -135,6 +136,37 @@ func (ast *astMapperware) checkQuerySizeLimit(ctx context.Context, bytesPerShard
 	return nil
 }
 
+// plannedBytesPerShard returns plan∩request bytes scaled onto the
+// mapper's bytesPerShard so the shard factor is unchanged. ok is false
+// when stats fail so the caller keeps the full-split estimate.
+func (ast *astMapperware) plannedBytesPerShard(
+	ctx context.Context,
+	r queryrangebase.Request,
+	planned []querylimits.TimeRange,
+	bytesPerShard uint64,
+) (uint64, bool) {
+	limiter := newQuerySizeLimiter(
+		ast.next,
+		ast.ng.Opts(),
+		ast.logger,
+		ast.limits.MaxQuerierBytesRead,
+		maxQuerierBytesReadSpec,
+		ast.statsHandler,
+	)
+	plannedBytes, err := limiter.getBytesForPlannedRanges(ctx, r, planned)
+	if err != nil {
+		return 0, false
+	}
+	if plannedBytes == 0 {
+		return 0, true
+	}
+	fullBytes, err := limiter.getBytesForQueryAndRange(ctx, r.GetQuery(), r.GetStart(), r.GetEnd())
+	if err != nil {
+		return 0, false
+	}
+	return scaleBytesToShard(plannedBytes, fullBytes, bytesPerShard), true
+}
+
 func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 	logger := util_log.WithContext(ctx, ast.logger)
 	spLogger := spanlogger.FromContext(
@@ -205,7 +237,19 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 	}
 	level.Debug(logger).Log("no-op", noop, "mapped", parsed.String())
 
-	// Note, even if noop, bytesPerShard contains the bytes that'd be read for the whole expr without sharding
+	// Note, even if noop, bytesPerShard contains the bytes that'd be read for the whole expr without sharding.
+	// A present plan sizes the limit from plan∩split / the already-chosen
+	// factor. GetStats (and thus the factor) still use the full split.
+	if planned, ok := querylimits.ExtractPlannedQueryRanges(ctx); ok {
+		if sized, ok := ast.plannedBytesPerShard(ctx, r, planned, bytesPerShard); ok {
+			level.Debug(logger).Log(
+				"msg", "sized MaxQuerierBytesRead using planned ranges",
+				"windows", len(planned),
+				"bytes_per_shard", sized,
+			)
+			bytesPerShard = sized
+		}
+	}
 	if err = ast.checkQuerySizeLimit(ctx, bytesPerShard, noop); err != nil {
 		return nil, err
 	}

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -136,9 +136,9 @@ func (ast *astMapperware) checkQuerySizeLimit(ctx context.Context, bytesPerShard
 	return nil
 }
 
-// plannedBytesPerShard returns plan∩request bytes scaled onto the
-// mapper's bytesPerShard so the shard factor is unchanged. ok is false
-// when stats fail so the caller keeps the full-split estimate.
+// plannedBytesPerShard is planned-window bytes divided by the existing
+// shard count, for the MaxQuerierBytesRead check. ok is false if stats
+// fail so the caller keeps the full-range estimate.
 func (ast *astMapperware) plannedBytesPerShard(
 	ctx context.Context,
 	r queryrangebase.Request,
@@ -238,8 +238,9 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 	level.Debug(logger).Log("no-op", noop, "mapped", parsed.String())
 
 	// Note, even if noop, bytesPerShard contains the bytes that'd be read for the whole expr without sharding.
-	// A present plan sizes the limit from plan∩split / the already-chosen
-	// factor. GetStats (and thus the factor) still use the full split.
+	// A present plan only changes the MaxQuerierBytesRead number (planned
+	// windows divided by the existing shard count). GetStats and the shard
+	// factor still use the full request range.
 	if planned, ok := querylimits.ExtractPlannedQueryRanges(ctx); ok {
 		if sized, ok := ast.plannedBytesPerShard(ctx, r, planned, bytesPerShard); ok {
 			level.Debug(logger).Log(

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -414,6 +414,57 @@ func Test_astMapper_QuerySizeLimits_PlannedRanges(t *testing.T) {
 		_, err := newWare().Do(ctx, req)
 		require.NoError(t, err)
 	})
+
+	t.Run("planned-window stats failure keeps the full-split estimate", func(t *testing.T) {
+		fullSpan := req.GetEnd().Sub(req.GetStart())
+		failingStats := queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+			if r.GetEnd().Sub(r.GetStart()) < fullSpan {
+				return nil, errors.New("planned window stats failed")
+			}
+			return &IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{Bytes: 100},
+			}, nil
+		})
+		downstream := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+			if _, ok := req.(*logproto.IndexStatsRequest); ok {
+				return failingStats.Do(context.Background(), req)
+			}
+			return &LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: logproto.BACKWARD,
+				Limit:     100,
+				Version:   1,
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+				},
+			}, nil
+		})
+		ware := newASTMapperware(
+			[]config.PeriodConfig{{IndexType: types.IndexTypeTSDB}},
+			testEngineOpts,
+			downstream,
+			downstream,
+			failingStats,
+			log.NewNopLogger(),
+			nilShardingMetrics,
+			fakeLimits{
+				maxSeries:               math.MaxInt32,
+				maxQueryParallelism:     1,
+				tsdbMaxQueryParallelism: 1,
+				queryTimeout:            time.Minute,
+				maxQuerierBytesRead:     10,
+			},
+			0,
+			[]string{},
+		)
+		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), []querylimits.TimeRange{{
+			Start: req.GetEnd().Add(-30 * time.Minute),
+			End:   req.GetEnd(),
+		}})
+		_, err := ware.Do(ctx, req)
+		require.Error(t, err)
+		require.ErrorContains(t, err, fmt.Sprintf(limErrQuerierTooManyBytesShardableTmpl, "100 B", "10 B"))
+	})
 }
 
 func Test_clipPlannedQueryRanges(t *testing.T) {

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
 )
 
 var (
@@ -336,6 +337,103 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 			require.Equal(t, tc.expectedStatsHandlerHits, statsCalled)
 		})
 	}
+}
+
+func Test_astMapper_QuerySizeLimits_PlannedRanges(t *testing.T) {
+	query := `{app="foo"} |= "foo"`
+	req := defaultReq()
+	req.Query = query
+	req.Plan = testutil.MustPlan(query)
+
+	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+		bytes := uint64(100)
+		if r.GetStart().After(start.Add(20 * time.Minute)) {
+			bytes = 5
+		}
+		return &IndexStatsResponse{
+			Response: &logproto.IndexStatsResponse{Bytes: bytes},
+		}, nil
+	})
+	downstream := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); ok {
+			return statsHandler.Do(context.Background(), req)
+		}
+		limit := uint32(100)
+		if lokiReq, ok := req.(*LokiRequest); ok {
+			limit = lokiReq.Limit
+		}
+		return &LokiResponse{
+			Status:    loghttp.QueryStatusSuccess,
+			Direction: logproto.BACKWARD,
+			Limit:     limit,
+			Version:   1,
+			Data: LokiData{
+				ResultType: loghttp.ResultTypeStream,
+			},
+		}, nil
+	})
+
+	newWare := func() *astMapperware {
+		return newASTMapperware(
+			[]config.PeriodConfig{{IndexType: types.IndexTypeTSDB}},
+			testEngineOpts,
+			downstream,
+			downstream,
+			statsHandler,
+			log.NewNopLogger(),
+			nilShardingMetrics,
+			fakeLimits{
+				maxSeries:               math.MaxInt32,
+				maxQueryParallelism:     1,
+				tsdbMaxQueryParallelism: 1,
+				queryTimeout:            time.Minute,
+				maxQuerierBytesRead:     10,
+			},
+			0,
+			[]string{},
+		)
+	}
+
+	t.Run("full split exceeds the limit without a plan", func(t *testing.T) {
+		_, err := newWare().Do(user.InjectOrgID(context.Background(), "1"), req)
+		require.Error(t, err)
+		require.ErrorContains(t, err, fmt.Sprintf(limErrQuerierTooManyBytesShardableTmpl, "100 B", "10 B"))
+	})
+
+	t.Run("plan overlap is scaled onto the existing shard estimate", func(t *testing.T) {
+		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), []querylimits.TimeRange{{
+			Start: req.GetEnd().Add(-30 * time.Minute),
+			End:   req.GetEnd(),
+		}})
+		_, err := newWare().Do(ctx, req)
+		require.NoError(t, err)
+	})
+
+	t.Run("empty plan is zero bytes", func(t *testing.T) {
+		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), nil)
+		_, err := newWare().Do(ctx, req)
+		require.NoError(t, err)
+	})
+}
+
+func Test_clipPlannedQueryRanges(t *testing.T) {
+	start := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	got := clipPlannedQueryRanges([]querylimits.TimeRange{
+		{Start: start.Add(-time.Hour), End: start.Add(15 * time.Minute)},
+		{Start: start.Add(2 * time.Hour), End: start.Add(3 * time.Hour)},
+		{Start: start.Add(20 * time.Minute), End: start.Add(40 * time.Minute)},
+	}, start, end)
+	require.Equal(t, []querylimits.TimeRange{
+		{Start: start, End: start.Add(15 * time.Minute)},
+		{Start: start.Add(20 * time.Minute), End: start.Add(40 * time.Minute)},
+	}, got)
+}
+
+func Test_scaleBytesToShard(t *testing.T) {
+	require.Equal(t, uint64(0), scaleBytesToShard(100, 0, 50))
+	require.Equal(t, uint64(25), scaleBytesToShard(100, 400, 100))
 }
 
 func Test_astMapper_TSDBShardingStrategyUsesContext(t *testing.T) {

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
 	"github.com/grafana/loki/v3/pkg/util/validation"
 )
 
@@ -233,12 +234,20 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 		interval = validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, h.limits.QuerySplitDuration)
 	}
 
-	// skip split by if unset
-	if interval == 0 {
-		return h.next.Do(ctx, r)
+	var intervals []queryrangebase.Request
+	if planned, ok := querylimits.ExtractPlannedQueryRanges(ctx); ok {
+		// A present plan is the scan set. Do not fall back to the full span.
+		intervals = splitByPlannedRanges(h.splitter, time.Now().UTC(), tenantIDs, r, interval, planned)
+		if len(intervals) == 0 {
+			return NewEmptyResponse(r)
+		}
+	} else {
+		// skip split by if unset
+		if interval == 0 {
+			return h.next.Do(ctx, r)
+		}
+		intervals = h.splitter.split(time.Now().UTC(), tenantIDs, r, interval)
 	}
-
-	intervals := h.splitter.split(time.Now().UTC(), tenantIDs, r, interval)
 
 	h.metrics.splits.Observe(float64(len(intervals)))
 
@@ -296,6 +305,32 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 		return resps[0], nil
 	}
 	return h.merger.MergeResponse(resps...)
+}
+
+// splitByPlannedRanges turns injected planned windows into downstream requests.
+// The plan is treated as already clipped to the query. When interval > 0, each
+// window is split further by the existing splitter.
+func splitByPlannedRanges(
+	s splitter,
+	execTime time.Time,
+	tenantIDs []string,
+	r queryrangebase.Request,
+	interval time.Duration,
+	planned []querylimits.TimeRange,
+) []queryrangebase.Request {
+	var out []queryrangebase.Request
+	for _, window := range planned {
+		if !window.Start.Before(window.End) {
+			continue
+		}
+		windowReq := r.WithStartEnd(window.Start, window.End)
+		if interval == 0 {
+			out = append(out, windowReq)
+			continue
+		}
+		out = append(out, s.split(execTime, tenantIDs, windowReq, interval)...)
+	}
+	return out
 }
 
 func allLokiResponses(responses []queryrangebase.Response) bool {

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/util/constants"
-	"github.com/grafana/loki/v3/pkg/util/querylimits"
 	"github.com/grafana/loki/v3/pkg/util/validation"
 )
 
@@ -234,20 +233,12 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 		interval = validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, h.limits.QuerySplitDuration)
 	}
 
-	var intervals []queryrangebase.Request
-	if planned, ok := querylimits.ExtractPlannedQueryRanges(ctx); ok {
-		// A present plan is the scan set. Do not fall back to the full span.
-		intervals = splitByPlannedRanges(h.splitter, time.Now().UTC(), tenantIDs, r, interval, planned)
-		if len(intervals) == 0 {
-			return NewEmptyResponse(r)
-		}
-	} else {
-		// skip split by if unset
-		if interval == 0 {
-			return h.next.Do(ctx, r)
-		}
-		intervals = h.splitter.split(time.Now().UTC(), tenantIDs, r, interval)
+	// skip split by if unset
+	if interval == 0 {
+		return h.next.Do(ctx, r)
 	}
+
+	intervals := h.splitter.split(time.Now().UTC(), tenantIDs, r, interval)
 
 	h.metrics.splits.Observe(float64(len(intervals)))
 
@@ -305,32 +296,6 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 		return resps[0], nil
 	}
 	return h.merger.MergeResponse(resps...)
-}
-
-// splitByPlannedRanges turns injected planned windows into downstream requests.
-// The plan is treated as already clipped to the query. When interval > 0, each
-// window is split further by the existing splitter.
-func splitByPlannedRanges(
-	s splitter,
-	execTime time.Time,
-	tenantIDs []string,
-	r queryrangebase.Request,
-	interval time.Duration,
-	planned []querylimits.TimeRange,
-) []queryrangebase.Request {
-	var out []queryrangebase.Request
-	for _, window := range planned {
-		if !window.Start.Before(window.End) {
-			continue
-		}
-		windowReq := r.WithStartEnd(window.Start, window.End)
-		if interval == 0 {
-			out = append(out, windowReq)
-			continue
-		}
-		out = append(out, s.split(execTime, tenantIDs, windowReq, interval)...)
-	}
-	return out
 }
 
 func allLokiResponses(responses []queryrangebase.Response) bool {

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/pkg/util/querylimits"
 )
 
 var nilMetrics = NewSplitByMetrics(nil)
@@ -2135,4 +2136,92 @@ func assertSplits(t *testing.T, want, splits []queryrangebase.Request) {
 			t.Logf("\t#%d [matches: %v]: expected %q/%q got %q/%q\n", j, equal, exp.GetStart(), exp.GetEnd(), act.GetStart(), act.GetEnd())
 		}
 	}
+}
+
+func Test_splitByInterval_PlannedRanges(t *testing.T) {
+	start := time.Unix(0, 0).UTC()
+	end := start.Add(4 * time.Hour)
+	query := `{app="foo"} |= "timeout"`
+
+	var mu sync.Mutex
+	var got []queryrangebase.Request
+	next := queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+		mu.Lock()
+		got = append(got, r)
+		mu.Unlock()
+		return &LokiResponse{
+			Status:    loghttp.QueryStatusSuccess,
+			Direction: logproto.FORWARD,
+			Limit:     1000,
+			Version:   uint32(loghttp.VersionV1),
+		}, nil
+	})
+
+	handler := SplitByIntervalMiddleware(
+		testSchemas,
+		WithSplitByLimits(fakeLimits{maxQueryParallelism: 1}, time.Hour),
+		DefaultCodec,
+		newDefaultSplitter(fakeLimits{}, nil),
+		nilMetrics,
+	).Wrap(next)
+
+	req := &LokiRequest{
+		StartTs:   start,
+		EndTs:     end,
+		Query:     query,
+		Limit:     1000,
+		Direction: logproto.FORWARD,
+		Path:      "/loki/api/v1/query_range",
+		Plan:      &plan.QueryPlan{AST: syntax.MustParseExpr(query)},
+	}
+
+	t.Run("absent plan splits the full span", func(t *testing.T) {
+		got = nil
+		ctx := user.InjectOrgID(context.Background(), "1")
+		_, err := handler.Do(ctx, req)
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+		require.Equal(t, start, got[0].GetStart().UTC())
+		require.Equal(t, end, got[3].GetEnd().UTC())
+	})
+
+	t.Run("present empty plan does not query downstream", func(t *testing.T) {
+		got = nil
+		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), nil)
+		resp, err := handler.Do(ctx, req)
+		require.NoError(t, err)
+		require.Empty(t, got)
+		_, ok := resp.(*LokiResponse)
+		require.True(t, ok)
+	})
+
+	t.Run("planned windows replace the full span", func(t *testing.T) {
+		got = nil
+		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), []querylimits.TimeRange{
+			{Start: start.Add(30 * time.Minute), End: start.Add(45 * time.Minute)},
+			{Start: start.Add(3 * time.Hour), End: start.Add(3*time.Hour + 20*time.Minute)},
+		})
+		_, err := handler.Do(ctx, req)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		require.Equal(t, start.Add(30*time.Minute), got[0].GetStart().UTC())
+		require.Equal(t, start.Add(45*time.Minute), got[0].GetEnd().UTC())
+		require.Equal(t, start.Add(3*time.Hour), got[1].GetStart().UTC())
+		require.Equal(t, start.Add(3*time.Hour+20*time.Minute), got[1].GetEnd().UTC())
+	})
+
+	t.Run("a long planned window is still split by interval", func(t *testing.T) {
+		got = nil
+		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), []querylimits.TimeRange{
+			{Start: start, End: start.Add(150 * time.Minute)},
+		})
+		_, err := handler.Do(ctx, req)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		require.Equal(t, start, got[0].GetStart().UTC())
+		require.Equal(t, start.Add(time.Hour), got[0].GetEnd().UTC())
+		require.Equal(t, start.Add(2*time.Hour), got[1].GetEnd().UTC())
+		require.Equal(t, start.Add(150*time.Minute), got[2].GetEnd().UTC())
+	})
+
 }

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/v3/pkg/util"
-	"github.com/grafana/loki/v3/pkg/util/querylimits"
 )
 
 var nilMetrics = NewSplitByMetrics(nil)
@@ -2136,92 +2135,4 @@ func assertSplits(t *testing.T, want, splits []queryrangebase.Request) {
 			t.Logf("\t#%d [matches: %v]: expected %q/%q got %q/%q\n", j, equal, exp.GetStart(), exp.GetEnd(), act.GetStart(), act.GetEnd())
 		}
 	}
-}
-
-func Test_splitByInterval_PlannedRanges(t *testing.T) {
-	start := time.Unix(0, 0).UTC()
-	end := start.Add(4 * time.Hour)
-	query := `{app="foo"} |= "timeout"`
-
-	var mu sync.Mutex
-	var got []queryrangebase.Request
-	next := queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
-		mu.Lock()
-		got = append(got, r)
-		mu.Unlock()
-		return &LokiResponse{
-			Status:    loghttp.QueryStatusSuccess,
-			Direction: logproto.FORWARD,
-			Limit:     1000,
-			Version:   uint32(loghttp.VersionV1),
-		}, nil
-	})
-
-	handler := SplitByIntervalMiddleware(
-		testSchemas,
-		WithSplitByLimits(fakeLimits{maxQueryParallelism: 1}, time.Hour),
-		DefaultCodec,
-		newDefaultSplitter(fakeLimits{}, nil),
-		nilMetrics,
-	).Wrap(next)
-
-	req := &LokiRequest{
-		StartTs:   start,
-		EndTs:     end,
-		Query:     query,
-		Limit:     1000,
-		Direction: logproto.FORWARD,
-		Path:      "/loki/api/v1/query_range",
-		Plan:      &plan.QueryPlan{AST: syntax.MustParseExpr(query)},
-	}
-
-	t.Run("absent plan splits the full span", func(t *testing.T) {
-		got = nil
-		ctx := user.InjectOrgID(context.Background(), "1")
-		_, err := handler.Do(ctx, req)
-		require.NoError(t, err)
-		require.Len(t, got, 4)
-		require.Equal(t, start, got[0].GetStart().UTC())
-		require.Equal(t, end, got[3].GetEnd().UTC())
-	})
-
-	t.Run("present empty plan does not query downstream", func(t *testing.T) {
-		got = nil
-		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), nil)
-		resp, err := handler.Do(ctx, req)
-		require.NoError(t, err)
-		require.Empty(t, got)
-		_, ok := resp.(*LokiResponse)
-		require.True(t, ok)
-	})
-
-	t.Run("planned windows replace the full span", func(t *testing.T) {
-		got = nil
-		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), []querylimits.TimeRange{
-			{Start: start.Add(30 * time.Minute), End: start.Add(45 * time.Minute)},
-			{Start: start.Add(3 * time.Hour), End: start.Add(3*time.Hour + 20*time.Minute)},
-		})
-		_, err := handler.Do(ctx, req)
-		require.NoError(t, err)
-		require.Len(t, got, 2)
-		require.Equal(t, start.Add(30*time.Minute), got[0].GetStart().UTC())
-		require.Equal(t, start.Add(45*time.Minute), got[0].GetEnd().UTC())
-		require.Equal(t, start.Add(3*time.Hour), got[1].GetStart().UTC())
-		require.Equal(t, start.Add(3*time.Hour+20*time.Minute), got[1].GetEnd().UTC())
-	})
-
-	t.Run("a long planned window is still split by interval", func(t *testing.T) {
-		got = nil
-		ctx := querylimits.InjectPlannedQueryRanges(user.InjectOrgID(context.Background(), "1"), []querylimits.TimeRange{
-			{Start: start, End: start.Add(150 * time.Minute)},
-		})
-		_, err := handler.Do(ctx, req)
-		require.NoError(t, err)
-		require.Len(t, got, 3)
-		require.Equal(t, start, got[0].GetStart().UTC())
-		require.Equal(t, start.Add(time.Hour), got[0].GetEnd().UTC())
-		require.Equal(t, start.Add(2*time.Hour), got[1].GetEnd().UTC())
-		require.Equal(t, start.Add(150*time.Minute), got[2].GetEnd().UTC())
-	})
-
 }

--- a/pkg/util/querylimits/planned_ranges.go
+++ b/pkg/util/querylimits/planned_ranges.go
@@ -17,43 +17,20 @@ type plannedQueryRanges struct {
 	ranges []TimeRange
 }
 
-// InjectPlannedQueryRanges attaches in-process planned ranges for the query
-// size limiter. This is server-only: do not serialize it onto HTTP or gRPC
-// headers. A present empty slice means "scan nothing" (0 bytes). Omitting
-// the value means the limiter should fall back to the request range.
+// InjectPlannedQueryRanges attaches a finished plan for the size limiter.
+// Keep it on the in-process context only; it is not an HTTP or gRPC header.
+// A present empty slice means "scan nothing" (0 bytes). Omitting the value
+// means size the request range.
 func InjectPlannedQueryRanges(ctx context.Context, ranges []TimeRange) context.Context {
 	copied := append([]TimeRange(nil), ranges...)
 	return context.WithValue(ctx, plannedQueryRangesCtxKey, &plannedQueryRanges{ranges: copied})
 }
 
 // ExtractPlannedQueryRanges returns planned ranges and whether they were set.
-// ok is false when no server middleware attached a plan.
 func ExtractPlannedQueryRanges(ctx context.Context) ([]TimeRange, bool) {
 	v, ok := ctx.Value(plannedQueryRangesCtxKey).(*plannedQueryRanges)
 	if !ok || v == nil {
 		return nil, false
 	}
 	return v.ranges, true
-}
-
-// PlannedRangeSource is a one-shot future for planned scan windows.
-// Wait is safe for concurrent callers. ok=false means treat as absent
-// (timeout or error): size the full request range.
-type PlannedRangeSource interface {
-	Wait(ctx context.Context) (ranges []TimeRange, ok bool)
-}
-
-// InjectPlannedRangeSource attaches a server-only plan future.
-// Do not serialize it onto HTTP or gRPC headers.
-func InjectPlannedRangeSource(ctx context.Context, src PlannedRangeSource) context.Context {
-	return context.WithValue(ctx, plannedRangeSourceCtxKey, src)
-}
-
-// ExtractPlannedRangeSource returns the plan future, if any.
-func ExtractPlannedRangeSource(ctx context.Context) (PlannedRangeSource, bool) {
-	v, ok := ctx.Value(plannedRangeSourceCtxKey).(PlannedRangeSource)
-	if !ok || v == nil {
-		return nil, false
-	}
-	return v, true
 }

--- a/pkg/util/querylimits/planned_ranges.go
+++ b/pkg/util/querylimits/planned_ranges.go
@@ -1,0 +1,59 @@
+package querylimits
+
+import (
+	"context"
+	"time"
+)
+
+// TimeRange is a half-open [Start, End) window used to size a query.
+type TimeRange struct {
+	Start time.Time
+	End   time.Time
+}
+
+// plannedQueryRanges distinguishes "absent" from "present, including empty".
+// A present empty list means the query should be sized as zero bytes.
+type plannedQueryRanges struct {
+	ranges []TimeRange
+}
+
+// InjectPlannedQueryRanges attaches in-process planned ranges for the query
+// size limiter. This is server-only: do not serialize it onto HTTP or gRPC
+// headers. A present empty slice means "scan nothing" (0 bytes). Omitting
+// the value means the limiter should fall back to the request range.
+func InjectPlannedQueryRanges(ctx context.Context, ranges []TimeRange) context.Context {
+	copied := append([]TimeRange(nil), ranges...)
+	return context.WithValue(ctx, plannedQueryRangesCtxKey, &plannedQueryRanges{ranges: copied})
+}
+
+// ExtractPlannedQueryRanges returns planned ranges and whether they were set.
+// ok is false when no server middleware attached a plan.
+func ExtractPlannedQueryRanges(ctx context.Context) ([]TimeRange, bool) {
+	v, ok := ctx.Value(plannedQueryRangesCtxKey).(*plannedQueryRanges)
+	if !ok || v == nil {
+		return nil, false
+	}
+	return v.ranges, true
+}
+
+// PlannedRangeSource is a one-shot future for planned scan windows.
+// Wait is safe for concurrent callers. ok=false means treat as absent
+// (timeout or error): size the full request range.
+type PlannedRangeSource interface {
+	Wait(ctx context.Context) (ranges []TimeRange, ok bool)
+}
+
+// InjectPlannedRangeSource attaches a server-only plan future.
+// Do not serialize it onto HTTP or gRPC headers.
+func InjectPlannedRangeSource(ctx context.Context, src PlannedRangeSource) context.Context {
+	return context.WithValue(ctx, plannedRangeSourceCtxKey, src)
+}
+
+// ExtractPlannedRangeSource returns the plan future, if any.
+func ExtractPlannedRangeSource(ctx context.Context) (PlannedRangeSource, bool) {
+	v, ok := ctx.Value(plannedRangeSourceCtxKey).(PlannedRangeSource)
+	if !ok || v == nil {
+		return nil, false
+	}
+	return v, true
+}

--- a/pkg/util/querylimits/planned_ranges_test.go
+++ b/pkg/util/querylimits/planned_ranges_test.go
@@ -1,0 +1,93 @@
+package querylimits
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlannedQueryRanges_AbsentVsEmpty(t *testing.T) {
+	_, ok := ExtractPlannedQueryRanges(context.Background())
+	require.False(t, ok)
+
+	ctx := InjectPlannedQueryRanges(context.Background(), nil)
+	ranges, ok := ExtractPlannedQueryRanges(ctx)
+	require.True(t, ok)
+	require.Empty(t, ranges)
+
+	ctx = InjectPlannedQueryRanges(context.Background(), []TimeRange{})
+	ranges, ok = ExtractPlannedQueryRanges(ctx)
+	require.True(t, ok)
+	require.Empty(t, ranges)
+}
+
+func TestPlannedQueryRanges_InjectCopies(t *testing.T) {
+	start := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	original := []TimeRange{{Start: start, End: start.Add(time.Hour)}}
+
+	ctx := InjectPlannedQueryRanges(context.Background(), original)
+	original[0].End = start
+
+	got, ok := ExtractPlannedQueryRanges(ctx)
+	require.True(t, ok)
+	require.Equal(t, start.Add(time.Hour), got[0].End)
+}
+
+func TestPlannedQueryRanges_NotSetFromHTTPHeaders(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 1, 8, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, InjectQueryLimitsContextHTTP(r, &Context{
+		Expr: `{app="foo"}`,
+		From: from,
+		To:   to,
+	}))
+	require.NoError(t, InjectQueryLimitsHTTP(r, &QueryLimits{}))
+
+	ctx := context.Background()
+
+	limitsCtx, err := ExtractQueryLimitsContextHTTP(r)
+	require.NoError(t, err)
+	require.NotNil(t, limitsCtx)
+	ctx = InjectQueryLimitsContextIntoContext(ctx, *limitsCtx)
+
+	limits, err := ExtractQueryLimitsHTTP(r)
+	require.NoError(t, err)
+	require.NotNil(t, limits)
+	ctx = InjectQueryLimitsIntoContext(ctx, *limits)
+
+	_, ok := ExtractPlannedQueryRanges(ctx)
+	require.False(t, ok)
+	_, ok = ExtractPlannedRangeSource(ctx)
+	require.False(t, ok)
+}
+
+type staticPlannedRangeSource struct {
+	ranges []TimeRange
+	ok     bool
+}
+
+func (s staticPlannedRangeSource) Wait(context.Context) ([]TimeRange, bool) {
+	return s.ranges, s.ok
+}
+
+func TestPlannedRangeSource_InjectExtract(t *testing.T) {
+	_, ok := ExtractPlannedRangeSource(context.Background())
+	require.False(t, ok)
+
+	src := staticPlannedRangeSource{
+		ranges: []TimeRange{{Start: time.Unix(1, 0), End: time.Unix(2, 0)}},
+		ok:     true,
+	}
+	ctx := InjectPlannedRangeSource(context.Background(), src)
+	got, ok := ExtractPlannedRangeSource(ctx)
+	require.True(t, ok)
+	ranges, ready := got.Wait(context.Background())
+	require.True(t, ready)
+	require.Equal(t, src.ranges, ranges)
+}

--- a/pkg/util/querylimits/planned_ranges_test.go
+++ b/pkg/util/querylimits/planned_ranges_test.go
@@ -2,7 +2,6 @@ package querylimits
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -34,60 +33,4 @@ func TestPlannedQueryRanges_InjectCopies(t *testing.T) {
 	got, ok := ExtractPlannedQueryRanges(ctx)
 	require.True(t, ok)
 	require.Equal(t, start.Add(time.Hour), got[0].End)
-}
-
-func TestPlannedQueryRanges_NotSetFromHTTPHeaders(t *testing.T) {
-	r, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
-	require.NoError(t, err)
-
-	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2024, 1, 8, 0, 0, 0, 0, time.UTC)
-	require.NoError(t, InjectQueryLimitsContextHTTP(r, &Context{
-		Expr: `{app="foo"}`,
-		From: from,
-		To:   to,
-	}))
-	require.NoError(t, InjectQueryLimitsHTTP(r, &QueryLimits{}))
-
-	ctx := context.Background()
-
-	limitsCtx, err := ExtractQueryLimitsContextHTTP(r)
-	require.NoError(t, err)
-	require.NotNil(t, limitsCtx)
-	ctx = InjectQueryLimitsContextIntoContext(ctx, *limitsCtx)
-
-	limits, err := ExtractQueryLimitsHTTP(r)
-	require.NoError(t, err)
-	require.NotNil(t, limits)
-	ctx = InjectQueryLimitsIntoContext(ctx, *limits)
-
-	_, ok := ExtractPlannedQueryRanges(ctx)
-	require.False(t, ok)
-	_, ok = ExtractPlannedRangeSource(ctx)
-	require.False(t, ok)
-}
-
-type staticPlannedRangeSource struct {
-	ranges []TimeRange
-	ok     bool
-}
-
-func (s staticPlannedRangeSource) Wait(context.Context) ([]TimeRange, bool) {
-	return s.ranges, s.ok
-}
-
-func TestPlannedRangeSource_InjectExtract(t *testing.T) {
-	_, ok := ExtractPlannedRangeSource(context.Background())
-	require.False(t, ok)
-
-	src := staticPlannedRangeSource{
-		ranges: []TimeRange{{Start: time.Unix(1, 0), End: time.Unix(2, 0)}},
-		ok:     true,
-	}
-	ctx := InjectPlannedRangeSource(context.Background(), src)
-	got, ok := ExtractPlannedRangeSource(ctx)
-	require.True(t, ok)
-	ranges, ready := got.Wait(context.Background())
-	require.True(t, ready)
-	require.Equal(t, src.ranges, ranges)
 }

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -18,7 +18,6 @@ const (
 	queryLimitsCtxKey        key = 1
 	queryLimitsContextCtxKey key = 2
 	plannedQueryRangesCtxKey key = 3
-	plannedRangeSourceCtxKey key = 4
 
 	HTTPHeaderQueryLimitsKey        = "X-Loki-Query-Limits"
 	HTTPHeaderQueryLimitsContextKey = "X-Loki-Query-Limits-Context"

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -17,6 +17,8 @@ type key int
 const (
 	queryLimitsCtxKey        key = 1
 	queryLimitsContextCtxKey key = 2
+	plannedQueryRangesCtxKey key = 3
+	plannedRangeSourceCtxKey key = 4
 
 	HTTPHeaderQueryLimitsKey        = "X-Loki-Query-Limits"
 	HTTPHeaderQueryLimitsContextKey = "X-Loki-Query-Limits-Context"


### PR DESCRIPTION
## Summary

[Issue](https://github.com/grafana/loki-logline-index-private/issues/285)

Selective `|=` queries 400 today because the frontend sizes **stream matchers × the full time range**. This change lets logline hints shrink that **estimate** so the query can pass the byte gates.

**What it does**
- If the full-range estimate is over `max_query_bytes_read`, prefetch **waits** for the hint lookup, then puts those windows on the in-process context (not an HTTP/gRPC header).
- `max_query_bytes_read` and `max_querier_bytes_read` size those windows only. They do not change what gets scanned.
- Filter middleware still applies hints the same way as before. This does not rewrite how hints are used in the query frontend. It only gets the query past the gates.

**If hints are not ready**
- Timeout or lookup error: no plan. The limiter still 400s on the full range.
- Empty hints: plan is present and 0 bytes. The query proceeds.

**Index stats cost**

Sizing a plan means one index-stats request per planned window (not one for the whole range). `max_querier_bytes_read` does this again per split, but only for windows that overlap that split, plus one full-split stats call to scale the shard estimate. Splits with no overlapping hints add nothing.

Example: 72h query, hourly splits, 4 hint windows in one hour.
- `max_query_bytes_read`: 4 stats calls (instead of 1)
- That one hour: 4 window calls + 1 full-hour call (on top of the shard resolver’s existing full-hour call)
- The other 71 hours: 0 extra

These are TSDB index-stats lookups (small, cached), not chunk reads. We did not measure this on the cell after teardown. The trade is a handful of cheap stats RPCs vs failing the query or scanning hundreds of GiB. It would only get interesting if a query had a very large number of hint windows and most splits overlapped one.

GEL follow-up (after this merges): pass Loki's `Overrides` (`CombinedLimits`) into `WrapMiddleware`, same object the size limiter uses. GEL's logline `Overrides` only has mode / min-bytes. If the new argument is omitted, GEL will not compile. If it is passed as `nil`, Loki does not break — the size limiter still uses tenant `max_query_bytes_read`, but prefetch never waits or injects a plan (treats the limit as 0).

## Test plan

- [x] `go test ./pkg/util/querylimits/ ./pkg/logline/queryfrontend/ ./pkg/querier/queryrange/`
- [x] Over-limit `|=` : `off` 400s, `live` waits, injects, 200s (dev-005 tenant 29: 221 GiB vs 100 GiB → ~13 GiB scanned)
- [x] Under-limit window: `off` and `live` return the same lines; prefetch does not wait
- [ ] Hint timeout / error still 400s on the full span
- [ ] GEL: pass `l.Loki.Overrides` into `WrapMiddleware` after this lands