### PR TITLE
refactor(tracing): Reduce query lifecycle spans

### DIFF
--- a/pkg/querier/queryrange/instrument.go
+++ b/pkg/querier/queryrange/instrument.go
@@ -60,6 +60,11 @@ var _ queryrangebase.Middleware = Tracer{}
 // Wrap implements the queryrangebase.Middleware
 func (t Tracer) Wrap(next queryrangebase.Handler) queryrangebase.Handler {
 	return queryrangebase.HandlerFunc(func(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+		switch r.(type) {
+		case *LokiRequest, *LokiInstantRequest:
+			return next.Do(ctx, r)
+		}
+
 		route := DefaultCodec.Path(r)
 		route = middleware.MakeLabelValue(route)
 		ctx, span := tracer.Start(ctx, route)

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -149,11 +149,7 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 
 			sp.metrics.inflightRequests.Inc()
 
-			ctx, queueSpan := tracer.Start(
-				httpgrpcutil.ExtractSpanFromRequest(ctx, request),
-				"querier_processor_runRequest",
-			)
-			defer queueSpan.End()
+			ctx = httpgrpcutil.ExtractSpanFromRequest(ctx, request)
 
 			logger := util_log.WithContext(ctx, sp.log)
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -23,8 +23,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
@@ -38,8 +36,6 @@ import (
 	lokihttpreq "github.com/grafana/loki/v3/pkg/util/httpreq"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 )
-
-var tracer = otel.Tracer("pkg/scheduler")
 
 const (
 	// NumTokens is 1 since we only need to insert 1 token to be used for leader election purposes.
@@ -231,10 +227,6 @@ type schedulerRequest struct {
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
-	queueSpan trace.Span
-
-	// This is only used for testing.
-	parentSpanContext trace.SpanContext
 }
 
 // FrontendLoop handles connection from frontend.
@@ -375,8 +367,7 @@ func (s *Scheduler) enqueueRequest(frontendContext context.Context, frontendAddr
 
 	now := time.Now()
 
-	req.parentSpanContext = trace.SpanFromContext(ctx).SpanContext()
-	req.ctx, req.queueSpan = tracer.Start(ctx, "queued")
+	req.ctx = ctx
 	req.queueTime = now
 	req.ctxCancel = cancel
 
@@ -451,7 +442,6 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 
 		reqQueueTime := time.Since(r.queueTime)
 		s.queueDuration.Observe(reqQueueTime.Seconds())
-		r.queueSpan.End()
 
 		// Add HTTP header to the request containing the query queue time
 		if r.request != nil {


### PR DESCRIPTION
## What this PR does

- Removes the query-scheduler `queued` span while retaining queue-duration metrics and timing headers.
- Removes the manual `querier_processor_runRequest` span while preserving trace-context extraction.
- Skips the redundant internal route span for range and instant queries, retaining transport/root tracing and `query.Exec`.

## Why

This is part 1 of a four-PR stack reducing Loki trace volume. Analysis in `ops-002` found sampled fanout-heavy queries producing hundreds of thousands of spans and being rejected as `trace_too_large`. These lifecycle spans repeat for every generated subrequest without adding information beyond retained metrics and execution spans.

This PR does not change sampling configuration or query behavior.

## Stack

| Part | Change |
|---|---|
| 1 | This PR: reduce query lifecycle spans |
| 2 | [#24497](https://github.com/grafana/loki/pull/24497): collapse cache and storage tracing spans |
| 3 | [#24498](https://github.com/grafana/loki/pull/24498): deduplicate index-gateway `GetChunkRef` tracing |
| 4 | [#24499](https://github.com/grafana/loki/pull/24499): bound high-fanout query tracing |