### PR TITLE
fix(tsdb): Persist chunk IngestedAt in the head WAL

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -283,10 +283,11 @@ func Test_HeadManager_RecoverHead(t *testing.T) {
 }
 
 // Test_HeadManager_RecoverHead_IngestedAt asserts that a chunk's ingestion
-// timestamp survives WAL replay. Without it, an index built from a recovered
-// head would drop the timestamp that an index built from the same data without
-// a restart carries, and retention would silently fall back to expiring those
-// chunks by their log timestamps.
+// timestamp survives WAL replay once the WAL is written as
+// WalRecordChunksV2. Without it, an index built from a recovered head would
+// drop the timestamp that an index built from the same data without a restart
+// carries, and retention would silently fall back to expiring those chunks by
+// their log timestamps.
 func Test_HeadManager_RecoverHead_IngestedAt(t *testing.T) {
 	now := time.Now()
 	dir := t.TempDir()
@@ -322,13 +323,24 @@ func Test_HeadManager_RecoverHead_IngestedAt(t *testing.T) {
 	require.True(t, ok)
 	require.Nil(t, recoverHead(mgr.name, mgr.dir, mgr.activeHeads, grp.wals, false, log.NewNopLogger(), NewMetrics(nil).walCorruptionsRepairs))
 
+	want := chks
+	if CurrentChunksRec < WalRecordChunksV2 {
+		// The encoder still writes the layout without ingestion timestamps,
+		// so replay zeroes them. Remove once CurrentChunksRec is
+		// WalRecordChunksV2.
+		want = index.ChunkMetas{
+			{MinTime: 1, MaxTime: 10, Checksum: 3, KB: 5, Entries: 6},
+			{MinTime: 11, MaxTime: 20, Checksum: 4, KB: 7, Entries: 8},
+		}
+	}
+
 	var recovered index.ChunkMetas
 	require.Nil(t, mgr.activeHeads.forAll(func(u string, _ labels.Labels, _ uint64, c index.ChunkMetas) error {
 		require.Equal(t, user, u)
 		recovered = append(recovered, c...)
 		return nil
 	}))
-	require.Equal(t, chks, recovered)
+	require.Equal(t, want, recovered)
 }
 
 // test head recover from corrupted wal

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -282,6 +282,55 @@ func Test_HeadManager_RecoverHead(t *testing.T) {
 
 }
 
+// Test_HeadManager_RecoverHead_IngestedAt asserts that a chunk's ingestion
+// timestamp survives WAL replay. Without it, an index built from a recovered
+// head would drop the timestamp that an index built from the same data without
+// a restart carries, and retention would silently fall back to expiring those
+// chunks by their log timestamps.
+func Test_HeadManager_RecoverHead_IngestedAt(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+
+	const user = "tenant1"
+	ls := mustParseLabels(`{foo="bar", __backfill__="true"}`)
+	chks := index.ChunkMetas{
+		// A backfilled chunk, stamped at flush time.
+		{MinTime: 1, MaxTime: 10, Checksum: 3, KB: 5, Entries: 6, IngestedAt: now.UnixMilli()},
+		// A live chunk in the same record keeps the zero value.
+		{MinTime: 11, MaxTime: 20, Checksum: 4, KB: 7, Entries: 8},
+	}
+
+	storeName := "store_2010-10-10"
+	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+	for _, d := range managerRequiredDirs(storeName, dir) {
+		require.Nil(t, util.EnsureDirectory(d))
+	}
+	require.Nil(t, mgr.Rotate(now))
+
+	w, err := newHeadWAL(log.NewNopLogger(), walPath(mgr.name, mgr.dir, now), now)
+	require.Nil(t, err)
+	require.Nil(t, w.Log(&WALRecord{
+		UserID:      user,
+		Fingerprint: labels.StableHash(ls),
+		Series:      record.RefSeries{Ref: chunks.HeadSeriesRef(0), Labels: ls},
+		Chks:        ChunkMetasRecord{Chks: chks, Ref: 0},
+	}))
+	require.Nil(t, w.Stop())
+
+	grp, ok, err := walsForPeriod(managerWalDir(mgr.name, mgr.dir), mgr.period, mgr.period.PeriodFor(now))
+	require.Nil(t, err)
+	require.True(t, ok)
+	require.Nil(t, recoverHead(mgr.name, mgr.dir, mgr.activeHeads, grp.wals, false, log.NewNopLogger(), NewMetrics(nil).walCorruptionsRepairs))
+
+	var recovered index.ChunkMetas
+	require.Nil(t, mgr.activeHeads.forAll(func(u string, _ labels.Labels, _ uint64, c index.ChunkMetas) error {
+		require.Equal(t, user, u)
+		recovered = append(recovered, c...)
+		return nil
+	}))
+	require.Equal(t, chks, recovered)
+}
+
 // test head recover from corrupted wal
 func Test_HeadManager_RecoverHead_CorruptedWAL(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
@@ -46,9 +46,12 @@ const (
 	WalRecordChunksV2
 )
 
-// CurrentChunksRec is the chunks record version this binary writes. Older
-// versions remain readable.
-const CurrentChunksRec = WalRecordChunksV2
+// CurrentChunksRec is the chunks record version this binary writes.
+// Older versions remain readable.
+// To enable safe rollback, the version needs to be change in 2 steps:
+// First, allow v2 decoding but keep v1 encoding.
+// Second, switch current record version to v2 to enable v2 encoding.
+const CurrentChunksRec = WalRecordChunks
 
 type WALRecord struct {
 	UserID      string

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
@@ -41,10 +41,14 @@ const (
 	WalRecordSeries RecordType = iota
 	WalRecordChunks
 	WalRecordSeriesWithFingerprint
-	// WalRecordChunksWithIngestedAt extends WalRecordChunks
-	// with each chunk's index.ChunkMeta.IngestedAt
-	WalRecordChunksWithIngestedAt
+	// WalRecordChunksV2 is WalRecordChunks plus each chunk's
+	// index.ChunkMeta.IngestedAt.
+	WalRecordChunksV2
 )
+
+// CurrentChunksRec is the chunks record version this binary writes. Older
+// versions remain readable.
+const CurrentChunksRec = WalRecordChunksV2
 
 type WALRecord struct {
 	UserID      string
@@ -89,19 +93,12 @@ func (r *WALRecord) encodeSeriesWithFingerprint(b []byte) []byte {
 	return encoded
 }
 
-// encodeChunks encodes the record's chunk metas, picking the record type from
-// the data: records holding at least one non-zero IngestedAt use
-// WalRecordChunksWithIngestedAt, all others keep the original WalRecordChunks
-// layout.
-func (r *WALRecord) encodeChunks(b []byte) []byte {
-	withIngestedAt := hasIngestedAt(r.Chks.Chks)
-
+// encodeChunks encodes the record's chunk metas in the given version's layout.
+// Callers writing to the WAL pass CurrentChunksRec; older versions are only
+// encoded by tests that pin their layout.
+func (r *WALRecord) encodeChunks(version RecordType, b []byte) []byte {
 	buf := encoding.EncWith(b)
-	if withIngestedAt {
-		buf.PutByte(byte(WalRecordChunksWithIngestedAt))
-	} else {
-		buf.PutByte(byte(WalRecordChunks))
-	}
+	buf.PutByte(byte(version))
 	buf.PutUvarintStr(r.UserID)
 	buf.PutBE64(r.Chks.Ref)
 	buf.PutUvarint(len(r.Chks.Chks))
@@ -112,24 +109,15 @@ func (r *WALRecord) encodeChunks(b []byte) []byte {
 		buf.PutBE32(chk.Checksum)
 		buf.PutBE32(chk.KB)
 		buf.PutBE32(chk.Entries)
-		if withIngestedAt {
-			buf.PutUvarint64(uint64(chk.IngestedAt))
+		if version >= WalRecordChunksV2 {
+			buf.PutBE64(uint64(chk.IngestedAt))
 		}
 	}
 
 	return buf.Get()
 }
 
-func hasIngestedAt(chks index.ChunkMetas) bool {
-	for i := range chks {
-		if chks[i].IngestedAt != 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func decodeChunks(b []byte, rec *WALRecord, withIngestedAt bool) error {
+func decodeChunks(b []byte, version RecordType, rec *WALRecord) error {
 	if len(b) == 0 {
 		return nil
 	}
@@ -156,8 +144,8 @@ func decodeChunks(b []byte, rec *WALRecord, withIngestedAt bool) error {
 			KB:       dec.Be32(),
 			Entries:  dec.Be32(),
 		}
-		if withIngestedAt {
-			chk.IngestedAt = int64(dec.Uvarint64())
+		if version >= WalRecordChunksV2 {
+			chk.IngestedAt = dec.Be64int64()
 		}
 		rec.Chks.Chks = append(rec.Chks.Chks, chk)
 	}
@@ -206,9 +194,9 @@ func decodeWALRecord(b []byte, walRec *WALRecord) error {
 		if len(rSeries) == 1 {
 			walRec.Series = rSeries[0]
 		}
-	case WalRecordChunks, WalRecordChunksWithIngestedAt:
+	case WalRecordChunks, WalRecordChunksV2:
 		userID = decbuf.UvarintStr()
-		if err := decodeChunks(decbuf.B, walRec, t == WalRecordChunksWithIngestedAt); err != nil {
+		if err := decodeChunks(decbuf.B, t, walRec); err != nil {
 			return err
 		}
 	default:
@@ -267,7 +255,7 @@ func (w *headWAL) Log(record *WALRecord) error {
 	}
 
 	if len(record.Chks.Chks) > 0 {
-		buf = record.encodeChunks(buf[:0])
+		buf = record.encodeChunks(CurrentChunksRec, buf[:0])
 		if err := w.wal.Log(buf); err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
@@ -41,11 +41,8 @@ const (
 	WalRecordSeries RecordType = iota
 	WalRecordChunks
 	WalRecordSeriesWithFingerprint
-	// WalRecordChunksWithIngestedAt carries the same fields as WalRecordChunks
-	// plus each chunk's index.ChunkMeta.IngestedAt. It exists as a separate type
-	// because WalRecordChunks is decoded as a fixed-width stride until the buffer
-	// drains, so growing that layout would make older binaries misparse the
-	// records written by newer ones.
+	// WalRecordChunksWithIngestedAt extends WalRecordChunks
+	// with each chunk's index.ChunkMeta.IngestedAt
 	WalRecordChunksWithIngestedAt
 )
 
@@ -95,9 +92,7 @@ func (r *WALRecord) encodeSeriesWithFingerprint(b []byte) []byte {
 // encodeChunks encodes the record's chunk metas, picking the record type from
 // the data: records holding at least one non-zero IngestedAt use
 // WalRecordChunksWithIngestedAt, all others keep the original WalRecordChunks
-// layout. Only chunks of backfilled streams under schema v14 carry IngestedAt
-// (see Ingester.maybeSetIngestedAt), so every other deployment keeps writing
-// WALs that a binary predating the new record type can still recover.
+// layout.
 func (r *WALRecord) encodeChunks(b []byte) []byte {
 	withIngestedAt := hasIngestedAt(r.Chks.Chks)
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal.go
@@ -41,6 +41,12 @@ const (
 	WalRecordSeries RecordType = iota
 	WalRecordChunks
 	WalRecordSeriesWithFingerprint
+	// WalRecordChunksWithIngestedAt carries the same fields as WalRecordChunks
+	// plus each chunk's index.ChunkMeta.IngestedAt. It exists as a separate type
+	// because WalRecordChunks is decoded as a fixed-width stride until the buffer
+	// drains, so growing that layout would make older binaries misparse the
+	// records written by newer ones.
+	WalRecordChunksWithIngestedAt
 )
 
 type WALRecord struct {
@@ -86,9 +92,21 @@ func (r *WALRecord) encodeSeriesWithFingerprint(b []byte) []byte {
 	return encoded
 }
 
+// encodeChunks encodes the record's chunk metas, picking the record type from
+// the data: records holding at least one non-zero IngestedAt use
+// WalRecordChunksWithIngestedAt, all others keep the original WalRecordChunks
+// layout. Only chunks of backfilled streams under schema v14 carry IngestedAt
+// (see Ingester.maybeSetIngestedAt), so every other deployment keeps writing
+// WALs that a binary predating the new record type can still recover.
 func (r *WALRecord) encodeChunks(b []byte) []byte {
+	withIngestedAt := hasIngestedAt(r.Chks.Chks)
+
 	buf := encoding.EncWith(b)
-	buf.PutByte(byte(WalRecordChunks))
+	if withIngestedAt {
+		buf.PutByte(byte(WalRecordChunksWithIngestedAt))
+	} else {
+		buf.PutByte(byte(WalRecordChunks))
+	}
 	buf.PutUvarintStr(r.UserID)
 	buf.PutBE64(r.Chks.Ref)
 	buf.PutUvarint(len(r.Chks.Chks))
@@ -99,12 +117,24 @@ func (r *WALRecord) encodeChunks(b []byte) []byte {
 		buf.PutBE32(chk.Checksum)
 		buf.PutBE32(chk.KB)
 		buf.PutBE32(chk.Entries)
+		if withIngestedAt {
+			buf.PutUvarint64(uint64(chk.IngestedAt))
+		}
 	}
 
 	return buf.Get()
 }
 
-func decodeChunks(b []byte, rec *WALRecord) error {
+func hasIngestedAt(chks index.ChunkMetas) bool {
+	for i := range chks {
+		if chks[i].IngestedAt != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeChunks(b []byte, rec *WALRecord, withIngestedAt bool) error {
 	if len(b) == 0 {
 		return nil
 	}
@@ -124,13 +154,17 @@ func decodeChunks(b []byte, rec *WALRecord) error {
 	rec.Chks.Chks = make(index.ChunkMetas, 0, ln)
 
 	for len(dec.B) > 0 && dec.Err() == nil {
-		rec.Chks.Chks = append(rec.Chks.Chks, index.ChunkMeta{
+		chk := index.ChunkMeta{
 			MinTime:  dec.Be64int64(),
 			MaxTime:  dec.Be64int64(),
 			Checksum: dec.Be32(),
 			KB:       dec.Be32(),
 			Entries:  dec.Be32(),
-		})
+		}
+		if withIngestedAt {
+			chk.IngestedAt = int64(dec.Uvarint64())
+		}
+		rec.Chks.Chks = append(rec.Chks.Chks, chk)
 	}
 
 	if err := dec.Err(); err != nil {
@@ -177,9 +211,9 @@ func decodeWALRecord(b []byte, walRec *WALRecord) error {
 		if len(rSeries) == 1 {
 			walRec.Series = rSeries[0]
 		}
-	case WalRecordChunks:
+	case WalRecordChunks, WalRecordChunksWithIngestedAt:
 		userID = decbuf.UvarintStr()
-		if err := decodeChunks(decbuf.B, walRec); err != nil {
+		if err := decodeChunks(decbuf.B, walRec, t == WalRecordChunksWithIngestedAt); err != nil {
 			return err
 		}
 	default:

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
@@ -58,8 +58,8 @@ func Test_Encoding_Chunks(t *testing.T) {
 		want    index.ChunkMetas
 	}{
 		{
-			name:    "current version round-trips the ingestion timestamps",
-			version: CurrentChunksRec,
+			name:    "WalRecordChunksV2 round-trips the ingestion timestamps",
+			version: WalRecordChunksV2,
 			want:    chks,
 		},
 		{

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
+	"github.com/grafana/loki/v3/pkg/util/encoding"
 )
 
 func Test_Encoding_Series(t *testing.T) {
@@ -47,34 +48,100 @@ func Test_Encoding_SeriesWithFingerprint(t *testing.T) {
 }
 
 func Test_Encoding_Chunks(t *testing.T) {
-	record := &WALRecord{
-		UserID: "foo",
-		Chks: ChunkMetasRecord{
-			Ref: 1,
-			Chks: index.ChunkMetas{
-				{
-					Checksum: 1,
-					MinTime:  1,
-					MaxTime:  4,
-					KB:       5,
-					Entries:  6,
-				},
-				{
-					Checksum: 2,
-					MinTime:  5,
-					MaxTime:  10,
-					KB:       7,
-					Entries:  8,
-				},
+	for _, tc := range []struct {
+		name       string
+		chks       index.ChunkMetas
+		wantRecord RecordType
+	}{
+		{
+			name:       "no ingestion timestamps",
+			wantRecord: WalRecordChunks,
+			chks: index.ChunkMetas{
+				{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
+				{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8},
 			},
 		},
-	}
-	buf := record.encodeChunks(nil)
-	decoded := &WALRecord{}
+		{
+			name:       "all chunks carry an ingestion timestamp",
+			wantRecord: WalRecordChunksWithIngestedAt,
+			chks: index.ChunkMetas{
+				{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6, IngestedAt: 1234},
+				{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8, IngestedAt: 5678},
+			},
+		},
+		{
+			name:       "a single ingestion timestamp promotes the whole record",
+			wantRecord: WalRecordChunksWithIngestedAt,
+			chks: index.ChunkMetas{
+				{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
+				{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8, IngestedAt: 5678},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			record := &WALRecord{
+				UserID: "foo",
+				Chks: ChunkMetasRecord{
+					Ref:  1,
+					Chks: tc.chks,
+				},
+			}
+			buf := record.encodeChunks(nil)
+			require.Equal(t, tc.wantRecord, RecordType(buf[0]))
 
-	err := decodeWALRecord(buf, decoded)
-	require.Nil(t, err)
-	require.Equal(t, record, decoded)
+			decoded := &WALRecord{}
+			require.NoError(t, decodeWALRecord(buf, decoded))
+			require.Equal(t, record, decoded)
+		})
+	}
+}
+
+// Test_Encoding_Chunks_LegacyRecord covers the mixed-version case of a rolling
+// restart: WALs written before WalRecordChunksWithIngestedAt existed must still
+// decode, with a zero IngestedAt, and records without ingestion timestamps must
+// still be written in that older layout so a rollback can read them.
+func Test_Encoding_Chunks_LegacyRecord(t *testing.T) {
+	chks := index.ChunkMetas{
+		{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
+		{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8},
+	}
+	record := &WALRecord{
+		UserID: "foo",
+		Chks:   ChunkMetasRecord{Ref: 1, Chks: chks},
+	}
+
+	require.Equal(t, encodeChunksLegacy(record, nil), record.encodeChunks(nil))
+
+	// A legacy record holds no ingestion timestamps, whatever the in-memory metas say.
+	record.Chks.Chks = index.ChunkMetas{
+		{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6, IngestedAt: 1234},
+	}
+	decoded := &WALRecord{}
+	require.NoError(t, decodeWALRecord(encodeChunksLegacy(record, nil), decoded))
+	require.Equal(t, index.ChunkMetas{
+		{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
+	}, decoded.Chks.Chks)
+}
+
+// encodeChunksLegacy is the WalRecordChunks encoder as it existed before
+// WalRecordChunksWithIngestedAt was added. It pins the layout that older
+// binaries wrote, and that both they and current ones must keep reading.
+func encodeChunksLegacy(r *WALRecord, b []byte) []byte {
+	buf := encoding.EncWith(b)
+	buf.PutByte(byte(WalRecordChunks))
+	buf.PutUvarintStr(r.UserID)
+	buf.PutBE64(r.Chks.Ref)
+	buf.PutUvarint(len(r.Chks.Chks))
+
+	for _, chk := range r.Chks.Chks {
+		buf.PutBE64(uint64(chk.MinTime))
+		buf.PutBE64(uint64(chk.MaxTime))
+		buf.PutBE32(chk.Checksum)
+		buf.PutBE32(chk.KB)
+		buf.PutBE32(chk.Entries)
+	}
+
+	return buf.Get()
 }
 
 func Test_HeadWALLog(t *testing.T) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_wal_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
-	"github.com/grafana/loki/v3/pkg/util/encoding"
 )
 
 func Test_Encoding_Series(t *testing.T) {
@@ -48,33 +47,29 @@ func Test_Encoding_SeriesWithFingerprint(t *testing.T) {
 }
 
 func Test_Encoding_Chunks(t *testing.T) {
+	chks := index.ChunkMetas{
+		{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6, IngestedAt: 1234},
+		{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8},
+	}
+
 	for _, tc := range []struct {
-		name       string
-		chks       index.ChunkMetas
-		wantRecord RecordType
+		name    string
+		version RecordType
+		want    index.ChunkMetas
 	}{
 		{
-			name:       "no ingestion timestamps",
-			wantRecord: WalRecordChunks,
-			chks: index.ChunkMetas{
+			name:    "current version round-trips the ingestion timestamps",
+			version: CurrentChunksRec,
+			want:    chks,
+		},
+		{
+			// WALs written by binaries predating WalRecordChunksV2 must keep
+			// decoding; their chunks have no ingestion timestamp.
+			name:    "WalRecordChunks drops the ingestion timestamps",
+			version: WalRecordChunks,
+			want: index.ChunkMetas{
 				{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
 				{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8},
-			},
-		},
-		{
-			name:       "all chunks carry an ingestion timestamp",
-			wantRecord: WalRecordChunksWithIngestedAt,
-			chks: index.ChunkMetas{
-				{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6, IngestedAt: 1234},
-				{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8, IngestedAt: 5678},
-			},
-		},
-		{
-			name:       "a single ingestion timestamp promotes the whole record",
-			wantRecord: WalRecordChunksWithIngestedAt,
-			chks: index.ChunkMetas{
-				{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
-				{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8, IngestedAt: 5678},
 			},
 		},
 	} {
@@ -83,65 +78,19 @@ func Test_Encoding_Chunks(t *testing.T) {
 				UserID: "foo",
 				Chks: ChunkMetasRecord{
 					Ref:  1,
-					Chks: tc.chks,
+					Chks: chks,
 				},
 			}
-			buf := record.encodeChunks(nil)
-			require.Equal(t, tc.wantRecord, RecordType(buf[0]))
+			buf := record.encodeChunks(tc.version, nil)
+			require.Equal(t, tc.version, RecordType(buf[0]))
 
 			decoded := &WALRecord{}
 			require.NoError(t, decodeWALRecord(buf, decoded))
-			require.Equal(t, record, decoded)
+			require.Equal(t, record.UserID, decoded.UserID)
+			require.Equal(t, record.Chks.Ref, decoded.Chks.Ref)
+			require.Equal(t, tc.want, decoded.Chks.Chks)
 		})
 	}
-}
-
-// Test_Encoding_Chunks_LegacyRecord covers the mixed-version case of a rolling
-// restart: WALs written before WalRecordChunksWithIngestedAt existed must still
-// decode, with a zero IngestedAt, and records without ingestion timestamps must
-// still be written in that older layout so a rollback can read them.
-func Test_Encoding_Chunks_LegacyRecord(t *testing.T) {
-	chks := index.ChunkMetas{
-		{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
-		{Checksum: 2, MinTime: 5, MaxTime: 10, KB: 7, Entries: 8},
-	}
-	record := &WALRecord{
-		UserID: "foo",
-		Chks:   ChunkMetasRecord{Ref: 1, Chks: chks},
-	}
-
-	require.Equal(t, encodeChunksLegacy(record, nil), record.encodeChunks(nil))
-
-	// A legacy record holds no ingestion timestamps, whatever the in-memory metas say.
-	record.Chks.Chks = index.ChunkMetas{
-		{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6, IngestedAt: 1234},
-	}
-	decoded := &WALRecord{}
-	require.NoError(t, decodeWALRecord(encodeChunksLegacy(record, nil), decoded))
-	require.Equal(t, index.ChunkMetas{
-		{Checksum: 1, MinTime: 1, MaxTime: 4, KB: 5, Entries: 6},
-	}, decoded.Chks.Chks)
-}
-
-// encodeChunksLegacy is the WalRecordChunks encoder as it existed before
-// WalRecordChunksWithIngestedAt was added. It pins the layout that older
-// binaries wrote, and that both they and current ones must keep reading.
-func encodeChunksLegacy(r *WALRecord, b []byte) []byte {
-	buf := encoding.EncWith(b)
-	buf.PutByte(byte(WalRecordChunks))
-	buf.PutUvarintStr(r.UserID)
-	buf.PutBE64(r.Chks.Ref)
-	buf.PutUvarint(len(r.Chks.Chks))
-
-	for _, chk := range r.Chks.Chks {
-		buf.PutBE64(uint64(chk.MinTime))
-		buf.PutBE64(uint64(chk.MaxTime))
-		buf.PutBE32(chk.Checksum)
-		buf.PutBE32(chk.KB)
-		buf.PutBE32(chk.Entries)
-	}
-
-	return buf.Get()
 }
 
 func Test_HeadWALLog(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

An index built from a WAL-recovered head dropped IngestedAt, so after an ingester restart the index disagreed with the one written for the same chunks by a replica that did not restart. Chunk dedup keys on (MinTime, MaxTime, Checksum), so the zero copy could win during compaction and retention would expire backfilled chunks by their log timestamps instead of their ingestion time.