### PR TITLE
feat(limits): Shadow-mode stream sharding via CheckLimitsAndShard

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -48,6 +48,7 @@ import (
 	ingester_client "github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	kafka_client "github.com/grafana/loki/v3/pkg/kafka/client"
+	"github.com/grafana/loki/v3/pkg/limits"
 	limits_frontend "github.com/grafana/loki/v3/pkg/limits/frontend"
 	limits_frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
@@ -206,6 +207,13 @@ type metrics struct {
 	pushStatsCount                        *prometheus.CounterVec
 	tenantPushSanitizedStructuredMetadata *prometheus.CounterVec
 
+	limitsServiceShardShadowDivergence    *prometheus.CounterVec
+	limitsServiceShardShadowUnimplemented *prometheus.CounterVec
+	limitsServiceShardShadowFailed        *prometheus.CounterVec
+	limitsServiceShardShadowRejected      *prometheus.CounterVec
+	limitsServiceShardShadowCompared      *prometheus.CounterVec
+	limitsServiceShardShadowCapped        *prometheus.CounterVec
+
 	// kafka metrics
 	kafkaAppends           *prometheus.CounterVec
 	kafkaWriteBytesTotal   prometheus.Counter
@@ -254,6 +262,42 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Name:      "distributor_push_structured_metadata_sanitized_total",
 			Help:      "The total number of times we've had to sanitize structured metadata (names or values) at ingestion time per tenant.",
 		}, []string{"tenant", "format"}),
+
+		limitsServiceShardShadowDivergence: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_limits_service_shard_shadow_divergence_total",
+			Help:      "For tenants/policies in 'shadow' mode, the total number of times the ingest-limits service's shard-count recommendation differed from the shard count actually used (computed by the local rate store). Only incremented for comparable observations -- see distributor_limits_service_shard_shadow_compared_total for the denominator.",
+		}, []string{"tenant"}),
+
+		limitsServiceShardShadowUnimplemented: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_limits_service_shard_shadow_unimplemented_total",
+			Help:      "For tenants/policies in 'shadow' mode, the total number of times the ingest-limits service responded Unimplemented -- i.e. shadow mode is enabled here but the backend's stream-shard-tracking pipeline isn't configured, so this flag is currently a no-op.",
+		}, []string{"tenant"}),
+
+		limitsServiceShardShadowFailed: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_limits_service_shard_shadow_failed_total",
+			Help:      "For tenants/policies in 'shadow' mode, the total number of shadow-mode observations that could not be compared because the ingest-limits service either didn't answer for the stream or explicitly reported it couldn't check it (ReasonFailed).",
+		}, []string{"tenant"}),
+
+		limitsServiceShardShadowRejected: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_limits_service_shard_shadow_rejected_total",
+			Help:      "For tenants/policies in 'shadow' mode, the total number of streams the ingest-limits service would have rejected outright (stream-count budget exhausted for a brand-new stream). The local rate store never rejects, so this is a divergence in kind, not a shard-count mismatch.",
+		}, []string{"tenant"}),
+
+		limitsServiceShardShadowCompared: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_limits_service_shard_shadow_compared_total",
+			Help:      "For tenants/policies in 'shadow' mode, the total number of shadow-mode observations with a real, comparable shard-count recommendation from the ingest-limits service. The denominator for distributor_limits_service_shard_shadow_divergence_total.",
+		}, []string{"tenant"}),
+
+		limitsServiceShardShadowCapped: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_limits_service_shard_shadow_capped_total",
+			Help:      "For tenants/policies in 'shadow' mode, the total number of comparable observations where the ingest-limits service capped the recommended shard count below the rate-justified ideal to fit the tenant's remaining stream-count budget. Capping is expected/explainable, not necessarily a rate-estimate disagreement.",
+		}, []string{"tenant"}),
 
 		kafkaAppends: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
