### PR TITLE
test: Fix flaky integration test

### DIFF
--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -336,20 +336,35 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 			expectedDeleteRequests[i].Status = "processed"
 		}
 
+		// Require the full set of processed requests. Matching only the returned
+		// list lets a partial response (4 of 5) succeed too early, which then
+		// fails the processed-total metric assertion.
 		require.Eventually(t, func() bool {
 			deleteRequests, err := cliCompactor.GetDeleteRequests()
 			require.NoError(t, err)
-
-		outer:
-			for i := range deleteRequests {
-				for j := range expectedDeleteRequests {
-					if deleteRequests[i] == expectedDeleteRequests[j] {
-						continue outer
-					}
-				}
+			if len(deleteRequests) != len(expectedDeleteRequests) {
 				return false
 			}
-			return true
+			for i := range expectedDeleteRequests {
+				found := false
+				for j := range deleteRequests {
+					if deleteRequests[j] == expectedDeleteRequests[i] {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return false
+				}
+			}
+
+			metrics, err := cliCompactor.Metrics()
+			require.NoError(t, err)
+			val, labels, err := extractMetric("loki_compactor_delete_requests_processed_total", metrics)
+			if err != nil {
+				return false
+			}
+			return labels["user"] == tenantID && val == float64(len(expectedDeleteRequests))
 		}, 20*time.Second, 1*time.Second)
 
 		// Check metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
The code was treating a partial success as a "done" condition, leading to an occasionally flaky test. (Additionally, an empty list also succeeded (the loop never ran)).

The wait now requires:
- each expected request present and processed
- the `processed-total` metric already at the appropriate count for that tenant

**Which issue(s) this PR fixes**:
In support of: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
