### PR TITLE
test: Clean up temporary files from integration tests

### DIFF
--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -77,13 +77,19 @@ limits_config:
 #     directory: {{.sharedDataPath}}/rules
 
 storage_config:
-  # Legacy config
+  # Legacy default store (schema object_store: filesystem). Must live under
+  # sharedPath so Cluster.Cleanup removes it; an empty directory becomes ".".
+  filesystem:
+    directory: {{.sharedDataPath}}/chunks
   named_stores:
     filesystem:
       store-1:
         directory: {{.sharedDataPath}}/fs-store-1
-  # Thanos config
+  # Thanos default store. use_thanos_objstore defaults to true and does not
+  # inherit common.storage.filesystem.chunks_directory.
   object_store:
+    filesystem:
+      dir: {{.sharedDataPath}}/chunks
     named_stores:
       filesystem:
         store-1:


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporary files which look like
```
integration/TAXvPEBFAGUH/
integration/THRJalBpYmxaYXVBLzdiM2FiMTI1ZWQ2NWQ5MTc6MWEwODE1MzMxZmU6MWEwOGI5ZmU5ZmU6MWJlODc4YmY=
```
are created from integration tests.  These are chunk objects related to the integration tests, and are present because the current working directory is used as a default, since `storage_config.object_store.filesystem.dir` is never set.  This PR adjusts `storage_config.filesystem.directory` also, in case the Thanos tests are disabled for some reason.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
