### PR TITLE
test: Fixes to allow -count values greater than 1

### DIFF
--- a/pkg/dataobj/metastore/metrics.go
+++ b/pkg/dataobj/metastore/metrics.go
@@ -226,18 +226,29 @@ func (p *ObjectMetastoreMetrics) register(reg prometheus.Registerer) {
 	if reg == nil {
 		return
 	}
-	reg.MustRegister(p.indexObjectsTotal)
-	reg.MustRegister(p.streamFilterTotalDuration)
-	reg.MustRegister(p.streamFilterSections)
-	reg.MustRegister(p.streamFilterStreamsReadDuration)
-	reg.MustRegister(p.streamFilterPointersReadDuration)
-	reg.MustRegister(p.estimateSectionsTotalDuration)
-	reg.MustRegister(p.estimateSectionsPointerReadDuration)
-	reg.MustRegister(p.estimateSectionsSections)
-	reg.MustRegister(p.resolvedSectionsTotalDuration)
-	reg.MustRegister(p.resolvedSectionsTotal)
-	reg.MustRegister(p.resolvedSectionsRatio)
-	reg.MustRegister(p.indexReadFlowTotal)
-	reg.MustRegister(p.indexReadRowsPerObject)
-	reg.MustRegister(p.resolvedSectionsPerObject)
+
+	collectors := []prometheus.Collector{
+		p.indexObjectsTotal,
+		p.streamFilterTotalDuration,
+		p.streamFilterSections,
+		p.streamFilterStreamsReadDuration,
+		p.streamFilterPointersReadDuration,
+		p.estimateSectionsTotalDuration,
+		p.estimateSectionsPointerReadDuration,
+		p.estimateSectionsSections,
+		p.resolvedSectionsTotalDuration,
+		p.resolvedSectionsTotal,
+		p.resolvedSectionsRatio,
+		p.indexReadFlowTotal,
+		p.indexReadRowsPerObject,
+		p.resolvedSectionsPerObject,
+	}
+
+	for _, collector := range collectors {
+		if err := reg.Register(collector); err != nil {
+			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+				panic(err)
+			}
+		}
+	}
 }

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -177,7 +177,10 @@ func getRandomPorts(n int) []int {
 }
 
 func TestLoki_CustomRunOptsBehavior(t *testing.T) {
-	t.Parallel()
+	// Loki.Run registers process-wide collectors on DefaultRegisterer.
+	// Isolate it so -count>1 does not panic on the second iteration.
+	prepareGlobalMetricsRegistry(t)
+
 	// Set an overall test timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/pkg/storage/chunk/client/congestion/congestion_test.go
+++ b/pkg/storage/chunk/client/congestion/congestion_test.go
@@ -4,12 +4,21 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewMetrics_DuplicateRegistration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	cfg := Config{}
+
+	require.NotNil(t, NewMetrics("dup", cfg, reg))
+	require.NotNil(t, NewMetrics("dup", cfg, reg))
+}
+
 func TestZeroValueConstruction(t *testing.T) {
 	cfg := Config{}
-	m := NewMetrics(t.Name(), cfg)
+	m := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), m)
 
 	require.IsType(t, &NoopController{}, ctrl)
@@ -24,7 +33,7 @@ func TestAIMDConstruction(t *testing.T) {
 			Strategy: "aimd",
 		},
 	}
-	m := NewMetrics(t.Name(), cfg)
+	m := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), m)
 
 	require.IsType(t, &AIMDController{}, ctrl)
@@ -39,7 +48,7 @@ func TestRetrierConstruction(t *testing.T) {
 			Strategy: "limited",
 		},
 	}
-	m := NewMetrics(t.Name(), cfg)
+	m := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), m)
 
 	require.IsType(t, &NoopController{}, ctrl)
@@ -57,7 +66,7 @@ func TestCombinedConstruction(t *testing.T) {
 			Strategy: "limited",
 		},
 	}
-	m := NewMetrics(t.Name(), cfg)
+	m := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), m)
 
 	require.IsType(t, &AIMDController{}, ctrl)
@@ -74,7 +83,7 @@ func TestNoopControllerWrapIsPassThrough(t *testing.T) {
 			Limit:    2,
 		},
 	}
-	m := NewMetrics(t.Name(), cfg)
+	m := NewMetrics(t.Name(), cfg, nil)
 	t.Cleanup(m.Unregister)
 
 	ctrl := NewController(cfg, log.NewNopLogger(), m)

--- a/pkg/storage/chunk/client/congestion/controller_test.go
+++ b/pkg/storage/chunk/client/congestion/controller_test.go
@@ -27,7 +27,7 @@ func TestRequestNoopRetry(t *testing.T) {
 		},
 	}
 
-	metrics := NewMetrics(t.Name(), cfg)
+	metrics := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
 
 	// allow 1 request through, fail the rest
@@ -60,7 +60,7 @@ func TestRequestZeroLimitedRetry(t *testing.T) {
 		},
 	}
 
-	metrics := NewMetrics(t.Name(), cfg)
+	metrics := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
 
 	// fail all requests
@@ -89,7 +89,7 @@ func TestRequestLimitedRetry(t *testing.T) {
 		},
 	}
 
-	metrics := NewMetrics(t.Name(), cfg)
+	metrics := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
 
 	// allow 1 request through, fail the rest
@@ -125,7 +125,7 @@ func TestRequestLimitedRetryNonRetryableErr(t *testing.T) {
 		},
 	}
 
-	metrics := NewMetrics(t.Name(), cfg)
+	metrics := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
 
 	// fail all requests