@@ -696,6 +740,14 @@ func (d *Distributor) pushWithResolver(ctx context.Context, req *logproto.PushRe
 	// We also work out the hash value at the same time.
 	streams := make([]KeyedStream, 0, len(req.Streams))
 
+	// Candidates for tenants/policies in "shadow" mode (see
+	// shardstreams.Config.LimitsServiceStreamShardingMode): the local rate
+	// store still drives real sharding for these, but the ingest-limits
+	// service is also asked for a recommendation, purely for comparison.
+	// Populated by maybeShardByRate below, observed once after the
+	// validation loop.
+	var shadowCandidates []limitsServiceShardCandidate
+
 	var validationErrors util.GroupedErrors
 
 	now := time.Now()
@@ -709,7 +761,22 @@ func (d *Distributor) pushWithResolver(ctx context.Context, req *logproto.PushRe
 	// (e.g. toggle time sharding or use a different desired_rate).
 	maybeShardByRate := func(stream logproto.Stream, pushSize int, policy string, shardStreamsCfg shardstreams.Config) {
 		if shardStreamsCfg.Enabled {
-			streams = append(streams, d.shardStream(stream, pushSize, tenantID, policy, shardStreamsCfg)...)
+			sharded, shardCount := d.shardStream(stream, pushSize, tenantID, policy, shardStreamsCfg)
+			streams = append(streams, sharded...)
+
+			if shardStreamsCfg.LimitsServiceStreamShardingMode == shardstreams.LimitsServiceStreamShardingModeShadow {
+				// shardCount is shardCountFor's raw recommendation, not
+				// len(sharded): createShards caps the physical shard count
+				// at len(stream.Entries) (see streamCount), which would
+				// otherwise look like a false divergence for a small push
+				// on a hot stream. pushSize is reused as-is for totalSize
+				// so the comparison stays apples-to-apples against what
+				// the rate store itself just used.
+				shadowCandidates = append(shadowCandidates, limitsServiceShardCandidate{
+					stream: stream, policy: policy, rateStoreShards: shardCount, totalSize: uint64(pushSize),
+				})
+			}
+
 			return
 		}
 		streams = append(streams, KeyedStream{
@@ -940,6 +1007,10 @@ func (d *Distributor) pushWithResolver(ctx context.Context, req *logproto.PushRe
 	// These limits are checked after the ingestion rate limit as this
 	// is how it works in ingesters.
 	if d.cfg.IngestLimitsEnabled {
+		if len(shadowCandidates) > 0 {
+			d.observeLimitsServiceShardShadow(ctx, tenantID, shadowCandidates)
+		}
+
 		accepted, rejected, err := d.ingestLimits.EnforceLimits(ctx, tenantID, streams)
 		if err == nil && !d.cfg.IngestLimitsDryRunEnabled {
 			if len(rejected) > 0 {
@@ -1259,6 +1330,10 @@ func (d *Distributor) trackDiscardedData(
 
 type streamWithTimeShard struct {
 	logproto.Stream
+	// linesTotalLen is deliberately line-bytes-only, not util.EntryTotalSize:
+	// it feeds the rate store's shardCountFor, and switching it to include
+	// structured metadata would change real sharding decisions for existing
+	// tenants, so that fix is deferred.
 	linesTotalLen int
 }
 
@@ -1326,9 +1401,9 @@ func shardStreamByTime(stream logproto.Stream, lbls labels.Labels, timeShardLen 
 	}
 
 	// Append one last shard with all of the logs without a time shard
-	logsWithoutTimeShardLen := 0
+	linesWithoutTimeShardLen := 0
 	for i := startIdx; i < entriesLen; i++ {
-		logsWithoutTimeShardLen += len(entries[i].Line)
+		linesWithoutTimeShardLen += len(entries[i].Line)
 	}
 
 	return append(result, streamWithTimeShard{
@@ -1337,21 +1412,88 @@ func shardStreamByTime(stream logproto.Stream, lbls labels.Labels, timeShardLen 
 			Hash:    stream.Hash,
 			Entries: stream.Entries[startIdx:entriesLen],
 		},
-		linesTotalLen: logsWithoutTimeShardLen,
+		linesTotalLen: linesWithoutTimeShardLen,
 	}), true
 }
 
-// shardStream shards (divides) the given stream into N smaller streams, where
-// N is the sharding size for the given stream. shardSteam returns the smaller
-// streams and their associated keys for hashing to ingesters.
+// limitsServiceShardCandidate is a logical (pre-shard) stream whose
+// tenant/policy is in "shadow" mode. rateStoreShards is shardCountFor's raw
+// recommendation for this push, not necessarily len(sharded) -- see
+// maybeShardByRate. totalSize is the same pushSize the rate store used.
+type limitsServiceShardCandidate struct {
+	stream          logproto.Stream
+	policy          string
+	rateStoreShards int
+	totalSize       uint64
+}
+
+// observeLimitsServiceShardShadow calls the ingest-limits service's
+// CheckLimitsAndShard RPC, purely to compare its
+// recommendation against the shard count the local rate store actually
+// produced.
 //
-// The number of shards is limited by the number of entries.
-func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID string, policy string, shardStreamsCfg shardstreams.Config) []KeyedStream {
+// This runs synchronously with a short timeout
+func (d *Distributor) observeLimitsServiceShardShadow(ctx context.Context, tenantID string, candidates []limitsServiceShardCandidate) {
+	shadowCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	results, err := d.ingestLimits.CheckLimitsAndShard(shadowCtx, tenantID, candidates)
+	if err != nil {
+		// A whole-RPC failure means none of these candidates were observed;
+		// count them all as failed so per-tenant comparison-coverage
+		// metrics don't silently omit them.
+		d.m.limitsServiceShardShadowFailed.WithLabelValues(tenantID).Add(float64(len(candidates)))
+		if status.Code(err) == codes.Unimplemented {
+			// The backend predates the CheckLimitsAndShard RPC (e.g.
+			// mid-rollout); surface this loudly, unlike a normal transient
+			// error.
+			d.m.limitsServiceShardShadowUnimplemented.WithLabelValues(tenantID).Inc()
+			level.Warn(d.logger).Log("msg", "shadow-mode check-limits-and-shard call returned Unimplemented; the backend may be running a version that predates this RPC", "tenant", tenantID)
+			return
+		}
+		level.Debug(d.logger).Log("msg", "failed shadow-mode check-limits-and-shard call", "tenant", tenantID, "err", err)
+		return
+	}
+	for _, c := range candidates {
+		result, ok := results[c.stream.Hash]
+		switch {
+		case !ok || result.ShardDecisionContext == uint32(limits.ReasonFailed):
+			// Not a usable observation: comparing it as a real
+			// recommendation would spuriously agree or diverge.
+			d.m.limitsServiceShardShadowFailed.WithLabelValues(tenantID).Inc()
+		case result.RejectReason != "":
+			// A rejection is a divergence in kind, not a shard-count
+			// mismatch -- the local rate store never rejects outright.
+			d.m.limitsServiceShardShadowRejected.WithLabelValues(tenantID).Inc()
+		default:
+			d.m.limitsServiceShardShadowCompared.WithLabelValues(tenantID).Inc()
+			if result.ShardDecisionContext == uint32(limits.ReasonStreamShardsCapped) {
+				d.m.limitsServiceShardShadowCapped.WithLabelValues(tenantID).Inc()
+			}
+			resultShards := int(result.Shards)
+			if resultShards != c.rateStoreShards {
+				d.m.limitsServiceShardShadowDivergence.WithLabelValues(tenantID).Inc()
+				level.Debug(log.With(util_log.WithUserID(tenantID, d.logger), "stream", c.stream.Labels)).Log(
+					"msg", "shard-count shadow divergence",
+					"rate_store_shards", c.rateStoreShards,
+					"limits_service_shards", resultShards,
+				)
+			}
+		}
+	}
+}
+
+// shardStream shards (divides) the given stream into N smaller streams,
+// where N is the sharding size for the given stream, and returns them along
+// with their associated keys for hashing to ingesters. It also returns the
+// raw shardCountFor recommendation that produced them, which is not
+// necessarily len(shards): createShards caps the physical shard count at
+// len(stream.Entries) (see streamCount).
+func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID string, policy string, shardStreamsCfg shardstreams.Config) ([]KeyedStream, int) {
 	logger := log.With(util_log.WithUserID(tenantID, d.logger), "stream", stream.Labels)
 	shardCount := d.shardCountFor(logger, &stream, pushSize, tenantID, shardStreamsCfg)
 
 	if shardCount <= 1 {
-		return []KeyedStream{{HashKey: lokiring.TokenFor(tenantID, stream.Labels), HashKeyNoShard: stream.Hash, Stream: stream, Policy: policy}}
+		return []KeyedStream{{HashKey: lokiring.TokenFor(tenantID, stream.Labels), HashKeyNoShard: stream.Hash, Stream: stream, Policy: policy}}, shardCount
 	}
 
 	d.m.streamShardCount.Inc()
@@ -1359,7 +1501,7 @@ func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID
 		level.Info(logger).Log("msg", "sharding request", "shard_count", shardCount)
 	}
 
-	return d.divideEntriesBetweenShards(tenantID, shardCount, shardStreamsCfg, stream, policy)
+	return d.divideEntriesBetweenShards(tenantID, shardCount, shardStreamsCfg, stream, policy), shardCount
 }
 
 func (d *Distributor) divideEntriesBetweenShards(tenantID string, totalShards int, shardStreamsCfg shardstreams.Config, stream logproto.Stream, policy string) []KeyedStream {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/go-kit/log"
+	"github.com/gogo/status"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/kv"
@@ -34,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/ingester"
@@ -864,59 +866,73 @@ func TestStreamShard(t *testing.T) {
 		streamSize int
 
 		wantDerivedStreamSize int
+		wantShardCount        int
 	}{
 		{
 			name:                  "zero shard because no entries",
 			entries:               nil,
 			streamSize:            50,
 			wantDerivedStreamSize: 1,
+			wantShardCount:        1,
 		},
 		{
 			name:                  "one shard with one entry",
 			streamSize:            1,
 			entries:               totalEntries[0:1],
 			wantDerivedStreamSize: 1,
+			wantShardCount:        1,
 		},
 		{
 			name:                  "two shards with 3 entries",
 			streamSize:            desiredRate.Val() + 1, // pass the desired rate by 1 byte to force two shards.
 			entries:               totalEntries[0:3],
 			wantDerivedStreamSize: 2,
+			wantShardCount:        2,
 		},
 		{
 			name:                  "two shards with 5 entries",
 			entries:               totalEntries[0:5],
 			streamSize:            desiredRate.Val() + 1, // pass the desired rate for 1 byte to force two shards.
 			wantDerivedStreamSize: 2,
+			wantShardCount:        2,
 		},
 		{
 			name:                  "one shard with 20 entries",
 			entries:               totalEntries[0:20],
 			streamSize:            1,
 			wantDerivedStreamSize: 1,
+			wantShardCount:        1,
 		},
 		{
 			name:                  "two shards with 20 entries",
 			entries:               totalEntries[0:20],
 			streamSize:            desiredRate.Val() + 1, // pass desired rate by 1 to force two shards.
 			wantDerivedStreamSize: 2,
+			wantShardCount:        2,
 		},
 		{
 			name:                  "four shards with 20 entries",
 			entries:               totalEntries[0:20],
 			streamSize:            1 + (desiredRate.Val() * 3), // force 4 shards.
 			wantDerivedStreamSize: 4,
+			wantShardCount:        4,
 		},
 		{
+			// Regression guard for the "recommendation vs. physically-realized
+			// shard count" distinction: the raw recommendation (wantShardCount)
+			// stays 4 even though only 2 physical shards are actually created,
+			// since createShards caps the physical count at len(stream.Entries).
 			name:                  "size for four shards with 2 entries, ends up with 4 shards ",
 			streamSize:            1 + (desiredRate.Val() * 3), // force 4 shards.
 			entries:               totalEntries[0:2],
 			wantDerivedStreamSize: 2,
+			wantShardCount:        4,
 		},
 		{
 			name:                  "four shards with 1 entry, ends up with 1 shard only",
 			entries:               totalEntries[0:1],
 			wantDerivedStreamSize: 1,
+			wantShardCount:        1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -939,8 +955,9 @@ func TestStreamShard(t *testing.T) {
 				shardTracker: NewShardTracker(),
 			}
 
-			derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake", "", d.validator.ShardStreams("fake"))
+			derivedStreams, shardCount := d.shardStream(baseStream, tc.streamSize, "fake", "", d.validator.ShardStreams("fake"))
 			require.Len(t, derivedStreams, tc.wantDerivedStreamSize)
+			require.Equal(t, tc.wantShardCount, shardCount)
 
 			for _, s := range derivedStreams {
 				// Generate sorted labels
@@ -984,7 +1001,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			shardTracker: NewShardTracker(),
 		}
 
-		derivedStreams := d.shardStream(baseStream, streamRate, "fake", "", d.validator.ShardStreams("fake"))
+		derivedStreams, _ := d.shardStream(baseStream, streamRate, "fake", "", d.validator.ShardStreams("fake"))
 		require.Len(t, derivedStreams, 2)
 
 		for i, s := range derivedStreams {
@@ -995,7 +1012,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			require.Equal(t, lbls.Get(ingester.ShardLbName), fmt.Sprint(i))
 		}
 
-		derivedStreams = d.shardStream(baseStream, streamRate, "fake", "", d.validator.ShardStreams("fake"))
+		derivedStreams, _ = d.shardStream(baseStream, streamRate, "fake", "", d.validator.ShardStreams("fake"))
 		require.Len(t, derivedStreams, 2)
 
 		for i, s := range derivedStreams {
@@ -1038,6 +1055,29 @@ func TestStreamShardByTime(t *testing.T) {
 			expResult: []streamWithTimeShard{
 				{Stream: logproto.Stream{Labels: `{__time_shard__="1730376000_1730379600", app="myapp"}`, Entries: []logproto.Entry{
 					{Timestamp: baseTimestamp, Line: "foo"},
+				}}, linesTotalLen: 3},
+			},
+		},
+		{
+			// Regression guard for the deliberate (line-only) sizing
+			// documented on streamWithTimeShard.linesTotalLen: structured
+			// metadata bytes must NOT be counted here, to match
+			// maybeShardByRate's non-time-sharded pushSize input to the
+			// legacy rate store. See that field's doc comment for why.
+			test:   "single shard with structured metadata: metadata bytes excluded",
+			labels: `{app="myapp"}`,
+			entries: []logproto.Entry{
+				{Timestamp: baseTimestamp, Line: "foo", StructuredMetadata: push.LabelsAdapter{
+					{Name: "traceID", Value: "deadbeef"},
+				}},
+			},
+			timeShardLen: time.Hour,
+			ignoreFrom:   baseTimestamp.Add(1 * time.Second),
+			expResult: []streamWithTimeShard{
+				{Stream: logproto.Stream{Labels: `{__time_shard__="1730376000_1730379600", app="myapp"}`, Entries: []logproto.Entry{
+					{Timestamp: baseTimestamp, Line: "foo", StructuredMetadata: push.LabelsAdapter{
+						{Name: "traceID", Value: "deadbeef"},
+					}},
 				}}, linesTotalLen: 3},
 			},
 		},
@@ -3121,6 +3161,197 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 
 				assert.Equal(t, test.expectedDiscardedSamples, discardedSamples, "DiscardedSamples should match expected value")
 				assert.Equal(t, test.expectedDiscardedBytes, discardedBytes, "DiscardedBytes should match expected value")
+			}
+		})
+	}
+}
+
+func TestDistributor_ObserveLimitsServiceShardShadow(t *testing.T) {
+	tests := []struct {
+		name string
+		// shardStreamsEnabled controls the legacy (real) rate-based sharding
+		// path. It must be true for shadow-mode candidates to be
+		// accumulated at all (see maybeShardByRate): shadow observation is
+		// only meaningful when the legacy path is actually making a
+		// rate-based decision to compare against.
+		shardStreamsEnabled            bool
+		checkLimitsAndShardResponse    *limitsproto.CheckLimitsAndShardResponse
+		checkLimitsAndShardResponseErr error
+		expectDivergence               bool
+		expectUnimplemented            bool
+		expectFailed                   bool
+		expectRejected                 bool
+		expectCompared                 bool
+		expectCapped                   bool
+	}{
+		{
+			// Shadow mode must never influence what's actually pushed: the
+			// push must succeed exactly as it would with the mode disabled,
+			// regardless of the (mocked, failing) shard RPC.
+			name:                           "shadow RPC fails entirely: push still succeeds, never affects real output",
+			shardStreamsEnabled:            true,
+			checkLimitsAndShardResponseErr: errors.New("shadow RPC unavailable"),
+			expectDivergence:               false,
+			// A whole-RPC failure means no candidates were observed at all;
+			// this must still count against the comparison-coverage
+			// metrics, not silently vanish from them.
+			expectFailed: true,
+		},
+		{
+			// The backend responds Unimplemented (e.g. an old version that
+			// predates the RPC, mid-rollout): this must be surfaced via a
+			// dedicated metric, not silently swallowed like a normal
+			// transient error.
+			name:                           "backend returns Unimplemented: surfaced via dedicated metric",
+			shardStreamsEnabled:            true,
+			checkLimitsAndShardResponseErr: status.Error(codes.Unimplemented, "unknown method CheckLimitsAndShard"),
+			expectDivergence:               false,
+			expectUnimplemented:            true,
+			expectFailed:                   true,
+		},
+		{
+			// Legacy says 1 shard (the local rate store has no history yet
+			// for this stream, so shardCountFor's "first push, don't shard
+			// until the rate is understood" rule applies regardless of
+			// shardStreamsEnabled); the shadow RPC says 3 -- this
+			// divergence must be recorded, but must still never affect what's
+			// written. shardStreamsEnabled must be true here: shadow
+			// candidates are only accumulated (and thus only compared) when
+			// rate-based sharding is actually enabled -- see
+			// maybeShardByRate.
+			name:                "shadow RPC diverges from the legacy decision: divergence recorded",
+			shardStreamsEnabled: true,
+			checkLimitsAndShardResponse: &limitsproto.CheckLimitsAndShardResponse{
+				Results: []*limitsproto.StreamShardResult{{StreamHash: 0x90eb45def17f924, Shards: 3}},
+			},
+			expectDivergence: true,
+			expectCompared:   true,
+		},
+		{
+			// The stream is missing from the response entirely (e.g. the
+			// frontend never got an answer for it from any zone): this must
+			// not be compared as if it were a real recommendation.
+			name:                "shadow RPC response has no result for the stream: not compared",
+			shardStreamsEnabled: true,
+			checkLimitsAndShardResponse: &limitsproto.CheckLimitsAndShardResponse{
+				Results: []*limitsproto.StreamShardResult{},
+			},
+			expectFailed: true,
+		},
+		{
+			// An explicit ReasonFailed result (e.g. the stream's partition
+			// isn't owned by any answering instance) must likewise be
+			// excluded from the numeric comparison, not treated as
+			// "recommended 1 shard".
+			name:                "shadow RPC reports ReasonFailed for the stream: not compared",
+			shardStreamsEnabled: true,
+			checkLimitsAndShardResponse: &limitsproto.CheckLimitsAndShardResponse{
+				Results: []*limitsproto.StreamShardResult{{
+					StreamHash:           0x90eb45def17f924,
+					Shards:               1,
+					ShardDecisionContext: uint32(limits.ReasonFailed),
+				}},
+			},
+			expectFailed: true,
+		},
+		{
+			// A rejection is a divergence in kind, not a shard-count
+			// mismatch -- the legacy path never rejects a stream outright --
+			// so it must be tracked separately from the numeric comparison.
+			name:                "shadow RPC rejects the stream: tracked separately from shard-count divergence",
+			shardStreamsEnabled: true,
+			checkLimitsAndShardResponse: &limitsproto.CheckLimitsAndShardResponse{
+				Results: []*limitsproto.StreamShardResult{{
+					StreamHash:   0x90eb45def17f924,
+					Shards:       0,
+					RejectReason: limits.ReasonMaxStreams.String(),
+				}},
+			},
+			expectRejected: true,
+		},
+		{
+			// A capped decision that happens to still match the legacy
+			// count is a real, comparable observation -- it must be counted
+			// as both "compared" and "capped", but not as a divergence.
+			name:                "shadow RPC caps the shard count but agrees with the legacy decision: compared and capped, no divergence",
+			shardStreamsEnabled: true,
+			checkLimitsAndShardResponse: &limitsproto.CheckLimitsAndShardResponse{
+				Results: []*limitsproto.StreamShardResult{{
+					StreamHash:           0x90eb45def17f924,
+					Shards:               1,
+					ShardDecisionContext: uint32(limits.ReasonStreamShardsCapped),
+				}},
+			},
+			expectCompared:   true,
+			expectCapped:     true,
+			expectDivergence: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validationLimits := &validation.Limits{}
+			flagext.DefaultValues(validationLimits)
+			validationLimits.ShardStreams.LimitsServiceStreamShardingMode = "shadow"
+			validationLimits.ShardStreams.Enabled = test.shardStreamsEnabled
+			distributors, _ := prepare(t, 1, 3, validationLimits, nil)
+			d := distributors[0]
+			// Shadow-mode observation is gated on this: it shares the "is
+			// the ingest-limits service available at all for this
+			// distributor" switch with the (separate, pre-existing)
+			// EnforceLimits/ExceedsLimits check below.
+			d.cfg.IngestLimitsEnabled = true
+
+			mockClient := mockIngestLimitsFrontendClient{
+				t: t,
+				// A non-nil, empty response so the real (unrelated)
+				// EnforceLimits call -- which now also runs, since it's
+				// gated by the same IngestLimitsEnabled switch -- is a
+				// no-op that accepts every stream, rather than crashing on
+				// a nil response.
+				exceedsLimitsResponse:          &limitsproto.ExceedsLimitsResponse{},
+				checkLimitsAndShardResponse:    test.checkLimitsAndShardResponse,
+				checkLimitsAndShardResponseErr: test.checkLimitsAndShardResponseErr,
+			}
+			d.ingestLimits = newIngestLimits(&mockClient, prometheus.NewRegistry())
+
+			req := &logproto.PushRequest{
+				Streams: []logproto.Stream{{
+					Labels: `{foo="bar"}`,
+					Entries: []logproto.Entry{{
+						Timestamp: time.Now(),
+						Line:      "baz",
+					}},
+				}},
+			}
+			resp, err := d.Push(ctx, req)
+			require.NoError(t, err)
+			require.Equal(t, success, resp)
+
+			// Assert every counter against its exact expected value, not just
+			// the one this case expects to increment. The classification is
+			// mutually exclusive (a stream is failed XOR rejected XOR
+			// compared), so a regression that double-counts a stream into an
+			// unexpected counter must fail here rather than slip through.
+			want := func(b bool) float64 {
+				if b {
+					return 1
+				}
+				return 0
+			}
+			for _, c := range []struct {
+				name    string
+				counter *prometheus.CounterVec
+				expect  bool
+			}{
+				{"divergence", d.m.limitsServiceShardShadowDivergence, test.expectDivergence},
+				{"unimplemented", d.m.limitsServiceShardShadowUnimplemented, test.expectUnimplemented},
+				{"failed", d.m.limitsServiceShardShadowFailed, test.expectFailed},
+				{"rejected", d.m.limitsServiceShardShadowRejected, test.expectRejected},
+				{"compared", d.m.limitsServiceShardShadowCompared, test.expectCompared},
+				{"capped", d.m.limitsServiceShardShadowCapped, test.expectCapped},
+			} {
+				require.Equal(t, want(c.expect), testutil.ToFloat64(c.counter.WithLabelValues("test")), "counter %s", c.name)
 			}
 		})
 	}

--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -20,6 +20,7 @@ import (
 type ingestLimitsFrontendClient interface {
 	ExceedsLimits(context.Context, *proto.ExceedsLimitsRequest) (*proto.ExceedsLimitsResponse, error)
 	UpdateRates(context.Context, *proto.UpdateRatesRequest) (*proto.UpdateRatesResponse, error)
+	CheckLimitsAndShard(context.Context, *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error)
 }
 
 // ingestLimitsFrontendRingClient uses the ring to discover ingest-limits-frontend
@@ -57,6 +58,25 @@ func (c *ingestLimitsFrontendRingClient) ExceedsLimits(ctx context.Context, req 
 		err = c.withTenantShuffleShard(ctx, req.Tenant, doExceedsLimitsFn)
 	} else {
 		err = c.withRandomShuffle(ctx, doExceedsLimitsFn)
+	}
+	return resp, err
+}
+
+// Implements the [ingestLimitsFrontendClient] interface.
+func (c *ingestLimitsFrontendRingClient) CheckLimitsAndShard(ctx context.Context, req *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error) {
+	var (
+		err                     error
+		resp                    *proto.CheckLimitsAndShardResponse
+		doCheckLimitsAndShardFn = func(ctx context.Context, client proto.IngestLimitsFrontendClient) error {
+			var clientErr error
+			resp, clientErr = client.CheckLimitsAndShard(ctx, req)
+			return clientErr
+		}
+	)
+	if c.shuffleShardEnabled {
+		err = c.withTenantShuffleShard(ctx, req.Tenant, doCheckLimitsAndShardFn)
+	} else {
+		err = c.withRandomShuffle(ctx, doCheckLimitsAndShardFn)
 	}
 	return resp, err
 }
@@ -228,6 +248,53 @@ func newExceedsLimitsRequest(tenant string, streams []KeyedStream) (*proto.Excee
 		})
 	}
 	return &proto.ExceedsLimitsRequest{
+		Tenant:  tenant,
+		Streams: streamMetadata,
+	}, nil
+}
+
+// CheckLimitsAndShard checks limits and returns a shard-count recommendation
+// for each candidate stream. It returns a map from each candidate's
+// pre-shard stream hash to its result. A candidate absent from the map (e.g.
+// because the whole call failed, or the frontend never got an answer for
+// it) must be treated by the caller as accepted with 1 shard -- fail open to
+// "don't shard this push", never to "reject it".
+func (l *ingestLimits) CheckLimitsAndShard(ctx context.Context, tenant string, candidates []limitsServiceShardCandidate) (map[uint64]*proto.StreamShardResult, error) {
+	l.requests.WithLabelValues("CheckLimitsAndShard").Inc()
+	req, err := newCheckLimitsAndShardRequest(tenant, candidates)
+	if err != nil {
+		l.requestsFailed.WithLabelValues("CheckLimitsAndShard").Inc()
+		return nil, err
+	}
+	resp, err := l.client.CheckLimitsAndShard(ctx, req)
+	if err != nil {
+		l.requestsFailed.WithLabelValues("CheckLimitsAndShard").Inc()
+		return nil, err
+	}
+
+	results := make(map[uint64]*proto.StreamShardResult, len(resp.Results))
+	for _, r := range resp.Results {
+		results[r.StreamHash] = r
+	}
+
+	return results, nil
+}
+
+func newCheckLimitsAndShardRequest(tenant string, candidates []limitsServiceShardCandidate) (*proto.CheckLimitsAndShardRequest, error) {
+	streamMetadata := make([]*proto.StreamMetadata, 0, len(candidates))
+	for _, c := range candidates {
+		// c.totalSize is the exact pushSize the rate store used for this
+		// stream, reused here so the comparison stays apples-to-apples. It
+		// is line+structured-metadata for non-time-sharded streams, but
+		// deliberately line-only for time-sharded ones (see
+		// streamWithTimeShard.linesTotalLen).
+		streamMetadata = append(streamMetadata, &proto.StreamMetadata{
+			StreamHash:      c.stream.Hash,
+			TotalSize:       c.totalSize,
+			IngestionPolicy: c.policy,
+		})
+	}
+	return &proto.CheckLimitsAndShardRequest{
 		Tenant:  tenant,
 		Streams: streamMetadata,
 	}, nil

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -26,6 +26,22 @@ type mockIngestLimitsFrontendClient struct {
 	expectedUpdateRatesRequest   *proto.UpdateRatesRequest
 	updateRatesResponse          *proto.UpdateRatesResponse
 	updateRatesResponseErr       error
+
+	expectedCheckLimitsAndShardRequest *proto.CheckLimitsAndShardRequest
+	checkLimitsAndShardResponse        *proto.CheckLimitsAndShardResponse
+	checkLimitsAndShardResponseErr     error
+}
+
+// Implements the ingestLimitsFrontendClient interface.
+func (c *mockIngestLimitsFrontendClient) CheckLimitsAndShard(_ context.Context, r *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error) {
+	c.calls.Add(1)
+	if c.expectedCheckLimitsAndShardRequest != nil {
+		require.Equal(c.t, c.expectedCheckLimitsAndShardRequest, r)
+	}
+	if c.checkLimitsAndShardResponseErr != nil {
+		return nil, c.checkLimitsAndShardResponseErr
+	}
+	return c.checkLimitsAndShardResponse, nil
 }
 
 // Implements the ingestLimitsFrontendClient interface.

--- a/pkg/distributor/shardstreams/config.go
+++ b/pkg/distributor/shardstreams/config.go
@@ -2,9 +2,23 @@ package shardstreams
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/util/flagext"
+)
+
+// Values for Config.LimitsServiceStreamShardingMode.
+const (
+	// LimitsServiceStreamShardingModeDisabled stream sharding
+	// is driven entirely by the distributor's local rate store.
+	LimitsServiceStreamShardingModeDisabled = "disabled"
+
+	// LimitsServiceStreamShardingModeShadow computes a shard-count
+	// recommendation via the ingest-limits service's CheckLimitsAndShard RPC
+	// for comparison/observability only. Actual sharding is still driven by
+	// the local rate store.
+	LimitsServiceStreamShardingModeShadow = "shadow"
 )
 
 type Config struct {
@@ -19,6 +33,11 @@ type Config struct {
 	// DesiredRate is the threshold used to shard the stream into smaller pieces.
 	// Expected to be in bytes.
 	DesiredRate flagext.ByteSize `yaml:"desired_rate" json:"desired_rate" doc:"description=Threshold used to cut a new shard. Default (1536KB) means if a rate is above 1536KB/s, it will be sharded into two streams."`
+
+	// LimitsServiceStreamShardingMode controls whether shard-count decisions
+	// are computed by the ingest-limits service instead of the distributor's
+	// local rate store.
+	LimitsServiceStreamShardingMode string `yaml:"limits_service_stream_sharding_mode" json:"limits_service_stream_sharding_mode" doc:"description=Experimental. Controls whether the ingest-limits service is asked for a shard-count recommendation for observability purposes. One of 'disabled' (default, unchanged behavior) or 'shadow' (compute via the limits service for comparison only; actual sharding is still driven by the local rate store)."`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, fs *flag.FlagSet) {
@@ -28,4 +47,21 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, fs *flag.FlagSet) {
 	fs.BoolVar(&cfg.LoggingEnabled, prefix+".logging-enabled", false, "Enable logging when sharding streams")
 	cfg.DesiredRate.Set("1536KB") //nolint:errcheck
 	fs.Var(&cfg.DesiredRate, prefix+".desired-rate", "threshold used to cut a new shard. Default (1536KB) means if a rate is above 1536KB/s, it will be sharded.")
+	fs.StringVar(&cfg.LimitsServiceStreamShardingMode, prefix+".limits-service-stream-sharding-mode", LimitsServiceStreamShardingModeDisabled, "Experimental. One of 'disabled' or 'shadow'. Controls whether the ingest-limits service is asked for a shard-count recommendation for observability purposes.")
+}
+
+// Validate returns an error if cfg is invalid.
+func (cfg *Config) Validate() error {
+	switch cfg.LimitsServiceStreamShardingMode {
+	// The empty string is accepted as equivalent to "disabled" -- the Go
+	// zero value for this field -- so that Config values built directly
+	// (e.g. in tests, or before flag defaults are applied) don't fail
+	// validation just for never having set this field explicitly.
+	case "", LimitsServiceStreamShardingModeDisabled, LimitsServiceStreamShardingModeShadow:
+		return nil
+	default:
+		return fmt.Errorf("invalid limits_service_stream_sharding_mode %q: must be one of %q, %q",
+			cfg.LimitsServiceStreamShardingMode,
+			LimitsServiceStreamShardingModeDisabled, LimitsServiceStreamShardingModeShadow)
+	}
 }

--- a/pkg/limits/frontend/client.go
+++ b/pkg/limits/frontend/client.go
@@ -21,6 +21,10 @@ type limitsClient interface {
 
 	// UpdateRates updates the per-second rates for the streams.
 	UpdateRates(context.Context, *proto.UpdateRatesRequest) (*proto.UpdateRatesResponse, error)
+
+	// CheckLimitsAndShard checks limits and returns a shard-count
+	// recommendation per stream.
+	CheckLimitsAndShard(context.Context, *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error)
 }
 
 // A cacheLimitsClient uses caches to reduce the load on limits backends.
@@ -76,6 +80,15 @@ func (c *cacheLimitsClient) ExceedsLimits(ctx context.Context, req *proto.Exceed
 // UpdateRates implements the [limitsClient] interface.
 func (c *cacheLimitsClient) UpdateRates(ctx context.Context, req *proto.UpdateRatesRequest) (*proto.UpdateRatesResponse, error) {
 	return c.onMiss.UpdateRates(ctx, req)
+}
+
+// CheckLimitsAndShard implements the [limitsClient] interface. It is
+// deliberately never routed through acceptedStreamsCache: that cache exists
+// to skip re-checking known-accepted streams, but shard-count decisions
+// depend on a live, continuously-updated rate estimate that must see every
+// push -- caching it here would starve the very signal this RPC depends on.
+func (c *cacheLimitsClient) CheckLimitsAndShard(ctx context.Context, req *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error) {
+	return c.onMiss.CheckLimitsAndShard(ctx, req)
 }
 
 type acceptedStreamsCache struct {

--- a/pkg/limits/frontend/client_test.go
+++ b/pkg/limits/frontend/client_test.go
@@ -75,6 +75,36 @@ func TestCacheLimitsClient(t *testing.T) {
 	})
 }
 
+func TestCacheLimitsClient_CheckLimitsAndShard_NeverCached(t *testing.T) {
+	// CheckLimitsAndShard must always forward to the backend uncached: its
+	// shard-count decisions depend on a live, continuously-updated rate
+	// estimate that must see every push, unlike ExceedsLimits's stable
+	// accept/reject fact. A cache that skipped forwarding known streams
+	// would starve the backend of the very signal this RPC depends on.
+	cache := newAcceptedStreamsCache(time.Minute, 15*time.Second, prometheus.NewRegistry())
+	// Pre-populate the accepted-streams cache with the same stream hash, to
+	// prove CheckLimitsAndShard ignores it entirely (a cache hit here would
+	// otherwise short-circuit the call).
+	cache.Update("test", []*proto.StreamMetadata{{StreamHash: 0x1}})
+
+	req := &proto.CheckLimitsAndShardRequest{
+		Tenant:  "test",
+		Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+	}
+	onMiss := &mockLimitsClient{
+		t:                                  t,
+		expectedCheckLimitsAndShardRequest: req,
+		checkLimitsAndShardResponse: &proto.CheckLimitsAndShardResponse{
+			Results: []*proto.StreamShardResult{{StreamHash: 0x1, Shards: 3}},
+		},
+	}
+	client := newCacheLimitsClient(cache, onMiss)
+	resp, err := client.CheckLimitsAndShard(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, uint32(3), resp.Results[0].Shards)
+	require.Equal(t, 1, onMiss.checkLimitsAndShardCalls)
+}
+
 func TestAcceptedStreamsCache(t *testing.T) {
 	t.Run("cache is cleared after TTL elapsed", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -39,6 +39,17 @@ type Frontend struct {
 	streams         prometheus.Counter
 	streamsFailed   prometheus.Counter
 	streamsRejected prometheus.Counter
+
+	// checkLimitsAndShardStreams, checkLimitsAndShardShards,
+	// checkLimitsAndShardFailed, and checkLimitsAndShardRejected are all
+	// dedicated to CheckLimitsAndShard rather than reusing
+	// streams/streamsFailed/streamsRejected above: in shadow mode, a push's
+	// streams are also sent through ExceedsLimits, so folding both
+	// endpoints into the same counters would double-count.
+	checkLimitsAndShardStreams  *prometheus.CounterVec
+	checkLimitsAndShardShards   *prometheus.CounterVec
+	checkLimitsAndShardFailed   *prometheus.CounterVec
+	checkLimitsAndShardRejected *prometheus.CounterVec
 }
 
 // New returns a new Frontend.
@@ -63,6 +74,30 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 				Name: "loki_ingest_limits_frontend_streams_rejected_total",
 				Help: "The total number of rejected streams.",
 			},
+		),
+		checkLimitsAndShardStreams: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "loki_ingest_limits_frontend_check_limits_and_shard_streams_total",
+				Help: "The total number of logical (pre-shard) streams received via CheckLimitsAndShard.",
+			}, []string{"tenant"},
+		),
+		checkLimitsAndShardShards: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "loki_ingest_limits_frontend_check_limits_and_shard_shards_total",
+				Help: "The total number of shards granted via CheckLimitsAndShard, i.e. the total physical stream count (unsharded and sharded) implied by these decisions.",
+			}, []string{"tenant"},
+		),
+		checkLimitsAndShardFailed: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "loki_ingest_limits_frontend_check_limits_and_shard_failed_total",
+				Help: "The total number of streams received via CheckLimitsAndShard that could not be checked.",
+			}, []string{"tenant"},
+		),
+		checkLimitsAndShardRejected: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "loki_ingest_limits_frontend_check_limits_and_shard_rejected_total",
+				Help: "The total number of streams rejected via CheckLimitsAndShard.",
+			}, []string{"tenant"},
 		),
 	}
 	// Set up a client pool for the limits service. The frontend will use this