@@ -168,7 +168,7 @@ func TestAIMDReducedThroughput(t *testing.T) {
 
 	var trigger atomic.Bool
 
-	metrics := NewMetrics(t.Name(), cfg)
+	metrics := NewMetrics(t.Name(), cfg, nil)
 	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
 
 	// fail requests only when triggered

--- a/pkg/storage/chunk/client/congestion/integration_test.go
+++ b/pkg/storage/chunk/client/congestion/integration_test.go
@@ -113,7 +113,7 @@ func newCongestionControlledS3(t *testing.T, handler http.HandlerFunc) congestio
 		Retry: congestion.RetrierConfig{Strategy: "limited", Limit: 2},
 	}
 
-	metrics := congestion.NewMetrics(t.Name(), cfg)
+	metrics := congestion.NewMetrics(t.Name(), cfg, nil)
 	t.Cleanup(metrics.Unregister)
 
 	ctrl := congestion.NewController(cfg, log.NewNopLogger(), metrics)

--- a/pkg/storage/chunk/client/congestion/metrics.go
+++ b/pkg/storage/chunk/client/congestion/metrics.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Metrics struct {
+	reg                prometheus.Registerer
 	currentLimit       prometheus.Gauge
 	backoffSec         prometheus.Counter
 	requests           prometheus.Counter
@@ -16,19 +17,23 @@ type Metrics struct {
 }
 
 func (m Metrics) Unregister() {
-	prometheus.Unregister(m.currentLimit)
-	prometheus.Unregister(m.backoffSec)
-	prometheus.Unregister(m.requests)
-	prometheus.Unregister(m.retries)
-	prometheus.Unregister(m.nonRetryableErrors)
-	prometheus.Unregister(m.retriesExceeded)
+	if m.reg == nil {
+		return
+	}
+	m.reg.Unregister(m.currentLimit)
+	m.reg.Unregister(m.backoffSec)
+	m.reg.Unregister(m.requests)
+	m.reg.Unregister(m.retries)
+	m.reg.Unregister(m.nonRetryableErrors)
+	m.reg.Unregister(m.retriesExceeded)
 }
 
 // NewMetrics creates metrics to be used for monitoring congestion control.
-// It needs to accept a "name" because congestion control is used in object clients, and there can be many object clients
-// creates for the same store (multiple period configs, etc). It is the responsibility of the caller to ensure uniqueness,
-// otherwise a duplicate registration panic will occur.
-func NewMetrics(name string, cfg Config) *Metrics {
+// name must be unique per store/period because many object clients can exist
+// in one process. A second registration of the same name is ignored so tests
+// can construct clients more than once against a shared registerer.
+// If reg is nil, collectors are created but not registered.
+func NewMetrics(name string, cfg Config, reg prometheus.Registerer) *Metrics {
 	labels := map[string]string{
 		"strategy": cfg.Controller.Strategy,
 		"name":     name,
@@ -81,11 +86,23 @@ func NewMetrics(name string, cfg Config) *Metrics {
 		}),
 	}
 
-	prometheus.MustRegister(m.currentLimit)
-	prometheus.MustRegister(m.backoffSec)
-	prometheus.MustRegister(m.requests)
-	prometheus.MustRegister(m.retries)
-	prometheus.MustRegister(m.nonRetryableErrors)
-	prometheus.MustRegister(m.retriesExceeded)
+	m.reg = reg
+	registerCollector(reg, m.currentLimit)
+	registerCollector(reg, m.backoffSec)
+	registerCollector(reg, m.requests)
+	registerCollector(reg, m.retries)
+	registerCollector(reg, m.nonRetryableErrors)
+	registerCollector(reg, m.retriesExceeded)
 	return &m
+}
+
+func registerCollector(reg prometheus.Registerer, c prometheus.Collector) {
+	if reg == nil {
+		return
+	}
+	if err := reg.Register(c); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			panic(err)
+		}
+	}
 }

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -379,7 +379,7 @@ func NewChunkClient(name, component string, cfg Config, schemaCfg config.SchemaC
 		cc := congestion.NewController(
 			ccCfg,
 			logger,
-			congestion.NewMetrics(fmt.Sprintf("%s-%s", name, p.From.String()), ccCfg),
+			congestion.NewMetrics(fmt.Sprintf("%s-%s", name, p.From.String()), ccCfg, registerer),
 		)
 		c = cc.Wrap(c)
 	}

--- a/pkg/storage/factory_congestion_test.go
+++ b/pkg/storage/factory_congestion_test.go
@@ -24,9 +24,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-// Each test here that calls NewChunkClient must use a unique PeriodConfig.From date.
-// NewChunkClient registers congestion metrics under a name built from that date and
-// never unregisters them, so a shared date panics the second test.
+// Each test here that calls NewChunkClient uses a unique PeriodConfig.From date
+// so congestion metric names do not collide when sharing a registerer.
 
 // The XML body must keep this shape. minio-go maps it to a retryable SlowDown.
 func writeS3SlowDown(w http.ResponseWriter, key string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of our tests were duplicating metrics registration, which caused runs with a `count` value greater than 1 to panic, like:
```
% go test -count=2 -timeout 2m -run TestNewChunkClient_ThanosCongestionControl_DisablesInnerRetries ./pkg/storage/

--- FAIL: TestNewChunkClient_ThanosCongestionControl_DisablesInnerRetries (0.00s)
panic: duplicate metrics collector registration attempted [recovered, repanicked]
```

This PR changes the code to tolerate or not re-register metrics.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