@@ -138,6 +173,41 @@ func (f *Frontend) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRe
 				f.streamsFailed.Inc()
 			} else {
 				f.streamsRejected.Inc()
+			}
+		}
+	}
+	return resp, nil
+}
+
+// CheckLimitsAndShard implements proto.IngestLimitsFrontendClient.
+func (f *Frontend) CheckLimitsAndShard(ctx context.Context, req *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error) {
+	f.checkLimitsAndShardStreams.WithLabelValues(req.Tenant).Add(float64(len(req.Streams)))
+	resp, err := f.limitsClient.CheckLimitsAndShard(ctx, req)
+	if err != nil {
+		// If the entire call failed, degrade to "don't shard this push" for
+		// every stream rather than rejecting it -- a materially safer
+		// failure mode for a throughput optimization than dropping data.
+		resp = &proto.CheckLimitsAndShardResponse{
+			Results: make([]*proto.StreamShardResult, 0, len(req.Streams)),
+		}
+		for _, stream := range req.Streams {
+			resp.Results = append(resp.Results, &proto.StreamShardResult{
+				StreamHash:           stream.StreamHash,
+				Shards:               1,
+				ShardDecisionContext: uint32(limits.ReasonFailed),
+			})
+		}
+		f.checkLimitsAndShardShards.WithLabelValues(req.Tenant).Add(float64(len(req.Streams)))
+		f.checkLimitsAndShardFailed.WithLabelValues(req.Tenant).Add(float64(len(req.Streams)))
+		level.Error(f.logger).Log("msg", "failed to check limits and shard", "err", err)
+	} else {
+		for _, res := range resp.Results {
+			f.checkLimitsAndShardShards.WithLabelValues(req.Tenant).Add(float64(res.Shards))
+			switch {
+			case res.ShardDecisionContext == uint32(limits.ReasonFailed):
+				f.checkLimitsAndShardFailed.WithLabelValues(req.Tenant).Inc()
+			case res.RejectReason != "":
+				f.checkLimitsAndShardRejected.WithLabelValues(req.Tenant).Inc()
 			}
 		}
 	}

--- a/pkg/limits/frontend/frontend_test.go
+++ b/pkg/limits/frontend/frontend_test.go
@@ -185,3 +185,81 @@ func TestFrontend_ExceedsLimits(t *testing.T) {
 		})
 	}
 }
+
+func newTestFrontend(t *testing.T) *Frontend {
+	t.Helper()
+	readRing, _ := newMockRingWithClientPool(t, "test", nil, nil)
+	f, err := New(Config{
+		LifecyclerConfig: ring.LifecyclerConfig{
+			RingConfig: ring.Config{
+				KVStore: kv.Config{
+					Store: "inmemory",
+				},
+			},
+			HeartbeatPeriod:  time.Second,
+			HeartbeatTimeout: time.Minute,
+		},
+	}, "test", readRing, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	return f
+}
+
+func TestFrontend_CheckLimitsAndShard_FailsOpenToOneShard(t *testing.T) {
+	f := newTestFrontend(t)
+	f.limitsClient = &mockLimitsClient{t: t, err: errors.New("boom")}
+	req := &proto.CheckLimitsAndShardRequest{
+		Tenant:  "test",
+		Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+	}
+	resp, err := f.CheckLimitsAndShard(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, []*proto.StreamShardResult{{
+		StreamHash:           0x1,
+		Shards:               1,
+		ShardDecisionContext: uint32(limits.ReasonFailed),
+	}}, resp.Results)
+}
+
+func TestFrontend_CheckLimitsAndShard_NoCaching(t *testing.T) {
+	// Regression guard: there is no fail-open cache. A real decision from
+	// one call must never be remembered and replayed on a later failure --
+	// every total failure collapses to 1 shard, and every per-stream
+	// failure/rejection is passed straight through from the backend/ring,
+	// regardless of what any earlier call returned for the same stream.
+	f := newTestFrontend(t)
+	req := &proto.CheckLimitsAndShardRequest{
+		Tenant:  "test",
+		Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+	}
+
+	mockClient := &mockLimitsClient{
+		t: t,
+		checkLimitsAndShardResponse: &proto.CheckLimitsAndShardResponse{
+			Results: []*proto.StreamShardResult{{StreamHash: 0x1, Shards: 20}},
+		},
+	}
+	f.limitsClient = mockClient
+	resp, err := f.CheckLimitsAndShard(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, uint32(20), resp.Results[0].Shards)
+
+	// A per-stream failure placeholder (RPC succeeds overall, but this
+	// stream's own partition went unanswered) passes through as 1 shard,
+	// not the earlier 20.
+	mockClient.checkLimitsAndShardResponse = &proto.CheckLimitsAndShardResponse{
+		Results: []*proto.StreamShardResult{{
+			StreamHash:           0x1,
+			Shards:               1,
+			ShardDecisionContext: uint32(limits.ReasonFailed),
+		}},
+	}
+	resp, err = f.CheckLimitsAndShard(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), resp.Results[0].Shards)
+
+	// A total RPC failure also collapses to 1 shard, not the earlier 20.
+	mockClient.err = errors.New("boom")
+	resp, err = f.CheckLimitsAndShard(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), resp.Results[0].Shards)
+}

--- a/pkg/limits/frontend/mock_test.go
+++ b/pkg/limits/frontend/mock_test.go
@@ -24,6 +24,10 @@ type mockLimitsClient struct {
 	expectedExceedsLimitsRequest *proto.ExceedsLimitsRequest
 	exceedsLimitsResponse        *proto.ExceedsLimitsResponse
 	err                          error
+
+	expectedCheckLimitsAndShardRequest *proto.CheckLimitsAndShardRequest
+	checkLimitsAndShardResponse        *proto.CheckLimitsAndShardResponse
+	checkLimitsAndShardCalls           int
 }
 
 func (m *mockLimitsClient) ExceedsLimits(_ context.Context, req *proto.ExceedsLimitsRequest) (*proto.ExceedsLimitsResponse, error) {
@@ -36,6 +40,14 @@ func (m *mockLimitsClient) ExceedsLimits(_ context.Context, req *proto.ExceedsLi
 func (m *mockLimitsClient) UpdateRates(_ context.Context, _ *proto.UpdateRatesRequest) (*proto.UpdateRatesResponse, error) {
 	// TODO(grobinson): Implement this method.
 	return nil, nil
+}
+
+func (m *mockLimitsClient) CheckLimitsAndShard(_ context.Context, req *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error) {
+	m.checkLimitsAndShardCalls++
+	if expected := m.expectedCheckLimitsAndShardRequest; expected != nil {
+		require.Equal(m.t, expected, req)
+	}
+	return m.checkLimitsAndShardResponse, m.err
 }
 
 // mockLimitsProtoClient mocks proto.IngestLimitsClient.

--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -78,7 +78,19 @@ func (r *ringLimitsClient) ExceedsLimits(ctx context.Context, req *proto.Exceeds
 	if len(req.Streams) == 0 {
 		return &resp, nil
 	}
-	unanswered, err := r.exhaustAllZones(ctx, req.Tenant, req.Streams, r.newExceedsLimitsRPCsFunc(&resp))
+	doRPCs := newRPCsFunc(r, log.With(r.logger, "rpc", "ExceedsLimits"), &resp.Results,
+		func(tenant string, streams []*proto.StreamMetadata) *proto.ExceedsLimitsRequest {
+			return &proto.ExceedsLimitsRequest{Tenant: tenant, Streams: streams}
+		},
+		func(ctx context.Context, client proto.IngestLimitsClient, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResult, error) {
+			resp, err := client.ExceedsLimits(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			return resp.Results, nil
+		},
+	)
+	unanswered, err := r.exhaustAllZones(ctx, req.Tenant, req.Streams, doRPCs)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +114,19 @@ func (r *ringLimitsClient) UpdateRates(ctx context.Context, req *proto.UpdateRat
 	if len(req.Streams) == 0 {
 		return &resp, nil
 	}
-	unanswered, err := r.exhaustAllZones(ctx, req.Tenant, req.Streams, r.newUpdateRatesRPCsFunc(&resp))
+	doRPCs := newRPCsFunc(r, log.With(r.logger, "rpc", "UpdateRates"), &resp.Results,
+		func(tenant string, streams []*proto.StreamMetadata) *proto.UpdateRatesRequest {
+			return &proto.UpdateRatesRequest{Tenant: tenant, Streams: streams}
+		},
+		func(ctx context.Context, client proto.IngestLimitsClient, req *proto.UpdateRatesRequest) ([]*proto.UpdateRatesResult, error) {
+			resp, err := client.UpdateRates(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			return resp.Results, nil
+		},
+	)
+	unanswered, err := r.exhaustAllZones(ctx, req.Tenant, req.Streams, doRPCs)
 	if err != nil {
 		return nil, err
 	}
@@ -120,59 +144,59 @@ func (r *ringLimitsClient) UpdateRates(ctx context.Context, req *proto.UpdateRat
 	return &resp, nil
 }
 
-// newExceedsLimitsRPCsFunc returns a doRPCsFunc that executes the ExceedsLimits
-// RPCs for the instances in a zone.
-func (r *ringLimitsClient) newExceedsLimitsRPCsFunc(resp *proto.ExceedsLimitsResponse) doRPCsFunc {
-	return func(
-		ctx context.Context,
-		tenant string,
-		streams []*proto.StreamMetadata,
-		zone string,
-		consumers map[int32]string,
-	) ([]uint64, error) {
-		errg, ctx := errgroup.WithContext(ctx)
-		instancesForStreams := r.instancesForStreams(streams, zone, consumers)
-		responseCh := make(chan *proto.ExceedsLimitsResponse, len(instancesForStreams))
-		answeredCh := make(chan uint64, len(streams))
-		for addr, streams := range instancesForStreams {
-			errg.Go(func() error {
-				client, err := r.pool.GetClientFor(addr)
-				if err != nil {
-					level.Error(r.logger).Log("msg", "failed to get client for instance", "instance", addr, "err", err.Error())
-					return nil
-				}
-				resp, err := client.(proto.IngestLimitsClient).ExceedsLimits(ctx, &proto.ExceedsLimitsRequest{
-					Tenant:  tenant,
-					Streams: streams,
-				})
-				if err != nil {
-					level.Error(r.logger).Log("failed check execeed limits for instance", "instance", addr, "err", err.Error())
-					return nil
-				}
-				responseCh <- resp
-				for _, stream := range streams {
-					answeredCh <- stream.StreamHash
-				}
-				return nil
+// CheckLimitsAndShard implements the [limitsClient] interface.
+func (r *ringLimitsClient) CheckLimitsAndShard(ctx context.Context, req *proto.CheckLimitsAndShardRequest) (*proto.CheckLimitsAndShardResponse, error) {
+	var resp proto.CheckLimitsAndShardResponse
+	if len(req.Streams) == 0 {
+		return &resp, nil
+	}
+	doRPCs := newRPCsFunc(
+		r, log.With(r.logger, "rpc", "CheckLimitsAndShard"), &resp.Results,
+		func(tenant string, streams []*proto.StreamMetadata) *proto.CheckLimitsAndShardRequest {
+			return &proto.CheckLimitsAndShardRequest{Tenant: tenant, Streams: streams}
+		},
+		func(ctx context.Context, client proto.IngestLimitsClient, req *proto.CheckLimitsAndShardRequest) ([]*proto.StreamShardResult, error) {
+			resp, err := client.CheckLimitsAndShard(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			return resp.Results, nil
+		},
+	)
+	unanswered, err := r.exhaustAllZones(ctx, req.Tenant, req.Streams, doRPCs)
+	if err != nil {
+		return nil, err
+	}
+	// Any unanswered streams after exhausting all zones degrade to "don't
+	// shard this push" rather than being rejected.
+	if len(unanswered) > 0 {
+		failed := make([]*proto.StreamShardResult, 0, len(unanswered))
+		for _, stream := range unanswered {
+			failed = append(failed, &proto.StreamShardResult{
+				StreamHash:           stream.StreamHash,
+				Shards:               1,
+				ShardDecisionContext: uint32(limits.ReasonFailed),
 			})
 		}
-		_ = errg.Wait()
-		close(responseCh)
-		close(answeredCh)
-		for r := range responseCh {
-			resp.Results = append(resp.Results, r.Results...)
-		}
-		answered := make([]uint64, 0, len(streams))
-		for streamHash := range answeredCh {
-			answered = append(answered, streamHash)
-		}
-		return answered, nil
+		resp.Results = append(resp.Results, failed...)
 	}
+	return &resp, nil
 }
 
-// newUpdateRatesRPCsFunc returns a doRPCsFunc that executes the UpdateRates
-// RPCs for the instances in a zone.
-func (r *ringLimitsClient) newUpdateRatesRPCsFunc(resp *proto.UpdateRatesResponse) doRPCsFunc {
+// newRPCsFunc returns a doRPCsFunc that dispatches an RPC to the instances
+// owning each stream's partition within a zone, merging their results into
+// results. newReq builds the per-instance request from the tenant and its
+// subset of streams; call performs the RPC against a single instance and
+// returns just its Results, since a stream is considered "answered" once an
+// instance responds at all -- not every RPC returns one result per requested
+// stream (e.g. ExceedsLimits only returns entries for rejected streams).
+func newRPCsFunc[Req, Resp any](
+	r *ringLimitsClient,
+	logger log.Logger,
+	responses *[]Resp,
+	newReq func(tenant string, streams []*proto.StreamMetadata) *Req,
+	call func(ctx context.Context, client proto.IngestLimitsClient, req *Req) ([]Resp, error),
+) doRPCsFunc {
 	return func(
 		ctx context.Context,
 		tenant string,
@@ -182,21 +206,18 @@ func (r *ringLimitsClient) newUpdateRatesRPCsFunc(resp *proto.UpdateRatesRespons
 	) ([]uint64, error) {
 		errg, ctx := errgroup.WithContext(ctx)
 		instancesForStreams := r.instancesForStreams(streams, zone, consumers)
-		responseCh := make(chan *proto.UpdateRatesResponse, len(instancesForStreams))
+		responseCh := make(chan []Resp, len(instancesForStreams))
 		answeredCh := make(chan uint64, len(streams))
 		for addr, streams := range instancesForStreams {
 			errg.Go(func() error {
 				client, err := r.pool.GetClientFor(addr)
 				if err != nil {
-					level.Error(r.logger).Log("msg", "failed to get client for instance", "instance", addr, "err", err.Error())
+					level.Error(logger).Log("msg", "failed to get client for instance", "instance", addr, "err", err.Error())
 					return nil
 				}
-				resp, err := client.(proto.IngestLimitsClient).UpdateRates(ctx, &proto.UpdateRatesRequest{
-					Tenant:  tenant,
-					Streams: streams,
-				})
+				resp, err := call(ctx, client.(proto.IngestLimitsClient), newReq(tenant, streams))
 				if err != nil {
-					level.Error(r.logger).Log("failed check execeed limits for instance", "instance", addr, "err", err.Error())
+					level.Error(logger).Log("msg", "failed to perform rpc for instance", "instance", addr, "err", err.Error())
 					return nil
 				}
 				responseCh <- resp
@@ -210,7 +231,7 @@ func (r *ringLimitsClient) newUpdateRatesRPCsFunc(resp *proto.UpdateRatesRespons
 		close(responseCh)
 		close(answeredCh)
 		for r := range responseCh {
-			resp.Results = append(resp.Results, r.Results...)
+			*responses = append(*responses, r...)
 		}
 		answered := make([]uint64, 0, len(streams))
 		for streamHash := range answeredCh {

--- a/pkg/limits/limit.go
+++ b/pkg/limits/limit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
 
@@ -19,6 +20,11 @@ type Limits interface {
 	IngestionBurstSizeBytes(userID string) int
 	MaxGlobalStreamsPerUser(userID string) int
 	PolicyMaxGlobalStreamsPerUser(userID, policy string) (int, bool)
+	// ShardStreams and PolicyShardStreams let the backend resolve the
+	// desired_rate used to turn an observed stream rate into a shard-count
+	// recommendation (see stream_shard_store.go).
+	ShardStreams(userID string) shardstreams.Config
+	PolicyShardStreams(userID, policy string) (shardstreams.Config, bool)
 }
 
 type limitsChecker struct {

--- a/pkg/limits/mock_test.go
+++ b/pkg/limits/mock_test.go
@@ -5,11 +5,16 @@ import (
 	"sync"
 
 	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
 )
 
 type mockLimits struct {
 	MaxGlobalStreams int
 	IngestionRate    float64
+
+	// ShardStreamsConfig is returned by ShardStreams/PolicyShardStreams.
+	ShardStreamsConfig shardstreams.Config
 }
 
 func (m *mockLimits) MaxGlobalStreamsPerUser(_ string) int {
@@ -32,6 +37,14 @@ func (m *mockLimits) IngestionBurstSizeBytes(_ string) int {
 
 func (m *mockLimits) PolicyMaxGlobalStreamsPerUser(_ string, _ string) (int, bool) {
 	return 0, false
+}
+
+func (m *mockLimits) ShardStreams(_ string) shardstreams.Config {
+	return m.ShardStreamsConfig
+}
+
+func (m *mockLimits) PolicyShardStreams(_, _ string) (shardstreams.Config, bool) {
+	return m.ShardStreamsConfig, false
 }
 
 // mockKafka mocks a [kgo.Client]. The zero value is usable.

--- a/pkg/limits/partition_lifecycler.go
+++ b/pkg/limits/partition_lifecycler.go
@@ -22,15 +22,21 @@ type partitionLifecycler struct {
 	activeWindow     time.Duration
 	logger           log.Logger
 
+	// streamShardStore, if non-nil, has its state for revoked partitions
+	// evicted alongside usage's.
+	streamShardStore *streamShardStore
+
 	// Used in tests.
 	clock quartz.Clock
 }
 
-// newPartitionLifecycler returns a new partitionLifecycler.
+// newPartitionLifecycler returns a new partitionLifecycler. streamShardStore
+// may be nil to skip stream-shard-tracking cleanup on revoke.
 func newPartitionLifecycler(
 	partitionManager *partitionManager,
 	offsetManager kafka_partition.OffsetManager,
 	usage *usageStore,
+	streamShardStore *streamShardStore,
 	activeWindow time.Duration,
 	logger log.Logger,
 ) *partitionLifecycler {
@@ -38,6 +44,7 @@ func newPartitionLifecycler(
 		partitionManager: partitionManager,
 		offsetManager:    offsetManager,
 		usage:            usage,
+		streamShardStore: streamShardStore,
 		activeWindow:     activeWindow,
 		logger:           logger,
 		clock:            quartz.NewReal(),
@@ -94,6 +101,9 @@ func (l *partitionLifecycler) revoke(_ context.Context, _ *kgo.Client, topics ma
 	for _, partitions := range topics {
 		l.partitionManager.Revoke(partitions)
 		l.usage.EvictPartitions(partitions)
+		if l.streamShardStore != nil {
+			l.streamShardStore.EvictPartitions(partitions)
+		}
 	}
 }
 

--- a/pkg/limits/proto/limits.pb.go
+++ b/pkg/limits/proto/limits.pb.go
@@ -516,6 +516,181 @@ func (m *UpdateRatesResult) GetRate() uint64 {
 	return 0
 }
 
+type CheckLimitsAndShardRequest struct {
+	Tenant string `protobuf:"bytes,1,opt,name=tenant,proto3" json:"tenant,omitempty"`
+	// streamHash must be the pre-shard hash of the logical stream, and
+	// totalSize the full byte size observed for it in this push (i.e. before
+	// any distributor-side sharding has split it into sub-streams).
+	Streams []*StreamMetadata `protobuf:"bytes,2,rep,name=streams,proto3" json:"streams,omitempty"`
+}
+
+func (m *CheckLimitsAndShardRequest) Reset()      { *m = CheckLimitsAndShardRequest{} }
+func (*CheckLimitsAndShardRequest) ProtoMessage() {}
+func (*CheckLimitsAndShardRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_aaed9e7d5298ac0f, []int{10}
+}
+func (m *CheckLimitsAndShardRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *CheckLimitsAndShardRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_CheckLimitsAndShardRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *CheckLimitsAndShardRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckLimitsAndShardRequest.Merge(m, src)
+}
+func (m *CheckLimitsAndShardRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *CheckLimitsAndShardRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_CheckLimitsAndShardRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CheckLimitsAndShardRequest proto.InternalMessageInfo
+
+func (m *CheckLimitsAndShardRequest) GetTenant() string {
+	if m != nil {
+		return m.Tenant
+	}
+	return ""
+}
+
+func (m *CheckLimitsAndShardRequest) GetStreams() []*StreamMetadata {
+	if m != nil {
+		return m.Streams
+	}
+	return nil
+}
+
+type CheckLimitsAndShardResponse struct {
+	Results []*StreamShardResult `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+}
+
+func (m *CheckLimitsAndShardResponse) Reset()      { *m = CheckLimitsAndShardResponse{} }
+func (*CheckLimitsAndShardResponse) ProtoMessage() {}
+func (*CheckLimitsAndShardResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_aaed9e7d5298ac0f, []int{11}
+}
+func (m *CheckLimitsAndShardResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *CheckLimitsAndShardResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_CheckLimitsAndShardResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *CheckLimitsAndShardResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckLimitsAndShardResponse.Merge(m, src)
+}
+func (m *CheckLimitsAndShardResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *CheckLimitsAndShardResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CheckLimitsAndShardResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CheckLimitsAndShardResponse proto.InternalMessageInfo
+
+func (m *CheckLimitsAndShardResponse) GetResults() []*StreamShardResult {
+	if m != nil {
+		return m.Results
+	}
+	return nil
+}
+
+type StreamShardResult struct {
+	StreamHash uint64 `protobuf:"varint,1,opt,name=streamHash,proto3" json:"streamHash,omitempty"`
+	// The number of shards the distributor should create for this stream on
+	// this push. 0 and 1 both mean no sharding is needed -- whether the
+	// stream was rejected is signaled independently via rejectReason, not by
+	// this value.
+	Shards uint32 `protobuf:"varint,2,opt,name=shards,proto3" json:"shards,omitempty"`
+	// Reason enum, see reason.go. Populated only when shards was capped below
+	// the rate-justified ideal (ShardsCapped), or when the decision could not
+	// be made (Failed). Never set merely because the stream was rejected --
+	// see rejectReason for that.
+	ShardDecisionContext uint32 `protobuf:"varint,3,opt,name=shardDecisionContext,proto3" json:"shardDecisionContext,omitempty"`
+	// Non-empty when the stream was rejected outright (only possible for a
+	// brand-new stream with no room left in the tenant's stream-count
+	// budget). Empty means the stream was accepted, regardless of shards.
+	RejectReason string `protobuf:"bytes,4,opt,name=rejectReason,proto3" json:"rejectReason,omitempty"`
+}
+
+func (m *StreamShardResult) Reset()      { *m = StreamShardResult{} }
+func (*StreamShardResult) ProtoMessage() {}
+func (*StreamShardResult) Descriptor() ([]byte, []int) {
+	return fileDescriptor_aaed9e7d5298ac0f, []int{12}
+}
+func (m *StreamShardResult) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StreamShardResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StreamShardResult.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StreamShardResult) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StreamShardResult.Merge(m, src)
+}
+func (m *StreamShardResult) XXX_Size() int {
+	return m.Size()
+}
+func (m *StreamShardResult) XXX_DiscardUnknown() {
+	xxx_messageInfo_StreamShardResult.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StreamShardResult proto.InternalMessageInfo
+
+func (m *StreamShardResult) GetStreamHash() uint64 {
+	if m != nil {
+		return m.StreamHash
+	}
+	return 0
+}
+
+func (m *StreamShardResult) GetShards() uint32 {
+	if m != nil {
+		return m.Shards
+	}
+	return 0
+}
+
+func (m *StreamShardResult) GetShardDecisionContext() uint32 {
+	if m != nil {
+		return m.ShardDecisionContext
+	}
+	return 0
+}
+
+func (m *StreamShardResult) GetRejectReason() string {
+	if m != nil {
+		return m.RejectReason
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*ExceedsLimitsRequest)(nil), "proto.ExceedsLimitsRequest")
 	proto.RegisterType((*ExceedsLimitsResponse)(nil), "proto.ExceedsLimitsResponse")
@@ -528,48 +703,58 @@ func init() {
 	proto.RegisterType((*UpdateRatesRequest)(nil), "proto.UpdateRatesRequest")
 	proto.RegisterType((*UpdateRatesResponse)(nil), "proto.UpdateRatesResponse")
 	proto.RegisterType((*UpdateRatesResult)(nil), "proto.UpdateRatesResult")
+	proto.RegisterType((*CheckLimitsAndShardRequest)(nil), "proto.CheckLimitsAndShardRequest")
+	proto.RegisterType((*CheckLimitsAndShardResponse)(nil), "proto.CheckLimitsAndShardResponse")
+	proto.RegisterType((*StreamShardResult)(nil), "proto.StreamShardResult")
 }
 
 func init() { proto.RegisterFile("pkg/limits/proto/limits.proto", fileDescriptor_aaed9e7d5298ac0f) }
 
 var fileDescriptor_aaed9e7d5298ac0f = []byte{
-	// 569 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x53, 0x3d, 0x6f, 0xd3, 0x40,
-	0x18, 0xf6, 0x25, 0x69, 0x4b, 0xdf, 0x52, 0x3e, 0xae, 0x09, 0x98, 0x90, 0x9e, 0x22, 0xc3, 0x90,
-	0x29, 0x11, 0xa1, 0x03, 0x42, 0x2c, 0x20, 0xa5, 0xa5, 0x52, 0x23, 0x55, 0x57, 0x31, 0x22, 0x74,
-	0xc4, 0xa7, 0x60, 0xd5, 0x39, 0x07, 0xdf, 0x05, 0x35, 0x9d, 0x98, 0x99, 0xf8, 0x19, 0x0c, 0xfc,
-	0x10, 0xc6, 0x0c, 0x0c, 0x1d, 0x89, 0xb3, 0x30, 0xf6, 0x27, 0xa0, 0x9c, 0x2f, 0x10, 0x3b, 0x4e,
-	0xcb, 0x90, 0xc9, 0xf7, 0x7e, 0xf8, 0xb9, 0xf7, 0x79, 0xef, 0x79, 0x60, 0xb7, 0x7f, 0xda, 0x6d,
-	0xf8, 0x5e, 0xcf, 0x53, 0xb2, 0xd1, 0x0f, 0x03, 0x15, 0x98, 0xa0, 0xae, 0x03, 0xbc, 0xa6, 0x3f,
-	0xce, 0x3b, 0x28, 0xb6, 0xce, 0x3a, 0x9c, 0xbb, 0xf2, 0x48, 0x57, 0x29, 0xff, 0x38, 0xe0, 0x52,
-	0xe1, 0x7b, 0xb0, 0xae, 0xb8, 0x60, 0x42, 0xd9, 0xa8, 0x8a, 0x6a, 0x9b, 0xd4, 0x44, 0xb8, 0x01,
-	0x1b, 0x52, 0x85, 0x9c, 0xf5, 0xa4, 0x9d, 0xab, 0xe6, 0x6b, 0x5b, 0xcd, 0x52, 0x8c, 0x57, 0x3f,
-	0xd1, 0xd9, 0x36, 0x57, 0xcc, 0x65, 0x8a, 0xd1, 0x59, 0x97, 0xd3, 0x86, 0x52, 0xea, 0x02, 0xd9,
-	0x0f, 0x84, 0xe4, 0x78, 0x0f, 0x36, 0x42, 0x2e, 0x07, 0xbe, 0x92, 0x36, 0xd2, 0x48, 0x65, 0x83,
-	0x94, 0x6e, 0x1f, 0xf8, 0x8a, 0xce, 0x5a, 0x9d, 0x36, 0xec, 0x64, 0xd4, 0x31, 0x01, 0x88, 0x2f,
-	0x7c, 0xcd, 0xe4, 0x07, 0x3d, 0x72, 0x81, 0xce, 0x65, 0xa6, 0x74, 0x42, 0xce, 0x64, 0x20, 0xec,
-	0x5c, 0x15, 0xd5, 0xb6, 0xa9, 0x89, 0x1c, 0x02, 0x95, 0x03, 0xae, 0x5e, 0x4a, 0xe9, 0x75, 0x05,
-	0x77, 0x8f, 0x59, 0xa8, 0x3c, 0xe5, 0x05, 0x62, 0xb6, 0x06, 0xe7, 0x27, 0x82, 0xdd, 0x25, 0x0d,
-	0x86, 0x86, 0x0f, 0x98, 0x2d, 0x54, 0x0d, 0xa3, 0x17, 0x86, 0xd1, 0x95, 0x08, 0xf5, 0xc5, 0x52,
-	0x4b, 0xa8, 0x70, 0x48, 0x33, 0x70, 0xcb, 0x2d, 0xb8, 0xbf, 0xa4, 0x1d, 0xdf, 0x81, 0xfc, 0x29,
-	0x1f, 0x6a, 0xee, 0x6b, 0x74, 0x7a, 0xc4, 0x45, 0x58, 0xfb, 0xc4, 0xfc, 0x01, 0xd7, 0x9c, 0xf3,
-	0x34, 0x0e, 0x9e, 0xe7, 0x9e, 0x21, 0xe7, 0x0c, 0x6e, 0x25, 0xdf, 0xeb, 0xda, 0x05, 0x56, 0x60,
-	0x53, 0x05, 0x8a, 0xf9, 0x27, 0xde, 0x79, 0x8c, 0x57, 0xa0, 0xff, 0x12, 0xb8, 0x06, 0xb7, 0x3d,
-	0xd1, 0xe5, 0x72, 0x3a, 0xce, 0x71, 0xe0, 0x7b, 0x9d, 0xa1, 0x9d, 0xd7, 0xb2, 0x49, 0xa7, 0x9d,
-	0x01, 0x14, 0x53, 0x4a, 0xe1, 0x9d, 0x20, 0x74, 0x31, 0x86, 0xc2, 0x79, 0x20, 0xb8, 0x51, 0x9b,
-	0x3e, 0xcf, 0x69, 0x30, 0x97, 0xd0, 0xe0, 0x13, 0xb8, 0xd1, 0x33, 0x7f, 0xeb, 0x6b, 0x96, 0x8a,
-	0xf0, 0x6f, 0x9b, 0xf3, 0x16, 0xf0, 0x9b, 0xbe, 0xcb, 0x14, 0xa7, 0x4c, 0xf1, 0xd5, 0x8b, 0xfc,
-	0x10, 0x76, 0x12, 0xf0, 0x46, 0x1b, 0xcd, 0xb4, 0xc4, 0x6d, 0x83, 0x93, 0x6c, 0x4e, 0x08, 0xfc,
-	0x00, 0xee, 0x2e, 0x54, 0xaf, 0x7d, 0x1d, 0x0c, 0x85, 0x90, 0xa9, 0xd9, 0xc3, 0xe8, 0x73, 0xf3,
-	0x3b, 0x82, 0xe2, 0xa1, 0xde, 0x7e, 0xec, 0x94, 0xfd, 0x30, 0x10, 0x8a, 0x0b, 0x17, 0x1f, 0xc1,
-	0x76, 0xc2, 0x42, 0xf8, 0x61, 0xb6, 0xf1, 0xf4, 0x8e, 0xca, 0x95, 0x25, 0xae, 0xd4, 0x0c, 0x1d,
-	0x0b, 0xef, 0xc3, 0xd6, 0xdc, 0xbc, 0xf8, 0x41, 0x16, 0xc3, 0x18, 0xa9, 0x9c, 0x49, 0xde, 0xe0,
-	0x34, 0xbf, 0xe4, 0xe0, 0xe6, 0xfc, 0xb8, 0x2b, 0x1e, 0xd3, 0x85, 0x52, 0xa6, 0x0b, 0xf1, 0xa3,
-	0xab, 0x3d, 0x1a, 0xa3, 0x3f, 0xfe, 0x1f, 0x23, 0xaf, 0x6e, 0x19, 0xaf, 0xf6, 0x46, 0x63, 0x62,
-	0x5d, 0x8c, 0x89, 0x75, 0x39, 0x26, 0xe8, 0x73, 0x44, 0xd0, 0xb7, 0x88, 0xa0, 0x1f, 0x11, 0x41,
-	0xa3, 0x88, 0xa0, 0x5f, 0x11, 0x41, 0xbf, 0x23, 0x62, 0x5d, 0x46, 0x04, 0x7d, 0x9d, 0x10, 0x6b,
-	0x34, 0x21, 0xd6, 0xc5, 0x84, 0x58, 0xef, 0xd7, 0x35, 0xe4, 0xd3, 0x3f, 0x01, 0x00, 0x00, 0xff,
-	0xff, 0x8a, 0x61, 0x2d, 0x75, 0xfa, 0x05, 0x00, 0x00,
+	// 676 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x54, 0x31, 0x53, 0x13, 0x4f,
+	0x14, 0xbf, 0x4d, 0x02, 0xfc, 0x79, 0xc0, 0x5f, 0x59, 0x82, 0xc6, 0x00, 0x3b, 0x78, 0x5a, 0xa4,
+	0x82, 0x31, 0x52, 0x38, 0x8e, 0x0d, 0x22, 0x20, 0x33, 0x30, 0x83, 0xcb, 0x58, 0xaa, 0xb3, 0xe6,
+	0xde, 0xc0, 0xc9, 0xb1, 0x17, 0x6f, 0x37, 0x0e, 0x50, 0xf9, 0x01, 0x2c, 0xfc, 0x0e, 0x36, 0x7e,
+	0x14, 0x4b, 0x0a, 0x0b, 0x4a, 0x39, 0x1a, 0xc7, 0x8a, 0x8f, 0xe0, 0x64, 0x6f, 0x4f, 0x73, 0xc9,
+	0x05, 0x28, 0xd2, 0x58, 0xdd, 0xbe, 0x7d, 0xbf, 0xfd, 0xed, 0xbd, 0xdf, 0xfb, 0xed, 0x83, 0xb9,
+	0xe6, 0xfe, 0xee, 0x62, 0xe0, 0x1f, 0xf8, 0x5a, 0x2d, 0x36, 0xa3, 0x50, 0x87, 0x36, 0x58, 0x30,
+	0x01, 0x1d, 0x32, 0x1f, 0xf7, 0x0d, 0x94, 0x57, 0x0f, 0x1b, 0x88, 0x9e, 0xda, 0x34, 0x59, 0x8e,
+	0xef, 0x5b, 0xa8, 0x34, 0xbd, 0x05, 0xc3, 0x1a, 0xa5, 0x90, 0xba, 0x42, 0xe6, 0x49, 0x6d, 0x94,
+	0xdb, 0x88, 0x2e, 0xc2, 0x88, 0xd2, 0x11, 0x8a, 0x03, 0x55, 0x29, 0xcc, 0x17, 0x6b, 0x63, 0xf5,
+	0xe9, 0x84, 0x6f, 0x61, 0xc7, 0xec, 0x6e, 0xa1, 0x16, 0x9e, 0xd0, 0x82, 0xa7, 0x28, 0x77, 0x0b,
+	0xa6, 0xbb, 0x2e, 0x50, 0xcd, 0x50, 0x2a, 0xa4, 0x4b, 0x30, 0x12, 0xa1, 0x6a, 0x05, 0x5a, 0x55,
+	0x88, 0x61, 0xaa, 0x5a, 0xa6, 0x6e, 0x78, 0x2b, 0xd0, 0x3c, 0x85, 0xba, 0x5b, 0x30, 0x95, 0x93,
+	0xa7, 0x0c, 0x20, 0xb9, 0xf0, 0xb9, 0x50, 0x7b, 0xe6, 0x97, 0x4b, 0xbc, 0x63, 0xa7, 0x5d, 0x4e,
+	0x84, 0x42, 0x85, 0xb2, 0x52, 0x98, 0x27, 0xb5, 0x09, 0x6e, 0x23, 0x97, 0xc1, 0xec, 0x3a, 0xea,
+	0x65, 0xa5, 0xfc, 0x5d, 0x89, 0xde, 0xb6, 0x88, 0xb4, 0xaf, 0xfd, 0x50, 0xa6, 0x32, 0xb8, 0xdf,
+	0x09, 0xcc, 0xf5, 0x01, 0xd8, 0x32, 0x02, 0xa0, 0xa2, 0x27, 0x6b, 0x2b, 0x7a, 0x62, 0x2b, 0xba,
+	0x94, 0x61, 0xa1, 0x37, 0xb5, 0x2a, 0x75, 0x74, 0xc4, 0x73, 0x78, 0xab, 0xab, 0x70, 0xbb, 0x0f,
+	0x9c, 0xde, 0x84, 0xe2, 0x3e, 0x1e, 0x99, 0xda, 0x87, 0x78, 0x7b, 0x49, 0xcb, 0x30, 0xf4, 0x41,
+	0x04, 0x2d, 0x34, 0x35, 0x17, 0x79, 0x12, 0x3c, 0x2e, 0x3c, 0x22, 0xee, 0x21, 0xfc, 0x9f, 0xed,
+	0xd7, 0x95, 0x02, 0xce, 0xc2, 0xa8, 0x0e, 0xb5, 0x08, 0x76, 0xfc, 0xe3, 0x84, 0xaf, 0xc4, 0xff,
+	0x6e, 0xd0, 0x1a, 0xdc, 0xf0, 0xe5, 0x2e, 0xaa, 0xf6, 0xef, 0x6c, 0x87, 0x81, 0xdf, 0x38, 0xaa,
+	0x14, 0x8d, 0x6d, 0xba, 0xb7, 0xdd, 0x16, 0x94, 0xbb, 0x9c, 0x82, 0x8d, 0x30, 0xf2, 0x28, 0x85,
+	0xd2, 0x71, 0x28, 0xd1, 0xba, 0xcd, 0xac, 0x3b, 0x3c, 0x58, 0xc8, 0x78, 0xf0, 0x01, 0xfc, 0x77,
+	0x60, 0x4f, 0x9b, 0x6b, 0xfa, 0x9a, 0xf0, 0x0f, 0xcc, 0x7d, 0x05, 0xf4, 0x65, 0xd3, 0x13, 0x1a,
+	0xb9, 0xd0, 0x38, 0x78, 0x93, 0x6f, 0xc0, 0x54, 0x86, 0xde, 0x7a, 0xa3, 0xde, 0x6d, 0xf1, 0x8a,
+	0xe5, 0xc9, 0x82, 0x33, 0x06, 0x5f, 0x87, 0xc9, 0x9e, 0xec, 0x95, 0xdd, 0xa1, 0x50, 0x8a, 0x84,
+	0x4e, 0x1b, 0x63, 0xd6, 0x2e, 0x42, 0x75, 0x65, 0x0f, 0x1b, 0xfb, 0xc9, 0x3b, 0x59, 0x96, 0xde,
+	0xce, 0x9e, 0x88, 0xbc, 0x81, 0x97, 0xfe, 0x02, 0x66, 0x72, 0xaf, 0xb9, 0x4a, 0x82, 0x84, 0x2f,
+	0x05, 0x67, 0x24, 0xf8, 0x42, 0x60, 0xb2, 0x27, 0x7d, 0x9d, 0x27, 0xae, 0xda, 0x70, 0x95, 0x3e,
+	0xf1, 0x24, 0xa2, 0x75, 0x28, 0x9b, 0xd5, 0x33, 0x6c, 0xf8, 0xca, 0x0f, 0xe5, 0x4a, 0x28, 0x35,
+	0x1e, 0x6a, 0xe3, 0x9c, 0x09, 0x9e, 0x9b, 0xa3, 0x2e, 0x8c, 0x47, 0xf8, 0x0e, 0x1b, 0x9a, 0x27,
+	0x43, 0xa3, 0x64, 0x34, 0xca, 0xec, 0xd5, 0x3f, 0x15, 0xa0, 0xbc, 0x61, 0xdc, 0x9d, 0x94, 0xbe,
+	0x16, 0xb5, 0x0f, 0x4b, 0x8f, 0x6e, 0xc2, 0x44, 0x66, 0x44, 0xd1, 0x99, 0xfc, 0xc1, 0x66, 0x1a,
+	0x51, 0x9d, 0xed, 0x33, 0xf5, 0x8c, 0x7c, 0xae, 0x43, 0xd7, 0x60, 0xac, 0xc3, 0x0f, 0xf4, 0x4e,
+	0x9e, 0x83, 0x12, 0xa6, 0x6a, 0xae, 0xb9, 0x52, 0x9e, 0xd7, 0x30, 0x95, 0xd3, 0x27, 0x7a, 0xd7,
+	0x1e, 0xea, 0x6f, 0x95, 0xaa, 0x7b, 0x19, 0x24, 0xe5, 0xaf, 0xff, 0x2a, 0xc0, 0x78, 0xa7, 0x1c,
+	0x03, 0x96, 0xc1, 0x83, 0xe9, 0xdc, 0x29, 0x4a, 0xef, 0x5d, 0x3e, 0x63, 0x13, 0xf6, 0xfb, 0xd7,
+	0x19, 0xc4, 0xff, 0x8e, 0xd8, 0x4f, 0x97, 0x4e, 0xce, 0x98, 0x73, 0x7a, 0xc6, 0x9c, 0x8b, 0x33,
+	0x46, 0x3e, 0xc6, 0x8c, 0x7c, 0x8d, 0x19, 0xf9, 0x16, 0x33, 0x72, 0x12, 0x33, 0xf2, 0x23, 0x66,
+	0xe4, 0x67, 0xcc, 0x9c, 0x8b, 0x98, 0x91, 0xcf, 0xe7, 0xcc, 0x39, 0x39, 0x67, 0xce, 0xe9, 0x39,
+	0x73, 0xde, 0x0e, 0x1b, 0xea, 0x87, 0xbf, 0x03, 0x00, 0x00, 0xff, 0xff, 0x60, 0x54, 0xf1, 0xae,
+	0x1a, 0x08, 0x00, 0x00,
 }
 
 func (this *ExceedsLimitsRequest) Equal(that interface{}) bool {
@@ -858,6 +1043,100 @@ func (this *UpdateRatesResult) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *CheckLimitsAndShardRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*CheckLimitsAndShardRequest)
+	if !ok {
+		that2, ok := that.(CheckLimitsAndShardRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Tenant != that1.Tenant {
+		return false
+	}
+	if len(this.Streams) != len(that1.Streams) {
+		return false
+	}
+	for i := range this.Streams {
+		if !this.Streams[i].Equal(that1.Streams[i]) {
+			return false
+		}
+	}
+	return true
+}
+func (this *CheckLimitsAndShardResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*CheckLimitsAndShardResponse)
+	if !ok {
+		that2, ok := that.(CheckLimitsAndShardResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Results) != len(that1.Results) {
+		return false
+	}
+	for i := range this.Results {
+		if !this.Results[i].Equal(that1.Results[i]) {
+			return false
+		}
+	}
+	return true
+}
+func (this *StreamShardResult) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*StreamShardResult)
+	if !ok {
+		that2, ok := that.(StreamShardResult)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.StreamHash != that1.StreamHash {
+		return false
+	}
+	if this.Shards != that1.Shards {
+		return false
+	}
+	if this.ShardDecisionContext != that1.ShardDecisionContext {
+		return false
+	}
+	if this.RejectReason != that1.RejectReason {
+		return false
+	}
+	return true
+}
 func (this *ExceedsLimitsRequest) GoString() string {
 	if this == nil {
 		return "nil"
@@ -987,6 +1266,44 @@ func (this *UpdateRatesResult) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+func (this *CheckLimitsAndShardRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&proto.CheckLimitsAndShardRequest{")
+	s = append(s, "Tenant: "+fmt.Sprintf("%#v", this.Tenant)+",\n")
+	if this.Streams != nil {
+		s = append(s, "Streams: "+fmt.Sprintf("%#v", this.Streams)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *CheckLimitsAndShardResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&proto.CheckLimitsAndShardResponse{")
+	if this.Results != nil {
+		s = append(s, "Results: "+fmt.Sprintf("%#v", this.Results)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *StreamShardResult) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 8)
+	s = append(s, "&proto.StreamShardResult{")
+	s = append(s, "StreamHash: "+fmt.Sprintf("%#v", this.StreamHash)+",\n")
+	s = append(s, "Shards: "+fmt.Sprintf("%#v", this.Shards)+",\n")
+	s = append(s, "ShardDecisionContext: "+fmt.Sprintf("%#v", this.ShardDecisionContext)+",\n")
+	s = append(s, "RejectReason: "+fmt.Sprintf("%#v", this.RejectReason)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
 func valueToGoStringLimits(v interface{}, typ string) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -1010,6 +1327,7 @@ const _ = grpc.SupportPackageIsVersion4
 type IngestLimitsFrontendClient interface {
 	ExceedsLimits(ctx context.Context, in *ExceedsLimitsRequest, opts ...grpc.CallOption) (*ExceedsLimitsResponse, error)
 	UpdateRates(ctx context.Context, in *UpdateRatesRequest, opts ...grpc.CallOption) (*UpdateRatesResponse, error)
+	CheckLimitsAndShard(ctx context.Context, in *CheckLimitsAndShardRequest, opts ...grpc.CallOption) (*CheckLimitsAndShardResponse, error)
 }
 
 type ingestLimitsFrontendClient struct {
@@ -1038,10 +1356,20 @@ func (c *ingestLimitsFrontendClient) UpdateRates(ctx context.Context, in *Update
 	return out, nil
 }
 
+func (c *ingestLimitsFrontendClient) CheckLimitsAndShard(ctx context.Context, in *CheckLimitsAndShardRequest, opts ...grpc.CallOption) (*CheckLimitsAndShardResponse, error) {
+	out := new(CheckLimitsAndShardResponse)
+	err := c.cc.Invoke(ctx, "/proto.IngestLimitsFrontend/CheckLimitsAndShard", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // IngestLimitsFrontendServer is the server API for IngestLimitsFrontend service.
 type IngestLimitsFrontendServer interface {
 	ExceedsLimits(context.Context, *ExceedsLimitsRequest) (*ExceedsLimitsResponse, error)
 	UpdateRates(context.Context, *UpdateRatesRequest) (*UpdateRatesResponse, error)
+	CheckLimitsAndShard(context.Context, *CheckLimitsAndShardRequest) (*CheckLimitsAndShardResponse, error)
 }
 
 // UnimplementedIngestLimitsFrontendServer can be embedded to have forward compatible implementations.
@@ -1053,6 +1381,9 @@ func (*UnimplementedIngestLimitsFrontendServer) ExceedsLimits(ctx context.Contex
 }
 func (*UnimplementedIngestLimitsFrontendServer) UpdateRates(ctx context.Context, req *UpdateRatesRequest) (*UpdateRatesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateRates not implemented")
+}
+func (*UnimplementedIngestLimitsFrontendServer) CheckLimitsAndShard(ctx context.Context, req *CheckLimitsAndShardRequest) (*CheckLimitsAndShardResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CheckLimitsAndShard not implemented")
 }
 
 func RegisterIngestLimitsFrontendServer(s *grpc.Server, srv IngestLimitsFrontendServer) {
@@ -1095,6 +1426,24 @@ func _IngestLimitsFrontend_UpdateRates_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _IngestLimitsFrontend_CheckLimitsAndShard_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CheckLimitsAndShardRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(IngestLimitsFrontendServer).CheckLimitsAndShard(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.IngestLimitsFrontend/CheckLimitsAndShard",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(IngestLimitsFrontendServer).CheckLimitsAndShard(ctx, req.(*CheckLimitsAndShardRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _IngestLimitsFrontend_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "proto.IngestLimitsFrontend",
 	HandlerType: (*IngestLimitsFrontendServer)(nil),
@@ -1106,6 +1455,10 @@ var _IngestLimitsFrontend_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateRates",
 			Handler:    _IngestLimitsFrontend_UpdateRates_Handler,
+		},
+		{
+			MethodName: "CheckLimitsAndShard",
+			Handler:    _IngestLimitsFrontend_CheckLimitsAndShard_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -1119,6 +1472,7 @@ type IngestLimitsClient interface {
 	ExceedsLimits(ctx context.Context, in *ExceedsLimitsRequest, opts ...grpc.CallOption) (*ExceedsLimitsResponse, error)
 	GetAssignedPartitions(ctx context.Context, in *GetAssignedPartitionsRequest, opts ...grpc.CallOption) (*GetAssignedPartitionsResponse, error)
 	UpdateRates(ctx context.Context, in *UpdateRatesRequest, opts ...grpc.CallOption) (*UpdateRatesResponse, error)
+	CheckLimitsAndShard(ctx context.Context, in *CheckLimitsAndShardRequest, opts ...grpc.CallOption) (*CheckLimitsAndShardResponse, error)
 }
 
 type ingestLimitsClient struct {
@@ -1156,11 +1510,21 @@ func (c *ingestLimitsClient) UpdateRates(ctx context.Context, in *UpdateRatesReq
 	return out, nil
 }
 
+func (c *ingestLimitsClient) CheckLimitsAndShard(ctx context.Context, in *CheckLimitsAndShardRequest, opts ...grpc.CallOption) (*CheckLimitsAndShardResponse, error) {
+	out := new(CheckLimitsAndShardResponse)
+	err := c.cc.Invoke(ctx, "/proto.IngestLimits/CheckLimitsAndShard", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // IngestLimitsServer is the server API for IngestLimits service.
 type IngestLimitsServer interface {
 	ExceedsLimits(context.Context, *ExceedsLimitsRequest) (*ExceedsLimitsResponse, error)
 	GetAssignedPartitions(context.Context, *GetAssignedPartitionsRequest) (*GetAssignedPartitionsResponse, error)
 	UpdateRates(context.Context, *UpdateRatesRequest) (*UpdateRatesResponse, error)
+	CheckLimitsAndShard(context.Context, *CheckLimitsAndShardRequest) (*CheckLimitsAndShardResponse, error)
 }
 
 // UnimplementedIngestLimitsServer can be embedded to have forward compatible implementations.
@@ -1175,6 +1539,9 @@ func (*UnimplementedIngestLimitsServer) GetAssignedPartitions(ctx context.Contex
 }
 func (*UnimplementedIngestLimitsServer) UpdateRates(ctx context.Context, req *UpdateRatesRequest) (*UpdateRatesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateRates not implemented")
+}
+func (*UnimplementedIngestLimitsServer) CheckLimitsAndShard(ctx context.Context, req *CheckLimitsAndShardRequest) (*CheckLimitsAndShardResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CheckLimitsAndShard not implemented")
 }
 
 func RegisterIngestLimitsServer(s *grpc.Server, srv IngestLimitsServer) {
@@ -1235,6 +1602,24 @@ func _IngestLimits_UpdateRates_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _IngestLimits_CheckLimitsAndShard_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CheckLimitsAndShardRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(IngestLimitsServer).CheckLimitsAndShard(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.IngestLimits/CheckLimitsAndShard",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(IngestLimitsServer).CheckLimitsAndShard(ctx, req.(*CheckLimitsAndShardRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _IngestLimits_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "proto.IngestLimits",
 	HandlerType: (*IngestLimitsServer)(nil),
@@ -1250,6 +1635,10 @@ var _IngestLimits_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateRates",
 			Handler:    _IngestLimits_UpdateRates_Handler,
+		},
+		{
+			MethodName: "CheckLimitsAndShard",
+			Handler:    _IngestLimits_CheckLimitsAndShard_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -1634,6 +2023,132 @@ func (m *UpdateRatesResult) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *CheckLimitsAndShardRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CheckLimitsAndShardRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CheckLimitsAndShardRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Streams) > 0 {
+		for iNdEx := len(m.Streams) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Streams[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintLimits(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Tenant) > 0 {
+		i -= len(m.Tenant)
+		copy(dAtA[i:], m.Tenant)
+		i = encodeVarintLimits(dAtA, i, uint64(len(m.Tenant)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *CheckLimitsAndShardResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CheckLimitsAndShardResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CheckLimitsAndShardResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Results) > 0 {
+		for iNdEx := len(m.Results) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Results[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintLimits(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StreamShardResult) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StreamShardResult) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StreamShardResult) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.RejectReason) > 0 {
+		i -= len(m.RejectReason)
+		copy(dAtA[i:], m.RejectReason)
+		i = encodeVarintLimits(dAtA, i, uint64(len(m.RejectReason)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.ShardDecisionContext != 0 {
+		i = encodeVarintLimits(dAtA, i, uint64(m.ShardDecisionContext))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Shards != 0 {
+		i = encodeVarintLimits(dAtA, i, uint64(m.Shards))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.StreamHash != 0 {
+		i = encodeVarintLimits(dAtA, i, uint64(m.StreamHash))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintLimits(dAtA []byte, offset int, v uint64) int {
 	offset -= sovLimits(v)
 	base := offset
@@ -1809,6 +2324,62 @@ func (m *UpdateRatesResult) Size() (n int) {
 	return n
 }
 
+func (m *CheckLimitsAndShardRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Tenant)
+	if l > 0 {
+		n += 1 + l + sovLimits(uint64(l))
+	}
+	if len(m.Streams) > 0 {
+		for _, e := range m.Streams {
+			l = e.Size()
+			n += 1 + l + sovLimits(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *CheckLimitsAndShardResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Results) > 0 {
+		for _, e := range m.Results {
+			l = e.Size()
+			n += 1 + l + sovLimits(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *StreamShardResult) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.StreamHash != 0 {
+		n += 1 + sovLimits(uint64(m.StreamHash))
+	}
+	if m.Shards != 0 {
+		n += 1 + sovLimits(uint64(m.Shards))
+	}
+	if m.ShardDecisionContext != 0 {
+		n += 1 + sovLimits(uint64(m.ShardDecisionContext))
+	}
+	l = len(m.RejectReason)
+	if l > 0 {
+		n += 1 + l + sovLimits(uint64(l))
+	}
+	return n
+}
+
 func sovLimits(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -1948,6 +2519,50 @@ func (this *UpdateRatesResult) String() string {
 	s := strings.Join([]string{`&UpdateRatesResult{`,
 		`StreamHash:` + fmt.Sprintf("%v", this.StreamHash) + `,`,
 		`Rate:` + fmt.Sprintf("%v", this.Rate) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CheckLimitsAndShardRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	repeatedStringForStreams := "[]*StreamMetadata{"
+	for _, f := range this.Streams {
+		repeatedStringForStreams += strings.Replace(f.String(), "StreamMetadata", "StreamMetadata", 1) + ","
+	}
+	repeatedStringForStreams += "}"
+	s := strings.Join([]string{`&CheckLimitsAndShardRequest{`,
+		`Tenant:` + fmt.Sprintf("%v", this.Tenant) + `,`,
+		`Streams:` + repeatedStringForStreams + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CheckLimitsAndShardResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	repeatedStringForResults := "[]*StreamShardResult{"
+	for _, f := range this.Results {
+		repeatedStringForResults += strings.Replace(f.String(), "StreamShardResult", "StreamShardResult", 1) + ","
+	}
+	repeatedStringForResults += "}"
+	s := strings.Join([]string{`&CheckLimitsAndShardResponse{`,
+		`Results:` + repeatedStringForResults + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StreamShardResult) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StreamShardResult{`,
+		`StreamHash:` + fmt.Sprintf("%v", this.StreamHash) + `,`,
+		`Shards:` + fmt.Sprintf("%v", this.Shards) + `,`,
+		`ShardDecisionContext:` + fmt.Sprintf("%v", this.ShardDecisionContext) + `,`,
+		`RejectReason:` + fmt.Sprintf("%v", this.RejectReason) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -3011,6 +3626,354 @@ func (m *UpdateRatesResult) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipLimits(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CheckLimitsAndShardRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowLimits
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CheckLimitsAndShardRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CheckLimitsAndShardRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tenant", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLimits
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthLimits
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Tenant = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Streams", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLimits
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthLimits
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Streams = append(m.Streams, &StreamMetadata{})
+			if err := m.Streams[len(m.Streams)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipLimits(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CheckLimitsAndShardResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowLimits
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CheckLimitsAndShardResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CheckLimitsAndShardResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Results", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLimits
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthLimits
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Results = append(m.Results, &StreamShardResult{})
+			if err := m.Results[len(m.Results)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipLimits(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StreamShardResult) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowLimits
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StreamShardResult: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StreamShardResult: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StreamHash", wireType)
+			}
+			m.StreamHash = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLimits
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StreamHash |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Shards", wireType)
+			}
+			m.Shards = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLimits
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Shards |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ShardDecisionContext", wireType)
+			}
+			m.ShardDecisionContext = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLimits
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ShardDecisionContext |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RejectReason", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLimits
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthLimits
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthLimits
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RejectReason = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipLimits(dAtA[iNdEx:])

--- a/pkg/limits/proto/limits.proto
+++ b/pkg/limits/proto/limits.proto
@@ -5,12 +5,14 @@ package proto;
 service IngestLimitsFrontend {
   rpc ExceedsLimits(ExceedsLimitsRequest) returns (ExceedsLimitsResponse) {}
   rpc UpdateRates(UpdateRatesRequest) returns (UpdateRatesResponse) {}
+  rpc CheckLimitsAndShard(CheckLimitsAndShardRequest) returns (CheckLimitsAndShardResponse) {}
 }
 
 service IngestLimits {
   rpc ExceedsLimits(ExceedsLimitsRequest) returns (ExceedsLimitsResponse) {}
   rpc GetAssignedPartitions(GetAssignedPartitionsRequest) returns (GetAssignedPartitionsResponse) {}
   rpc UpdateRates(UpdateRatesRequest) returns (UpdateRatesResponse) {}
+  rpc CheckLimitsAndShard(CheckLimitsAndShardRequest) returns (CheckLimitsAndShardResponse) {}
 }
 
 message ExceedsLimitsRequest {
@@ -58,4 +60,34 @@ message UpdateRatesResponse {
 message UpdateRatesResult {
   uint64 streamHash = 1;
   uint64 rate = 2;
+}
+
+message CheckLimitsAndShardRequest {
+  string tenant = 1;
+  // streamHash must be the pre-shard hash of the logical stream, and
+  // totalSize the full byte size observed for it in this push (i.e. before
+  // any distributor-side sharding has split it into sub-streams).
+  repeated StreamMetadata streams = 2;
+}
+
+message CheckLimitsAndShardResponse {
+  repeated StreamShardResult results = 1;
+}
+
+message StreamShardResult {
+  uint64 streamHash = 1;
+  // The number of shards the distributor should create for this stream on
+  // this push. 0 and 1 both mean no sharding is needed -- whether the
+  // stream was rejected is signaled independently via rejectReason, not by
+  // this value.
+  uint32 shards = 2;
+  // Reason enum, see reason.go. Populated only when shards was capped below
+  // the rate-justified ideal (ShardsCapped), or when the decision could not
+  // be made (Failed). Never set merely because the stream was rejected --
+  // see rejectReason for that.
+  uint32 shardDecisionContext = 3;
+  // Non-empty when the stream was rejected outright (only possible for a
+  // brand-new stream with no room left in the tenant's stream-count
+  // budget). Empty means the stream was accepted, regardless of shards.
+  string rejectReason = 4;
 }

--- a/pkg/limits/reason.go
+++ b/pkg/limits/reason.go
@@ -11,6 +11,11 @@ const (
 	// ReasonMaxStreams is returned when a stream cannot be accepted because
 	// the tenant has either reached or exceeded their maximum stream limit.
 	ReasonMaxStreams
+	// ReasonStreamShardsCapped is returned by CheckLimitsAndShard when a stream's
+	// shard count was granted, but capped below the rate-justified ideal
+	// because there was not enough room left in the tenant's stream-count
+	// budget. The stream is still accepted.
+	ReasonStreamShardsCapped
 )
 
 func (r Reason) String() string {
@@ -19,6 +24,8 @@ func (r Reason) String() string {
 		return "failed"
 	case ReasonMaxStreams:
 		return "max streams"
+	case ReasonStreamShardsCapped:
+		return "shards capped"
 	default:
 		return "unknown reason"
 	}

--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -51,8 +52,14 @@ type Service struct {
 	usage               *usageStore
 	logger              log.Logger
 
+	// The stream-shard-tracking pipeline (see stream_shard_store.go). Shares
+	// partitionManager with the primary pipeline above.
+	streamShardStore *streamShardStore
+
 	// Metrics.
-	streamEvictionsTotal *prometheus.CounterVec
+	streamEvictionsTotal             *prometheus.CounterVec
+	streamShardEvictionsTotal        *prometheus.CounterVec
+	streamShardStreamsDiscardedTotal *prometheus.CounterVec
 
 	// Readiness check, see [Service.CheckReady].
 	partitionReadinessPassed          bool
@@ -108,10 +115,24 @@ func New(cfg Config, limits Limits, logger log.Logger, reg prometheus.Registerer
 	if err != nil {
 		return nil, fmt.Errorf("failed to create offset manager: %w", err)
 	}
+	s.streamShardStore, err = newStreamShardStore(cfg.ActiveWindow, cfg.RateWindow, cfg.BucketSize, cfg.NumPartitions, limits, s.usage.StreamsUsed, reg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stream shard store: %w", err)
+	}
+	s.streamShardStreamsDiscardedTotal = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "loki_ingest_limits_stream_shard_streams_discarded_total",
+		Help: "Total number of times streams were discarded by CheckLimitsAndShard because their partition is not assigned to this instance.",
+	}, []string{"partition"})
+	s.streamShardEvictionsTotal = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "ingest_limits_stream_shard_evictions_total",
+		Help:      "The total number of shard-tracked streams evicted due to age per tenant. This is not a global total, as tenants can be sharded over multiple pods.",
+	}, []string{"tenant"})
 	s.partitionLifecycler = newPartitionLifecycler(
 		s.partitionManager,
 		offsetManager,
 		s.usage,
+		s.streamShardStore,
 		cfg.ActiveWindow,
 		logger,
 	)
@@ -186,6 +207,41 @@ func (s *Service) ExceedsLimits(
 	req *proto.ExceedsLimitsRequest,
 ) (*proto.ExceedsLimitsResponse, error) {
 	return s.limitsChecker.ExceedsLimits(ctx, req)
+}
+
+// CheckLimitsAndShard implements the [proto.IngestLimitsServer] interface. It
+// filters out streams whose partition isn't owned by this instance, then
+// delegates the shard-count decision for the rest to streamShardStore.
+func (s *Service) CheckLimitsAndShard(
+	ctx context.Context,
+	req *proto.CheckLimitsAndShardRequest,
+) (*proto.CheckLimitsAndShardResponse, error) {
+	streams := req.Streams
+	valid := 0
+	// Streams whose partition isn't owned by this instance get an explicit
+	// ReasonFailed entry rather than being silently dropped: the frontend's
+	// dispatch marks a stream "answered" once any instance responds, so a
+	// dropped stream would never be retried against another zone.
+	results := make([]*proto.StreamShardResult, 0, len(streams))
+	for _, stream := range streams {
+		partition := int32(stream.StreamHash % uint64(s.cfg.NumPartitions))
+		if !s.partitionManager.Has(partition) {
+			s.streamShardStreamsDiscardedTotal.WithLabelValues(strconv.Itoa(int(partition))).Inc()
+			results = append(results, &proto.StreamShardResult{
+				StreamHash:           stream.StreamHash,
+				Shards:               1,
+				ShardDecisionContext: uint32(ReasonFailed),
+			})
+			continue
+		}
+		streams[valid] = stream
+		valid++
+	}
+	streams = streams[:valid]
+
+	results = append(results, s.streamShardStore.checkAndShard(ctx, req.Tenant, streams, time.Now())...)
+
+	return &proto.CheckLimitsAndShardResponse{Results: results}, nil
 }
 
 // UpdateRates implements the [proto.IngestLimitsServer] interface.
@@ -329,6 +385,10 @@ func (s *Service) evictOldStreamsPeriodic(ctx context.Context) {
 			evicted := s.usage.Evict()
 			for tenant, numEvicted := range evicted {
 				s.streamEvictionsTotal.WithLabelValues(tenant).Add(float64(numEvicted))
+			}
+			shardEvicted := s.streamShardStore.Evict()
+			for tenant, numEvicted := range shardEvicted {
+				s.streamShardEvictionsTotal.WithLabelValues(tenant).Add(float64(numEvicted))
 			}
 		}
 	}

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -36,15 +36,18 @@ var (
 	)
 )
 
-// getPolicyBucketAndLimit determines which policy bucket to use and the max streams limit
+// getPolicyBucketAndStreamsLimit determines which policy bucket to use and the max streams limit
 // for a given tenant and policy. Returns the policy bucket name and the max streams limit.
 // The policy bucket will be the input policy name only if the max streams limit is overridden for the policy.
-func (s *usageStore) getPolicyBucketAndStreamsLimit(tenant, policy string) (policyBucket string, maxStreams uint64) {
-	defaultMaxStreams := uint64(s.limits.MaxGlobalStreamsPerUser(tenant) / s.numPartitions)
+//
+// Shared between usageStore and streamShardStore, which must agree on it
+// exactly since streamShardStore.room cross-references usageStore's budget.
+func getPolicyBucketAndStreamsLimit(limits Limits, numPartitions int, tenant, policy string) (policyBucket string, maxStreams uint64) {
+	defaultMaxStreams := uint64(limits.MaxGlobalStreamsPerUser(tenant) / numPartitions)
 
 	if policy != noPolicy {
-		if policyMaxStreams, exists := s.limits.PolicyMaxGlobalStreamsPerUser(tenant, policy); exists {
-			return policy, uint64(policyMaxStreams / s.numPartitions) // Use policy-specific bucket
+		if policyMaxStreams, exists := limits.PolicyMaxGlobalStreamsPerUser(tenant, policy); exists {
+			return policy, uint64(policyMaxStreams / numPartitions) // Use policy-specific bucket
 		}
 	}
 	return noPolicy, defaultMaxStreams // Use default bucket (noPolicy)
@@ -198,7 +201,7 @@ func (s *usageStore) Update(tenant string, metadata *proto.StreamMetadata, seenA
 		return errOutsideActiveWindow
 	}
 	partition := s.getPartitionForHash(metadata.StreamHash)
-	policyBucket, _ := s.getPolicyBucketAndStreamsLimit(tenant, metadata.IngestionPolicy)
+	policyBucket, _ := getPolicyBucketAndStreamsLimit(s.limits, s.numPartitions, tenant, metadata.IngestionPolicy)
 	s.withLock(tenant, func(i int) {
 		s.update(i, tenant, partition, policyBucket, metadata, seenAt)
 	})
@@ -221,7 +224,7 @@ func (s *usageStore) UpdateCond(tenant string, metadata []*proto.StreamMetadata,
 			partition := s.getPartitionForHash(m.StreamHash)
 
 			// Determine which policy bucket to use and the max streams limit
-			policyBucket, maxStreams := s.getPolicyBucketAndStreamsLimit(tenant, m.IngestionPolicy)
+			policyBucket, maxStreams := getPolicyBucketAndStreamsLimit(s.limits, s.numPartitions, tenant, m.IngestionPolicy)
 
 			s.checkInitMap(i, tenant, partition, policyBucket)
 			streams := s.stripes[i][tenant][partition][policyBucket]
@@ -559,6 +562,22 @@ func getActiveRateBuckets(buckets []rateBucket, withinRateWindow func(int64) boo
 		}
 	}
 	return result
+}
+
+// StreamsUsed returns the number of logical (pre-shard) streams currently
+// tracked for the given tenant, partition, and policy bucket, including
+// streams outside the active window that have not yet been evicted.
+//
+// This count is NOT shard-aware: a stream split into N shards still occupies
+// exactly one entry here. A caller that needs the real, shard-inclusive
+// count must combine this with its own shard-aware bookkeeping -- see
+// streamShardStore.room.
+func (s *usageStore) StreamsUsed(tenant string, partition int32, policyBucket string) uint64 {
+	var n uint64
+	s.withRLock(tenant, func(i int) {
+		n = uint64(len(s.stripes[i][tenant][partition][policyBucket]))
+	})
+	return n
 }
 
 func (s *usageStore) get(i int, tenant string, partition int32, streamHash uint64) (stream streamUsage, ok bool) {

--- a/pkg/limits/stream_shard_store.go
+++ b/pkg/limits/stream_shard_store.go
@@ -1,0 +1,531 @@
+package limits
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/v3/pkg/limits/proto"
+)
+
+var (
+	streamShardTrackedStreamsDesc = prometheus.NewDesc(
+		"loki_ingest_limits_stream_shard_tracked_streams",
+		"The current number of distinct logical (pre-shard) streams tracked by the stream-shard-tracking pipeline per tenant.",
+		[]string{"tenant"},
+		nil,
+	)
+	streamShardAllocatedShardsDesc = prometheus.NewDesc(
+		"loki_ingest_limits_stream_shard_allocated_shards",
+		"The current sum of shard counts granted by the stream-shard-tracking pipeline per tenant. This is a prediction, not a live count: a stream that shrinks here doesn't retroactively shrink in ingesters, which are still driven by the legacy rate-store path during shadow mode, so there is an inherent lag. Compare against loki_ingester_memory_streams for the real, physical per-tenant stream count.",
+		[]string{"tenant"},
+		nil,
+	)
+)
+
+// streamShardStore is a standalone store dedicated to stream-sharding
+// decisions, kept separate from usageStore (its own map, its own eviction)
+// so it can't regress the existing stream-count enforcement in
+// usageStore/UpdateCond.
+//
+// It is purely in-memory and per-instance: a restart or partition rebalance
+// loses rate history for affected streams, which then warm up again from
+// scratch (see checkAndShard's "brand-new or expired" case).
+//
+// streamShardStore reads (never writes) usageStore's stream count via
+// streamsUsed, since shard growth must not push a tenant over
+// max_global_streams_per_user. See room for how the two counts are combined
+// without double-counting streams known to both.
+type streamShardStore struct {
+	activeWindow  time.Duration
+	rateWindow    time.Duration
+	bucketSize    time.Duration
+	numBuckets    int
+	numPartitions int
+
+	stripes []map[string]streamShardTenantUsage
+	locks   []stripeLock
+
+	limits Limits
+	// streamsUsed returns the number of streams usageStore currently tracks
+	// for a tenant/partition/policy bucket. Wired to usageStore.StreamsUsed.
+	streamsUsed func(tenant string, partition int32, policyBucket string) uint64
+}
+
+// streamShardTenantUsage is the per-tenant state: partition -> policy -> bucket.
+type streamShardTenantUsage map[int32]map[string]*streamShardBucket
+
+// streamShardBucket holds all streams tracked by streamShardStore for one
+// (tenant, partition, policy bucket).
+type streamShardBucket struct {
+	streams map[uint64]streamShardUsage
+}
+
+// streamShardUsage is the state streamShardStore tracks for a single logical (pre-shard)
+// stream.
+type streamShardUsage struct {
+	hash        uint64
+	lastSeenAt  int64
+	shardCount  uint32
+	rateBuckets []rateBucket
+	policy      string
+}
+
+func newStreamShardStore(
+	activeWindow, rateWindow, bucketSize time.Duration,
+	numPartitions int,
+	limits Limits,
+	streamsUsed func(tenant string, partition int32, policyBucket string) uint64,
+	reg prometheus.Registerer,
+) (*streamShardStore, error) {
+	s := &streamShardStore{
+		activeWindow:  activeWindow,
+		rateWindow:    rateWindow,
+		bucketSize:    bucketSize,
+		numBuckets:    int(rateWindow / bucketSize),
+		numPartitions: numPartitions,
+		stripes:       make([]map[string]streamShardTenantUsage, numStripes),
+		locks:         make([]stripeLock, numStripes),
+		limits:        limits,
+		streamsUsed:   streamsUsed,
+	}
+	for i := range s.stripes {
+		s.stripes[i] = make(map[string]streamShardTenantUsage)
+	}
+	if err := reg.Register(s); err != nil {
+		return nil, fmt.Errorf("failed to register metrics: %w", err)
+	}
+	return s, nil
+}
+
+// checkAndShard evaluates each stream in metadata and decides how many
+// shards it should use:
+//
+//   - A brand-new or expired stream always starts at 1 shard (no rate
+//     history exists yet to justify more), and is rejected outright (0
+//     shards) if there is no room left even for 1.
+//   - An existing stream whose policy has sharding disabled is held at 1
+//     shard regardless of rate.
+//   - An existing stream with sharding enabled has its rate recomputed from
+//     the observation in this call, a "desired" shard count derived from
+//     rate/desiredRate, and the result capped to fit the tenant's remaining
+//     budget: granted = max(1, min(desired, room)). This never forces an
+//     active stream down to 0 shards (only a rejection of a brand-new
+//     stream can do that), and never shrinks a stream because *other*
+//     streams grew -- only because its own rate dropped.
+//   - If no rate history has been recorded for this stream yet (its rate
+//     buckets are still empty, e.g. this is the first live push since it
+//     was granted its initial shard count), the shard count is held steady
+//     rather than being recomputed from a rate of zero.
+func (s *streamShardStore) checkAndShard(ctx context.Context, tenant string, metadata []*proto.StreamMetadata, seenAt time.Time) []*proto.StreamShardResult {
+	var (
+		cutoff  = seenAt.Add(-s.activeWindow).UnixNano()
+		results = make([]*proto.StreamShardResult, 0, len(metadata))
+	)
+	s.withLock(tenant, func(i int) {
+		for _, m := range metadata {
+			// Stop early if the caller has already given up (deadline
+			// exceeded or cancelled) rather than doing abandoned work while
+			// holding the stripe lock. Streams not yet processed are simply
+			// absent from the response; callers fail open for them.
+			if ctx.Err() != nil {
+				return
+			}
+			partition := s.getPartitionForHash(m.StreamHash)
+			shardCfg, _ := s.limits.PolicyShardStreams(tenant, m.IngestionPolicy)
+			policyBucket, maxStreams := getPolicyBucketAndStreamsLimit(s.limits, s.numPartitions, tenant, m.IngestionPolicy)
+			bucket := s.checkInitMap(i, tenant, partition, policyBucket)
+
+			existing, wasPresent := bucket.streams[m.StreamHash]
+			isNewOrExpired := !wasPresent || existing.lastSeenAt < cutoff
+
+			// selfKnown is wasPresent, not "wasPresent and still valid": even
+			// an expired entry is still sitting in bucket.streams (it isn't
+			// deleted/reset until later in this same call), so bucketSlots
+			// below would otherwise double-count its own stale allocation as
+			// belonging to some other stream, wrongly shrinking room for a
+			// reactivating stream evaluating itself.
+			room := s.room(bucket, tenant, partition, policyBucket, maxStreams, existing, wasPresent)
+
+			var (
+				stream  streamShardUsage
+				desired uint32
+			)
+			switch {
+			case isNewOrExpired:
+				// Reset (mirrors usageStore.update's reset-on-expiry
+				// semantics). No rate history: never shard on first sight.
+				stream = streamShardUsage{hash: m.StreamHash, policy: policyBucket}
+				if maxStreams > 0 && room < 1 {
+					// No room even for a single slot: reject outright.
+					delete(bucket.streams, m.StreamHash)
+					results = append(results, &proto.StreamShardResult{
+						StreamHash:   m.StreamHash,
+						Shards:       0,
+						RejectReason: ReasonMaxStreams.String(),
+					})
+					continue
+				}
+				// Seed the first rate bucket with this push's bytes even
+				// though the decision itself stays at 1 shard: otherwise
+				// this push's bytes are dropped forever (never fed into any
+				// rate computation), and only the stream's SECOND push would
+				// initialize the buckets, biasing the rate low for bursty or
+				// infrequently-pushed streams.
+				s.updateRateBucket(&stream, m.TotalSize, seenAt)
+				desired = 1
+			case !shardCfg.Enabled:
+				stream = existing
+				desired = 1
+			default:
+				stream = existing
+				// Must be checked BEFORE updateRateBucket: stream is a
+				// shallow copy of existing (same underlying rateBuckets
+				// array), so updateRateBucket's in-place mutation would
+				// otherwise make every stream look "warm" by the time it's
+				// checked, even one that has never seen live traffic before
+				// this exact call.
+				wasCold := rateBucketsCold(existing.rateBuckets)
+				s.updateRateBucket(&stream, m.TotalSize, seenAt)
+				if wasCold {
+					// This instance hasn't observed live traffic for this
+					// stream before now (e.g. it just took over the
+					// partition). Hold steady rather than recompute from a
+					// rate based on a single, just-started bucket.
+					desired = maxu32(1, stream.shardCount)
+				} else {
+					rate := currentRate(stream.rateBuckets, seenAt, s.rateWindow)
+					desired = maxu32(1, ceilDivU32(rate, uint64(shardCfg.DesiredRate.Val())))
+				}
+			}
+
+			// granted combines the rate-justified desired count with the
+			// tenant's remaining budget. The two cases are NOT symmetric:
+			//
+			//   - Shrinking (desired <= existing.shardCount) is always
+			//     self-inflicted (this stream's own rate dropped) and always
+			//     safe -- it only frees room for others, so it is never
+			//     capped by room. Capping it here would double-penalize a
+			//     stream that's already giving back capacity.
+			//   - Growing (desired > existing.shardCount) is capped by room,
+			//     but the floor is existing.shardCount, NOT a flat 1 or 0:
+			//     an active stream must never be forced to shrink just
+			//     because *other* streams grew and consumed the room it
+			//     would have grown into. It can only ever shrink in
+			//     response to its own rate (the branch above).
+			//
+			// A brand-new/expired stream has no "existing" allocation to
+			// floor against, so it is simply capped to whatever room
+			// remains (already guaranteed >= 1, or rejected above).
+			var granted uint32
+			switch {
+			case maxStreams == 0:
+				granted = desired
+			case isNewOrExpired:
+				granted = minu32(desired, uint32(room))
+			case desired <= existing.shardCount:
+				granted = desired
+			default:
+				granted = maxu32(existing.shardCount, minu32(desired, uint32(room)))
+			}
+
+			shardDecisionContext := ReasonUnknown
+			if granted < desired {
+				shardDecisionContext = ReasonStreamShardsCapped
+			}
+
+			stream.hash = m.StreamHash
+			stream.policy = policyBucket
+			stream.shardCount = granted
+			seenAtNano := seenAt.UnixNano()
+			if seenAtNano > stream.lastSeenAt {
+				stream.lastSeenAt = seenAtNano
+			}
+			bucket.streams[m.StreamHash] = stream
+
+			results = append(results, &proto.StreamShardResult{
+				StreamHash:           m.StreamHash,
+				Shards:               granted,
+				ShardDecisionContext: uint32(shardDecisionContext),
+			})
+		}
+	})
+	return results
+}
+
+// room returns how many additional slots are available in bucket for
+// maxStreams, excluding whatever the stream identified by existing/selfKnown
+// already holds. maxStreams == 0 (unlimited) is handled by callers, not
+// here.
+//
+// The tenant's real usage is the union of two, mostly-disjoint views:
+//   - usageStore's count of logical streams it knows about (accurate for
+//     streams this pipeline hasn't evaluated yet, e.g. because "shadow"
+//     mode was only just enabled for the tenant/policy).
+//   - streamShardStore's own bucket, which is accurate (including shard
+//     multiplicity) for every stream this pipeline has already evaluated at
+//     least once.
+//
+// Rather than determine the exact overlap between the two sets (which would
+// require exposing usageStore's actual stream-hash keys), this estimates the
+// count of "not yet known to streamShardStore" streams as
+// max(0, usageStoreCount - knownToStreamShardStore). This is exact in both
+// steady states (all streams known to one store or the other) and
+// self-corrects as a tenant/policy migrates between modes.
+func (s *streamShardStore) room(bucket *streamShardBucket, tenant string, partition int32, policyBucket string, maxStreams uint64, existing streamShardUsage, selfKnown bool) int64 {
+	if maxStreams == 0 {
+		return 1<<63 - 1
+	}
+	knownToStreamShardStore := uint64(len(bucket.streams))
+	usageStoreCount := s.streamsUsed(tenant, partition, policyBucket)
+	var notYetMigrated uint64
+	if usageStoreCount > knownToStreamShardStore {
+		notYetMigrated = usageStoreCount - knownToStreamShardStore
+	}
+	othersSlots := bucketSlots(bucket)
+	if selfKnown {
+		othersSlots -= streamShardSlots(existing.shardCount)
+	}
+	room := int64(maxStreams) - int64(notYetMigrated) - int64(othersSlots)
+	if room < 0 {
+		room = 0
+	}
+	return room
+}
+
+// Evict evicts all streams that have not been seen within the active
+// window, mirroring usageStore.Evict.
+func (s *streamShardStore) Evict() map[string]int {
+	cutoff := time.Now().Add(-s.activeWindow).UnixNano()
+	evicted := make(map[string]int)
+	s.forEachLock(func(i int) {
+		for tenant, partitions := range s.stripes[i] {
+			for _, policies := range partitions {
+				for _, bucket := range policies {
+					for streamHash, stream := range bucket.streams {
+						if stream.lastSeenAt < cutoff {
+							delete(bucket.streams, streamHash)
+							evicted[tenant]++
+						}
+					}
+				}
+			}
+		}
+	})
+	return evicted
+}
+
+// Describe implements [prometheus.Collector].
+func (s *streamShardStore) Describe(descs chan<- *prometheus.Desc) {
+	descs <- streamShardTrackedStreamsDesc
+	descs <- streamShardAllocatedShardsDesc
+}
+
+// Collect implements [prometheus.Collector].
+func (s *streamShardStore) Collect(metrics chan<- prometheus.Metric) {
+	var (
+		trackedStreams  = make(map[string]int)
+		allocatedShards = make(map[string]uint64)
+	)
+	s.forEachRLock(func(i int) {
+		for tenant, partitions := range s.stripes[i] {
+			for _, policies := range partitions {
+				for _, bucket := range policies {
+					for _, stream := range bucket.streams {
+						trackedStreams[tenant]++
+						allocatedShards[tenant] += streamShardSlots(stream.shardCount)
+					}
+				}
+			}
+		}
+	})
+	for tenant, n := range trackedStreams {
+		metrics <- prometheus.MustNewConstMetric(
+			streamShardTrackedStreamsDesc,
+			prometheus.GaugeValue,
+			float64(n),
+			tenant,
+		)
+	}
+	for tenant, n := range allocatedShards {
+		metrics <- prometheus.MustNewConstMetric(
+			streamShardAllocatedShardsDesc,
+			prometheus.GaugeValue,
+			float64(n),
+			tenant,
+		)
+	}
+}
+
+// EvictPartitions evicts all streams for the specified partitions, mirroring
+// usageStore.EvictPartitions. Called when this instance is no longer
+// assigned those partitions (see partition_lifecycler.go).
+func (s *streamShardStore) EvictPartitions(partitionsToEvict []int32) {
+	s.forEachLock(func(i int) {
+		for tenant, partitions := range s.stripes[i] {
+			for _, p := range partitionsToEvict {
+				delete(partitions, p)
+			}
+			if len(partitions) == 0 {
+				delete(s.stripes[i], tenant)
+			}
+		}
+	})
+}
+
+// setForTests directly seeds a stream's state. Used in tests only, to set
+// up capacity/room scenarios precisely without indirectly driving them
+// through rate-bucket math. Not goroutine-safe.
+func (s *streamShardStore) setForTests(tenant string, partition int32, policyBucket string, stream streamShardUsage) {
+	s.withLock(tenant, func(i int) {
+		bucket := s.checkInitMap(i, tenant, partition, policyBucket)
+		bucket.streams[stream.hash] = stream
+	})
+}
+
+func (s *streamShardStore) updateRateBucket(stream *streamShardUsage, sizeDelta uint64, seenAt time.Time) {
+	if len(stream.rateBuckets) == 0 {
+		stream.rateBuckets = make([]rateBucket, s.numBuckets)
+	}
+	seenAtUnixNano := seenAt.UnixNano()
+	bucketNum := seenAtUnixNano / int64(s.bucketSize)
+	bucketIdx := int(bucketNum % int64(s.numBuckets))
+	b := stream.rateBuckets[bucketIdx]
+	bucketStart := seenAt.Truncate(s.bucketSize).UnixNano()
+	if b.timestamp < bucketStart {
+		b.timestamp = bucketStart
+		b.size = 0
+	}
+	b.size += sizeDelta
+	stream.rateBuckets[bucketIdx] = b
+}
+
+func (s *streamShardStore) getPartitionForHash(hash uint64) int32 {
+	return int32(hash % uint64(s.numPartitions))
+}
+
+func (s *streamShardStore) getStripe(tenant string) int {
+	h := fnv.New32()
+	_, _ = h.Write([]byte(tenant))
+	return int(h.Sum32() % uint32(len(s.locks)))
+}
+
+func (s *streamShardStore) withLock(tenant string, fn func(i int)) {
+	i := s.getStripe(tenant)
+	s.locks[i].Lock()
+	defer s.locks[i].Unlock()
+	fn(i)
+}
+
+func (s *streamShardStore) forEachLock(fn func(i int)) {
+	for i := range s.stripes {
+		s.locks[i].Lock()
+		fn(i)
+		s.locks[i].Unlock()
+	}
+}
+
+// forEachRLock executes fn with a shared lock for each stripe.
+func (s *streamShardStore) forEachRLock(fn func(i int)) {
+	for i := range s.stripes {
+		s.locks[i].RLock()
+		fn(i)
+		s.locks[i].RUnlock()
+	}
+}
+
+// checkInitMap initializes the maps for tenant/partition/policy if needed
+// and returns the bucket. It must not be called without the stripe lock.
+func (s *streamShardStore) checkInitMap(i int, tenant string, partition int32, policy string) *streamShardBucket {
+	if _, ok := s.stripes[i][tenant]; !ok {
+		s.stripes[i][tenant] = make(streamShardTenantUsage)
+	}
+	if _, ok := s.stripes[i][tenant][partition]; !ok {
+		s.stripes[i][tenant][partition] = make(map[string]*streamShardBucket)
+	}
+	if _, ok := s.stripes[i][tenant][partition][policy]; !ok {
+		s.stripes[i][tenant][partition][policy] = &streamShardBucket{streams: make(map[uint64]streamShardUsage)}
+	}
+	return s.stripes[i][tenant][partition][policy]
+}
+
+// streamShardSlots returns how many budget slots a stream with the given shard
+// count consumes: 0 (unsharded/unknown) and 1 both consume exactly 1 slot.
+func streamShardSlots(shardCount uint32) uint64 {
+	if shardCount == 0 {
+		return 1
+	}
+	return uint64(shardCount)
+}
+
+// bucketSlots returns the total slots consumed by all streams in bucket.
+func bucketSlots(bucket *streamShardBucket) uint64 {
+	var n uint64
+	for _, stream := range bucket.streams {
+		n += streamShardSlots(stream.shardCount)
+	}
+	return n
+}
+
+// rateBucketsCold returns true if none of the buckets have ever been
+// written to, i.e. this instance has not observed any live traffic for the
+// stream since the buckets were last (re)initialized (e.g. right after this
+// instance took ownership of the stream's partition).
+func rateBucketsCold(buckets []rateBucket) bool {
+	for _, b := range buckets {
+		if b.timestamp != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// currentRate computes a windowed-average byte rate from buckets, using the
+// same technique as usageStore/Service.UpdateRates: sum the bytes in
+// buckets that fall within the rate window, divided by the rate window
+// duration.
+func currentRate(buckets []rateBucket, now time.Time, rateWindow time.Duration) uint64 {
+	withinWindow := func(t int64) bool {
+		return now.Add(-rateWindow).UnixNano() <= t
+	}
+	active := getActiveRateBuckets(buckets, withinWindow)
+	if len(active) == 0 {
+		return 0
+	}
+	var total uint64
+	for _, b := range active {
+		total += b.size
+	}
+	seconds := rateWindow.Seconds()
+	if seconds <= 0 {
+		return 0
+	}
+	return uint64(float64(total) / seconds)
+}
+
+func ceilDivU32(a uint64, b uint64) uint32 {
+	if b == 0 {
+		return 1
+	}
+	if a == 0 {
+		return 0
+	}
+	return uint32((a + b - 1) / b)
+}
+
+func minu32(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxu32(a, b uint32) uint32 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/pkg/limits/stream_shard_store_test.go
+++ b/pkg/limits/stream_shard_store_test.go
@@ -1,0 +1,435 @@
+package limits
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
+	"github.com/grafana/loki/v3/pkg/limits/proto"
+)
+
+// warmRateBuckets returns a rateBuckets slice with the current bucket
+// already populated (non-zero timestamp, zero size), so a seeded stream is
+// treated as "warm" (rateBucketsCold returns false) and the next
+// checkAndShard call computes its rate from that call's own push, instead
+// of holding steady as if this instance had just taken ownership of the
+// stream's partition with no live traffic observed yet.
+func warmRateBuckets(numBuckets int, bucketSize time.Duration, now time.Time) []rateBucket {
+	buckets := make([]rateBucket, numBuckets)
+	bucketNum := now.UnixNano() / int64(bucketSize)
+	idx := int(bucketNum % int64(numBuckets))
+	buckets[idx] = rateBucket{timestamp: now.Truncate(bucketSize).UnixNano()}
+	return buckets
+}
+
+// newShardingEnabledMockLimits returns a mockLimits with sharding enabled
+// and a permissive desired_rate. mockLimits{}'s zero value has sharding
+// *disabled* (Go's zero value for shardstreams.Config.Enabled is false),
+// which would make every checkAndShard call collapse to 1 shard -- easy to
+// trip over when a test only cares about, e.g., replay/eviction behavior
+// and doesn't intend to exercise the sharding-disabled code path at all.
+func newShardingEnabledMockLimits() *mockLimits {
+	cfg := shardstreams.Config{Enabled: true}
+	cfg.DesiredRate.Set("1B") //nolint:errcheck
+	return &mockLimits{ShardStreamsConfig: cfg}
+}
+
+func newTestStreamShardStore(t *testing.T, maxGlobalStreams int, desiredRate string, streamsUsed func(string, int32, string) uint64) *streamShardStore {
+	t.Helper()
+	cfg := shardstreams.Config{Enabled: true}
+	require.NoError(t, cfg.DesiredRate.Set(desiredRate))
+	if streamsUsed == nil {
+		streamsUsed = func(string, int32, string) uint64 { return 0 }
+	}
+	l := &mockLimits{
+		MaxGlobalStreams:   maxGlobalStreams,
+		ShardStreamsConfig: cfg,
+	}
+	// numPartitions=1 so every test stream hash lands in partition 0,
+	// keeping test setup simple.
+	s, err := newStreamShardStore(15*time.Minute, 5*time.Minute, time.Minute, 1, l, streamsUsed, prometheus.NewRegistry())
+	require.NoError(t, err)
+	return s
+}
+
+func TestStreamShardStore_CheckAndShard(t *testing.T) {
+	// seedStream pre-populates a stream via setForTests before the push
+	// being asserted on. warm controls whether it has an already-populated
+	// rate bucket (rateBucketsCold == false, so the push's rate is computed
+	// normally) or not (cold: the shard count is held steady instead).
+	type seedStream struct {
+		hash       uint64
+		shardCount uint32
+		warm       bool
+	}
+	tests := []struct {
+		name                     string
+		maxGlobalStreams         int
+		shardStreamsEnabled      bool
+		streamsUsed              func(tenant string, partition int32, policyBucket string) uint64
+		seed                     []seedStream
+		advanceBeforeCall        time.Duration
+		pushHash                 uint64
+		pushTotalSize            uint64
+		wantShards               uint32
+		wantShardDecisionContext Reason
+		wantRejectReason         string
+	}{
+		{
+			// A huge first push must still never shard on the very first
+			// sighting: there is no rate history yet to justify more than 1
+			// shard.
+			name:                     "new stream starts at one shard",
+			maxGlobalStreams:         100,
+			shardStreamsEnabled:      true,
+			pushHash:                 1,
+			pushTotalSize:            1_000_000,
+			wantShards:               1,
+			wantShardDecisionContext: ReasonUnknown,
+		},
+		{
+			// usageStore (via streamsUsed) reports the bucket is already
+			// fully at the tenant's real budget.
+			name:                "new stream rejected when no room",
+			maxGlobalStreams:    5,
+			shardStreamsEnabled: true,
+			streamsUsed:         func(string, int32, string) uint64 { return 5 },
+			pushHash:            1,
+			pushTotalSize:       100,
+			wantShards:          0,
+			wantRejectReason:    ReasonMaxStreams.String(),
+		},
+		{
+			// Three other streams occupy 6 slots total (2 each); the target
+			// stream currently holds 1 shard and is warm, so its rate is
+			// computed (rateWindow=5m=300s, desiredRate=1B/s: TotalSize=1500
+			// -> rate=5B/s -> desired=5), then capped to fit the remaining
+			// budget: room = maxStreams(9) - others(6) = 3; granted =
+			// max(current=1, min(desired=5, room=3)) = 3.
+			name:                "growth capped to fit budget",
+			maxGlobalStreams:    9,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 100, shardCount: 2},
+				{hash: 101, shardCount: 2},
+				{hash: 102, shardCount: 2},
+				{hash: 1, shardCount: 1, warm: true},
+			},
+			pushHash:                 1,
+			pushTotalSize:            1500,
+			wantShards:               3,
+			wantShardDecisionContext: ReasonStreamShardsCapped,
+		},
+		{
+			// The target stream already holds 5 shards and is warm; another
+			// stream has grown to consume the rest of the budget. The
+			// target's rate still justifies growth to 6 shards (rate=6B/s):
+			// room = maxStreams(10) - others(5) = 5; desired(6) >
+			// current(5), so granted = max(current=5, min(6,5)) = 5 -- held
+			// steady, neither force-shrunk to make room for the other
+			// stream nor grown further since there's no room left to grow
+			// into.
+			name:                "never force shrink from others' growth",
+			maxGlobalStreams:    10,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 1, shardCount: 5, warm: true},
+				{hash: 2, shardCount: 5},
+			},
+			pushHash:                 1,
+			pushTotalSize:            1800,
+			wantShards:               5,
+			wantShardDecisionContext: ReasonStreamShardsCapped,
+		},
+		{
+			// The target stream currently holds 8 shards and is warm;
+			// another stream consumes the entire remaining budget (room=0:
+			// maxStreams(10) - others(2) - self(8) = 0). The target's rate
+			// has dropped to justify only 3 shards (rate=3B/s): a
+			// self-inflicted shrink is never capped by room, since it only
+			// frees capacity.
+			name:                "self shrink ignores room",
+			maxGlobalStreams:    10,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 1, shardCount: 8, warm: true},
+				{hash: 2, shardCount: 2},
+			},
+			pushHash:                 1,
+			pushTotalSize:            900,
+			wantShards:               3,
+			wantShardDecisionContext: ReasonUnknown,
+		},
+		{
+			// A push that would otherwise justify many shards must still be
+			// held at 1 while sharding is disabled for this policy.
+			name:                "sharding disabled never exceeds one shard",
+			maxGlobalStreams:    100,
+			shardStreamsEnabled: false,
+			seed: []seedStream{
+				{hash: 1, shardCount: 1},
+			},
+			pushHash:                 1,
+			pushTotalSize:            1_000_000,
+			wantShards:               1,
+			wantShardDecisionContext: ReasonUnknown,
+		},
+		{
+			// Simulates a stream restored from a replayed snapshot (e.g.
+			// after a partition rebalance): it has a durable shardCount,
+			// but no rate history has been observed yet by this instance
+			// (not warm). The very next live push, even a tiny one, must
+			// not collapse the shard count to whatever a fresh,
+			// mostly-empty rate bucket implies.
+			name:                "cold rate buckets hold steady",
+			maxGlobalStreams:    100,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 1, shardCount: 7},
+			},
+			pushHash:                 1,
+			pushTotalSize:            1,
+			wantShards:               7,
+			wantShardDecisionContext: ReasonUnknown,
+		},
+		{
+			// Advancing past the active window means the stream is now
+			// expired and must be treated as brand new (no shard-count
+			// memory carried over).
+			name:                "expired stream resets to one shard",
+			maxGlobalStreams:    100,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 1, shardCount: 7},
+			},
+			advanceBeforeCall:        15*time.Minute + time.Second,
+			pushHash:                 1,
+			pushTotalSize:            1_000_000,
+			wantShards:               1,
+			wantShardDecisionContext: ReasonUnknown,
+		},
+		{
+			// Regression guard: a reactivating (expired-then-reseen) stream
+			// must not have its own stale shard allocation double-counted
+			// against itself when room() decides whether it can reset to 1
+			// shard.
+			name:                "reactivating stream's own stale allocation doesn't count against itself",
+			maxGlobalStreams:    5,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 1, shardCount: 5},
+			},
+			advanceBeforeCall:        15*time.Minute + time.Second,
+			pushHash:                 1,
+			pushTotalSize:            100,
+			wantShards:               1,
+			wantShardDecisionContext: ReasonUnknown,
+		},
+		{
+			name:                "unlimited when maxStreams is zero",
+			maxGlobalStreams:    0,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 1, shardCount: 1, warm: true},
+			},
+			pushHash:                 1,
+			pushTotalSize:            1500, // rate=5B/s -> desired=5
+			wantShards:               5,
+			wantShardDecisionContext: ReasonUnknown,
+		},
+		{
+			// Regression guard: a tracked stream holding 5 shards must
+			// consume 5 budget slots, not 1. maxGlobalStreams here exactly
+			// equals that shard count, so a new stream must be rejected
+			// outright.
+			name:                "existing stream's granted shards fully consume the budget",
+			maxGlobalStreams:    5,
+			shardStreamsEnabled: true,
+			seed: []seedStream{
+				{hash: 100, shardCount: 5},
+			},
+			pushHash:         1,
+			pushTotalSize:    100,
+			wantShards:       0,
+			wantRejectReason: ReasonMaxStreams.String(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				cfg := shardstreams.Config{Enabled: test.shardStreamsEnabled}
+				require.NoError(t, cfg.DesiredRate.Set("1B"))
+				streamsUsed := test.streamsUsed
+				if streamsUsed == nil {
+					streamsUsed = func(string, int32, string) uint64 { return 0 }
+				}
+				l := &mockLimits{MaxGlobalStreams: test.maxGlobalStreams, ShardStreamsConfig: cfg}
+				// numPartitions=1 so every test stream hash lands in partition 0.
+				s, err := newStreamShardStore(15*time.Minute, 5*time.Minute, time.Minute, 1, l, streamsUsed, prometheus.NewRegistry())
+				require.NoError(t, err)
+				now := time.Now()
+
+				for _, seed := range test.seed {
+					usage := streamShardUsage{hash: seed.hash, lastSeenAt: now.UnixNano(), shardCount: seed.shardCount, policy: noPolicy}
+					if seed.warm {
+						usage.rateBuckets = warmRateBuckets(s.numBuckets, s.bucketSize, now)
+					}
+					s.setForTests("tenant1", 0, noPolicy, usage)
+				}
+
+				if test.advanceBeforeCall > 0 {
+					time.Sleep(test.advanceBeforeCall)
+				}
+
+				results := s.checkAndShard(context.Background(), "tenant1", []*proto.StreamMetadata{
+					{StreamHash: test.pushHash, TotalSize: test.pushTotalSize},
+				}, time.Now())
+				require.Len(t, results, 1)
+				require.Equal(t, test.wantShards, results[0].Shards)
+				require.Equal(t, uint32(test.wantShardDecisionContext), results[0].ShardDecisionContext)
+				require.Equal(t, test.wantRejectReason, results[0].RejectReason)
+			})
+		})
+	}
+}
+
+func TestStreamShardStore_CheckAndShard_NewStreamSeedsItsFirstRateBucket(t *testing.T) {
+	// Regression guard: a brand-new stream's first push must still start at
+	// 1 shard (no rate history to justify more), but its bytes must be
+	// recorded into the rate buckets rather than dropped -- otherwise only
+	// the SECOND push would initialize the buckets, and a real rate
+	// computation wouldn't happen until the third push, permanently biasing
+	// bursty/infrequent streams low.
+	synctest.Test(t, func(t *testing.T) {
+		s := newTestStreamShardStore(t, 100, "1B", nil)
+
+		// First push: brand new stream. Must start at 1 shard.
+		results := s.checkAndShard(context.Background(), "tenant1", []*proto.StreamMetadata{
+			{StreamHash: 1, TotalSize: 1500},
+		}, time.Now())
+		require.Len(t, results, 1)
+		require.Equal(t, uint32(1), results[0].Shards)
+
+		// Second push, same instant (same 1-minute bucket, per
+		// newTestStreamShardStore's bucketSize): if the first push's bytes
+		// were recorded, the rate is already computable from BOTH pushes
+		// combined -- 3000 bytes / 300s rate window = 10 B/s, desired 10
+		// shards at desiredRate=1B/s -- instead of being held steady at 1
+		// while "cold" (which would only stop being true on the THIRD push
+		// without this fix).
+		results = s.checkAndShard(context.Background(), "tenant1", []*proto.StreamMetadata{
+			{StreamHash: 1, TotalSize: 1500},
+		}, time.Now())
+		require.Len(t, results, 1)
+		require.Equal(t, uint32(10), results[0].Shards)
+	})
+}
+
+// collectStreamShardStoreGauges reads streamShardStore's own Collector
+// output directly (bypassing a full registry Gather), returning the
+// per-tenant tracked-streams/allocated-shards gauge values it currently
+// reports.
+func collectStreamShardStoreGauges(t *testing.T, s *streamShardStore, tenant string) (trackedStreams, allocatedShards float64) {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 16)
+	go func() {
+		s.Collect(ch)
+		close(ch)
+	}()
+	for m := range ch {
+		var pb dto.Metric
+		require.NoError(t, m.Write(&pb))
+		require.Len(t, pb.Label, 1)
+		require.Equal(t, "tenant", pb.Label[0].GetName())
+		if pb.Label[0].GetValue() != tenant {
+			continue
+		}
+		switch m.Desc() {
+		case streamShardTrackedStreamsDesc:
+			trackedStreams = pb.GetGauge().GetValue()
+		case streamShardAllocatedShardsDesc:
+			allocatedShards = pb.GetGauge().GetValue()
+		}
+	}
+	return trackedStreams, allocatedShards
+}
+
+func TestStreamShardStore_Collect_ReflectsCurrentStateNotCumulative(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s := newTestStreamShardStore(t, 100, "1B", nil)
+
+		// Nothing tracked yet.
+		trackedStreams, allocatedShards := collectStreamShardStoreGauges(t, s, "tenant1")
+		require.Equal(t, float64(0), trackedStreams)
+		require.Equal(t, float64(0), allocatedShards)
+
+		// First push: brand new stream, always starts at 1 shard.
+		results := s.checkAndShard(context.Background(), "tenant1", []*proto.StreamMetadata{
+			{StreamHash: 1, TotalSize: 1500},
+		}, time.Now())
+		require.Len(t, results, 1)
+		require.Equal(t, uint32(1), results[0].Shards)
+
+		trackedStreams, allocatedShards = collectStreamShardStoreGauges(t, s, "tenant1")
+		require.Equal(t, float64(1), trackedStreams)
+		require.Equal(t, float64(1), allocatedShards)
+
+		// Second push, same stream: its rate now justifies 10 shards. Collect
+		// must reflect the CURRENT allocation (10), not accumulate the two
+		// pushes' shard counts (1 + 10 = 11) -- these are lazily-aggregated
+		// gauges over live state, not counters.
+		results = s.checkAndShard(context.Background(), "tenant1", []*proto.StreamMetadata{
+			{StreamHash: 1, TotalSize: 1500},
+		}, time.Now())
+		require.Len(t, results, 1)
+		require.Equal(t, uint32(10), results[0].Shards)
+
+		trackedStreams, allocatedShards = collectStreamShardStoreGauges(t, s, "tenant1")
+		require.Equal(t, float64(1), trackedStreams, "still exactly one distinct logical stream")
+		require.Equal(t, float64(10), allocatedShards, "reflects the current allocation, not the sum across pushes")
+	})
+}
+
+func TestStreamShardStore_Evict_FreesAllOfAStreamsSlots(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s := newTestStreamShardStore(t, 5, "1B", nil)
+		now := time.Now()
+		s.setForTests("tenant1", 0, noPolicy, streamShardUsage{
+			hash: 1, lastSeenAt: now.UnixNano(), shardCount: 5, policy: noPolicy,
+		})
+		time.Sleep(15*time.Minute + time.Second)
+		evicted := s.Evict()
+		require.Equal(t, 1, evicted["tenant1"])
+		// All 5 of the evicted stream's slots must be freed: a brand-new stream
+		// should now fit within the (otherwise fully consumed) budget.
+		results := s.checkAndShard(context.Background(), "tenant1", []*proto.StreamMetadata{
+			{StreamHash: 2, TotalSize: 1},
+		}, time.Now())
+		require.Len(t, results, 1)
+		require.Equal(t, uint32(1), results[0].Shards)
+		require.Empty(t, results[0].RejectReason)
+	})
+}
+
+func TestStreamShardStore_EvictPartitions(t *testing.T) {
+	s := newTestStreamShardStore(t, 5, "1B", nil)
+	now := time.Now()
+	s.setForTests("tenant1", 0, noPolicy, streamShardUsage{
+		hash: 1, lastSeenAt: now.UnixNano(), shardCount: 5, policy: noPolicy,
+	})
+	s.EvictPartitions([]int32{0})
+	// Slots must be freed for the evicted partition, same as a normal Evict.
+	results := s.checkAndShard(context.Background(), "tenant1", []*proto.StreamMetadata{
+		{StreamHash: 2, TotalSize: 1},
+	}, now)
+	require.Len(t, results, 1)
+	require.Equal(t, uint32(1), results[0].Shards)
+	require.Empty(t, results[0].RejectReason)
+}

--- a/pkg/limits/stream_shard_test.go
+++ b/pkg/limits/stream_shard_test.go
@@ -1,0 +1,41 @@
+package limits
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/limits/proto"
+)
+
+func TestService_CheckLimitsAndShard_UnownedPartitionStreamsGetAnExplicitFailedResult(t *testing.T) {
+	// Regression guard: a stream whose partition isn't owned by this
+	// instance must not silently vanish from the response -- it must come
+	// back with an explicit ShardDecisionContext=ReasonFailed entry, so the
+	// frontend's fail-open handling can engage for it instead of the caller
+	// getting no answer at all for that stream.
+	store := newTestStreamShardStore(t, 100, "1B", nil)
+	pm, err := newPartitionManager(prometheus.NewRegistry())
+	require.NoError(t, err)
+	// No partitions assigned to pm, so every stream below is "unowned".
+	s := &Service{
+		cfg:              Config{NumPartitions: 1},
+		partitionManager: pm,
+		streamShardStore: store,
+		streamShardStreamsDiscardedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "test_streams_discarded_total",
+		}, []string{"partition"}),
+	}
+
+	resp, err := s.CheckLimitsAndShard(t.Context(), &proto.CheckLimitsAndShardRequest{
+		Tenant:  "tenant1",
+		Streams: []*proto.StreamMetadata{{StreamHash: 1, TotalSize: 100}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []*proto.StreamShardResult{{
+		StreamHash:           1,
+		Shards:               1,
+		ShardDecisionContext: uint32(ReasonFailed),
+	}}, resp.Results)
+}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -642,6 +642,10 @@ func (l *Limits) Validate() error {
 		}
 	}
 
+	if err := l.ShardStreams.Validate(); err != nil {
+		return err
+	}
+
 	for policy, pl := range l.PolicyOverrideLimits {
 		if err := pl.Validate(); err != nil {
 			return fmt.Errorf("policy_override_limits[%q]: %w", policy, err)


### PR DESCRIPTION
New `CheckLimitsAndShard` RPC: the ingest-limits service recommends a per-stream shard count from an observed rate, capped to the tenant's remaining stream-count budget.

The distributor uses it in **shadow mode** only (`limits_service_stream_sharding_mode: shadow`) — the recommendation is compared against the local rate store via metrics and never drives real sharding. Defaults to `disabled` (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)