### PR TITLE
refactor(storage): Collapse cache and storage tracing spans

### DIFF
--- a/pkg/storage/chunk/cache/instrumented.go
+++ b/pkg/storage/chunk/cache/instrumented.go
@@ -6,11 +6,9 @@ import (
 	instr "github.com/grafana/dskit/instrument"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	attribute "go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	loki_instrument "github.com/grafana/loki/v3/pkg/util/instrument"
 )
 
 // Instrument returns an instrumented cache.
@@ -73,15 +71,8 @@ func (i *instrumentedCache) Store(ctx context.Context, keys []string, bufs [][]b
 	}
 
 	method := i.name + ".store"
-	return instr.CollectedRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
-		sp := trace.SpanFromContext(ctx)
-		sp.SetAttributes(attribute.Int("keys", len(keys)))
-		storeErr := i.Cache.Store(ctx, keys, bufs)
-		if storeErr != nil {
-			sp.SetStatus(codes.Error, storeErr.Error())
-			sp.RecordError(storeErr)
-		}
-		return storeErr
+	return loki_instrument.TimeRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
+		return i.Cache.Store(ctx, keys, bufs)
 	})
 }
 
@@ -94,21 +85,9 @@ func (i *instrumentedCache) Fetch(ctx context.Context, keys []string) ([]string,
 		method   = i.name + ".fetch"
 	)
 
-	err := instr.CollectedRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
-		sp := trace.SpanFromContext(ctx)
-		sp.SetAttributes(attribute.Int("keys requested", len(keys)))
+	err := loki_instrument.TimeRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
 		found, bufs, missing, fetchErr = i.Cache.Fetch(ctx, keys)
-		if fetchErr != nil {
-			sp.SetStatus(codes.Error, fetchErr.Error())
-			sp.RecordError(fetchErr)
-			return fetchErr
-		}
-
-		sp.SetAttributes(
-			attribute.Int("keys found", len(found)),
-			attribute.Int("keys missing", len(keys)-len(found)),
-		)
-		return nil
+		return fetchErr
 	})
 
 	i.fetchedKeys.Add(float64(len(keys)))

--- a/pkg/storage/chunk/client/util/parallel_chunk_fetch.go
+++ b/pkg/storage/chunk/client/util/parallel_chunk_fetch.go
@@ -5,14 +5,10 @@ import (
 	"sync"
 
 	"github.com/go-kit/log/level"
-	"go.opentelemetry.io/otel"
-	attribute "go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
-
-var tracer = otel.Tracer("pkg/storage/chunk/client/util")
 
 var decodeContextPool = sync.Pool{
 	New: func() interface{} {
@@ -22,11 +18,6 @@ var decodeContextPool = sync.Pool{
 
 // GetParallelChunks fetches chunks in parallel (up to maxParallel).
 func GetParallelChunks(ctx context.Context, maxParallel int, chunks []chunk.Chunk, f func(context.Context, *chunk.DecodeContext, chunk.Chunk) (chunk.Chunk, error)) ([]chunk.Chunk, error) {
-	ctx, sp := tracer.Start(ctx, "GetParallelChunks")
-	defer sp.End()
-
-	sp.SetAttributes(attribute.Int("requested", len(chunks)))
-
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -69,7 +60,6 @@ func GetParallelChunks(ctx context.Context, maxParallel int, chunks []chunk.Chun
 		}
 	}
 
-	sp.SetAttributes(attribute.Int("fetched", len(result)))
 	if lastErr != nil {
 		level.Error(util_log.Logger).Log("msg", "error fetching chunks", "err", lastErr)
 	}

--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
@@ -54,6 +56,19 @@ const (
 )
 
 const chunkDecodeParallelism = 16
+
+const (
+	traceRequestedChunks        = "chunkstore.requested_chunks"
+	traceReturnedChunks         = "chunkstore.returned_chunks"
+	traceCacheHits              = "chunkstore.cache_hits"
+	traceCacheMisses            = "chunkstore.cache_misses"
+	traceCacheBytes             = "chunkstore.cache_bytes"
+	traceStorageRequestedChunks = "chunkstore.storage_requested_chunks"
+	traceStorageFetchedChunks   = "chunkstore.storage_fetched_chunks"
+	traceStorageBytes           = "chunkstore.storage_bytes"
+	traceCacheErrors            = "chunkstore.cache_errors"
+	traceStorageErrors          = "chunkstore.storage_errors"
+)
 
 // Fetcher deals with fetching chunk contents from the cache/store,
 // and writing back any misses to the cache.  Also responsible for decoding
@@ -141,15 +156,35 @@ func (c *Fetcher) Client() client.Client {
 }
 
 // FetchChunks fetches a set of chunks from cache and store. Note, returned chunks are not in the same order they are passed in
-func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
+func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) (result []chunk.Chunk, operationErr error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
 	ctx, sp := tracer.Start(ctx, "ChunkStore.FetchChunks")
-	defer sp.End()
-
 	log := spanlogger.FromContext(ctx, util_log.Logger)
 	defer log.Finish()
+
+	var traceStats fetchTraceStats
+	traceStats.requestedChunks = len(chunks)
+	defer func() {
+		sp.SetAttributes(
+			attribute.Int(traceRequestedChunks, traceStats.requestedChunks),
+			attribute.Int(traceReturnedChunks, len(result)),
+			attribute.Int(traceCacheHits, traceStats.cacheHits),
+			attribute.Int(traceCacheMisses, traceStats.cacheMisses),
+			attribute.Int(traceCacheBytes, traceStats.cacheBytes),
+			attribute.Int(traceStorageRequestedChunks, traceStats.storageRequestedChunks),
+			attribute.Int(traceStorageFetchedChunks, traceStats.storageFetchedChunks),
+			attribute.Int(traceStorageBytes, traceStats.storageBytes),
+			attribute.Int(traceCacheErrors, traceStats.cacheErrors),
+			attribute.Int(traceStorageErrors, traceStats.storageErrors),
+		)
+		if operationErr != nil {
+			sp.SetStatus(codes.Error, operationErr.Error())
+			sp.RecordError(operationErr)
+		}
+		sp.End()
+	}()
 
 	// Extend the extendedHandoff to be 10% larger to allow for some overlap because this is a sliding window
 	// and the l1 cache may be oversized enough to allow for some extra chunks
@@ -175,8 +210,11 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 	// Fetch from L1 chunk cache
 	cacheHits, cacheBufs, _, l1CacheErr := c.cache.Fetch(ctx, keys)
 	if l1CacheErr != nil {
+		traceStats.cacheErrors++
 		level.Warn(log).Log("msg", "error fetching from cache", "err", l1CacheErr)
 	}
+	traceStats.cacheHits += len(cacheHits)
+	traceStats.cacheBytes += cacheBufferBytes(cacheBufs)
 
 	for _, buf := range cacheBufs {
 		chunkFetchedSize.WithLabelValues("cache").Observe(float64(len(buf)))
@@ -196,8 +234,11 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 
 		cacheHitsL2, cacheBufsL2, _, err := c.cachel2.Fetch(ctx, missingL1Keys)
 		if err != nil {
+			traceStats.cacheErrors++
 			level.Warn(log).Log("msg", "error fetching from cache", "err", err)
 		}
+		traceStats.cacheHits += len(cacheHitsL2)
+		traceStats.cacheBytes += cacheBufferBytes(cacheBufsL2)
 
 		for _, buf := range cacheBufsL2 {
 			chunkFetchedSize.WithLabelValues("cache_l2").Observe(float64(len(buf)))
@@ -211,8 +252,11 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 	// missing chunks that we need to fetch from the storage layer
 	fromCache, missing, cacheDecodeErr := c.processCacheResponse(ctx, chunks, cacheHits, cacheBufs)
 	if cacheDecodeErr != nil {
+		traceStats.cacheErrors++
 		level.Warn(log).Log("msg", "error process response from cache", "err", cacheDecodeErr)
 	}
+	traceStats.cacheMisses = len(missing)
+	traceStats.storageRequestedChunks = len(missing)
 
 	var (
 		fromStorage []chunk.Chunk
@@ -231,12 +275,15 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 
 		chunkFetchedSize.WithLabelValues("store").Observe(float64(size))
 	}
+	traceStats.storageFetchedChunks = len(fromStorage)
+	traceStats.storageBytes = bytes
 
 	st := stats.FromContext(ctx)
 	st.AddCacheEntriesStored(stats.ChunkCache, len(fromStorage))
 	st.AddCacheBytesSent(stats.ChunkCache, bytes)
 
 	if storageErr != nil {
+		traceStats.storageErrors++
 		if !errors.Is(storageErr, context.Canceled) && !errors.Is(storageErr, context.DeadlineExceeded) {
 			storageErrors.WithLabelValues(c.storageErrorReason(storageErr)).Inc()
 			if failures := len(missing) - len(fromStorage); failures > 0 {
@@ -246,18 +293,47 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 		level.Error(log).Log("msg", "failed downloading chunks", "err", storageErr)
 
 		if c.propagateChunkFetchErrors {
-			return nil, storageErr
+			operationErr = storageErr
+			return nil, operationErr
 		}
 	}
 
-	if cacheErr := c.WriteBackCache(ctx, fromStorage); cacheErr != nil {
+	cacheStoreErrors, cacheErr := c.writeBackCache(ctx, fromStorage)
+	traceStats.cacheErrors += cacheStoreErrors
+	if cacheErr != nil {
+		traceStats.cacheErrors++
 		level.Warn(log).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)
 	}
 
 	return append(fromCache, fromStorage...), nil
 }
 
+type fetchTraceStats struct {
+	requestedChunks        int
+	cacheHits              int
+	cacheMisses            int
+	cacheBytes             int
+	storageRequestedChunks int
+	storageFetchedChunks   int
+	storageBytes           int
+	cacheErrors            int
+	storageErrors          int
+}
+
+func cacheBufferBytes(bufs [][]byte) int {
+	bytes := 0
+	for _, buf := range bufs {
+		bytes += len(buf)
+	}
+	return bytes
+}
+
 func (c *Fetcher) WriteBackCache(ctx context.Context, chunks []chunk.Chunk) error {
+	_, err := c.writeBackCache(ctx, chunks)
+	return err
+}
+
+func (c *Fetcher) writeBackCache(ctx context.Context, chunks []chunk.Chunk) (int, error) {
 	keys := make([]string, 0, len(chunks))
 	bufs := make([][]byte, 0, len(chunks))
 	keysL2 := make([]string, 0, len(chunks))
@@ -273,7 +349,7 @@ func (c *Fetcher) WriteBackCache(ctx context.Context, chunks []chunk.Chunk) erro
 			encoded, err = chunks[i].Encoded()
 			// TODO don't fail, just log and continue?
 			if err != nil {
-				return err
+				return 0, err
 			}
 		}
 		// Determine which cache we should write to
@@ -288,18 +364,21 @@ func (c *Fetcher) WriteBackCache(ctx context.Context, chunks []chunk.Chunk) erro
 		}
 	}
 
+	storeErrors := 0
 	err := c.cache.Store(ctx, keys, bufs)
 	if err != nil {
+		storeErrors++
 		level.Warn(util_log.Logger).Log("msg", "writeBackCache cache store fail", "err", err)
 	}
 	if len(keysL2) > 0 {
 		err = c.cachel2.Store(ctx, keysL2, bufsL2)
 		if err != nil {
+			storeErrors++
 			level.Warn(util_log.Logger).Log("msg", "writeBackCacheL2 cache store fail", "err", err)
 		}
 	}
 
-	return nil
+	return storeErrors, nil
 }
 
 // ProcessCacheResponse decodes the chunks coming back from the cache, separating

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -9,11 +9,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/compression"
@@ -321,6 +326,156 @@ func TestFetchChunks_HandlesStorageErrors(t *testing.T) {
 	}
 }
 
+func TestFetchChunksTracing(t *testing.T) {
+	previousProvider := otel.GetTracerProvider()
+	previousTracer := tracer
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	tracer = provider.Tracer("pkg/storage/chunk/fetcher")
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousProvider)
+		tracer = previousTracer
+		_ = provider.Shutdown(context.Background())
+	})
+
+	t.Run("aggregate attributes stay bounded", func(t *testing.T) {
+		for _, count := range []int{2, 64} {
+			t.Run(strconv.Itoa(count), func(t *testing.T) {
+				now := time.Now()
+				fetch := make([]chunk.Chunk, 0, count)
+				for i := 0; i < count; i++ {
+					fetch = append(fetch, makeChunks(now, c{time.Duration(i) * time.Hour, time.Duration(i+1) * time.Hour})...)
+				}
+				sc := testSchemaConfig()
+				rawCache := cache.NewMockCache()
+				cacheChunks := fetch[:count/2]
+				storageChunks := fetch[count/2:]
+				keys := make([]string, 0, len(cacheChunks))
+				bufs := make([][]byte, 0, len(cacheChunks))
+				for _, chk := range cacheChunks {
+					buf, err := chk.Encoded()
+					require.NoError(t, err)
+					keys = append(keys, sc.ExternalKey(chk.ChunkRef))
+					bufs = append(bufs, buf)
+				}
+				require.NoError(t, rawCache.Store(context.Background(), keys, bufs))
+				instrumentedCache := cache.Instrument("fetcher-test", rawCache, prometheus.NewRegistry())
+				rawStorage := testutils.NewInMemoryObjectClient()
+				storage := client.NewClientWithMaxParallel(rawStorage, nil, 1, sc)
+				require.NoError(t, storage.PutChunks(context.Background(), storageChunks))
+				fetcher, err := New(instrumentedCache, cache.NewMockCache(), false, sc, storage, 0, 0, false)
+				require.NoError(t, err)
+				t.Cleanup(fetcher.Stop)
+
+				recorder.Reset()
+				got, err := fetcher.FetchChunks(context.Background(), fetch)
+				require.NoError(t, err)
+				require.Len(t, got, count)
+
+				spans := recorder.Ended()
+				require.Len(t, spans, 1)
+				span := spans[0]
+				require.Equal(t, "ChunkStore.FetchChunks", span.Name())
+				require.Empty(t, span.Events())
+				require.Equal(t, codes.Unset, span.Status().Code)
+				require.Len(t, span.Attributes(), 10)
+				attrs := spanAttributeInts(span)
+				require.Equal(t, int64(count), attrs[traceRequestedChunks])
+				require.Equal(t, int64(count), attrs[traceReturnedChunks])
+				require.Equal(t, int64(count/2), attrs[traceCacheHits])
+				require.Equal(t, int64(count/2), attrs[traceCacheMisses])
+				require.Greater(t, attrs[traceCacheBytes], int64(0))
+				require.Equal(t, int64(count/2), attrs[traceStorageRequestedChunks])
+				require.Equal(t, int64(count/2), attrs[traceStorageFetchedChunks])
+				require.Greater(t, attrs[traceStorageBytes], int64(0))
+				require.Equal(t, int64(0), attrs[traceCacheErrors])
+				require.Equal(t, int64(0), attrs[traceStorageErrors])
+			})
+		}
+	})
+
+	t.Run("propagated storage error", func(t *testing.T) {
+		recorder.Reset()
+		chunks := makeChunks(time.Now(), c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour})
+		storageErr := errors.New("storage failed")
+		storage := &storageErrorClient{err: storageErr, chunks: chunks[:1]}
+		fetcher, err := New(cache.NewMockCache(), cache.NewMockCache(), false, testSchemaConfig(), storage, 0, 0, true)
+		require.NoError(t, err)
+		t.Cleanup(fetcher.Stop)
+
+		got, err := fetcher.FetchChunks(context.Background(), chunks)
+		require.ErrorIs(t, err, storageErr)
+		require.Nil(t, got)
+
+		spans := recorder.Ended()
+		require.Len(t, spans, 1)
+		span := spans[0]
+		require.Equal(t, codes.Error, span.Status().Code)
+		require.Equal(t, storageErr.Error(), span.Status().Description)
+		var recordedException bool
+		for _, event := range span.Events() {
+			if event.Name == "exception" {
+				recordedException = true
+			}
+			require.NotContains(t, event.Name, "chunk")
+		}
+		require.True(t, recordedException)
+		attrs := spanAttributeInts(span)
+		require.Equal(t, int64(2), attrs[traceRequestedChunks])
+		require.Equal(t, int64(0), attrs[traceReturnedChunks])
+		require.Equal(t, int64(2), attrs[traceCacheMisses])
+		require.Equal(t, int64(2), attrs[traceStorageRequestedChunks])
+		require.Equal(t, int64(1), attrs[traceStorageFetchedChunks])
+		require.Equal(t, int64(1), attrs[traceStorageErrors])
+	})
+
+	t.Run("cache store failure is aggregated without changing fetch result", func(t *testing.T) {
+		recorder.Reset()
+		chunks := makeChunks(time.Now(), c{time.Hour, 2 * time.Hour})
+		sc := testSchemaConfig()
+		rawStorage := testutils.NewInMemoryObjectClient()
+		storage := client.NewClientWithMaxParallel(rawStorage, nil, 1, sc)
+		require.NoError(t, storage.PutChunks(context.Background(), chunks))
+		storeErr := errors.New("cache store failed")
+		failingCache := cache.Instrument("fetcher-test-store-error", &storeErrorCache{Cache: cache.NewMockCache(), err: storeErr}, prometheus.NewRegistry())
+		fetcher, err := New(failingCache, cache.NewMockCache(), false, sc, storage, 0, 0, false)
+		require.NoError(t, err)
+		t.Cleanup(fetcher.Stop)
+
+		got, err := fetcher.FetchChunks(context.Background(), chunks)
+		require.NoError(t, err)
+		assertChunks(t, chunks, got)
+
+		spans := recorder.Ended()
+		require.Len(t, spans, 1)
+		span := spans[0]
+		require.Equal(t, "ChunkStore.FetchChunks", span.Name())
+		require.Equal(t, codes.Unset, span.Status().Code)
+		require.Empty(t, span.Events())
+		require.Len(t, span.Attributes(), 10)
+		attrs := spanAttributeInts(span)
+		require.Equal(t, int64(1), attrs[traceRequestedChunks])
+		require.Equal(t, int64(1), attrs[traceReturnedChunks])
+		require.Equal(t, int64(0), attrs[traceCacheHits])
+		require.Equal(t, int64(1), attrs[traceCacheMisses])
+		require.Equal(t, int64(0), attrs[traceCacheBytes])
+		require.Equal(t, int64(1), attrs[traceStorageRequestedChunks])
+		require.Equal(t, int64(1), attrs[traceStorageFetchedChunks])
+		require.Greater(t, attrs[traceStorageBytes], int64(0))
+		require.Equal(t, int64(1), attrs[traceCacheErrors])
+		require.Equal(t, int64(0), attrs[traceStorageErrors])
+	})
+}
+
+func spanAttributeInts(span sdktrace.ReadOnlySpan) map[string]int64 {
+	attrs := make(map[string]int64, len(span.Attributes()))
+	for _, attr := range span.Attributes() {
+		attrs[string(attr.Key)] = attr.Value.AsInt64()
+	}
+	return attrs
+}
+
 func readStorageErrorCounters(t *testing.T) map[string]float64 {
 	t.Helper()
 
@@ -348,6 +503,15 @@ type storageErrorClient struct {
 	err                 error
 	chunks              []chunk.Chunk
 	notFound, retryable bool
+}
+
+type storeErrorCache struct {
+	cache.Cache
+	err error
+}
+
+func (c *storeErrorCache) Store(context.Context, []string, [][]byte) error {
+	return c.err
 }
 
 func (s *storageErrorClient) GetChunks(context.Context, []chunk.Chunk) ([]chunk.Chunk, error) {


### PR DESCRIPTION
## What this PR does

- Keeps one aggregate `ChunkStore.FetchChunks` span.
- Removes nested cache fetch/store spans and the `GetParallelChunks` span.
- Records bounded aggregate cache, storage, byte, result, and error attributes on the retained fetch span.
- Adds regression coverage showing span count remains constant as chunk count grows.

## Why

This is part 2 of a four-PR stack reducing Loki trace volume. Cache and parallel-fetch wrappers repeated for every generated query request and represented a large fraction of oversized traces.

This PR does not change cache behavior, storage behavior, metrics, or sampling configuration.

Depends on [#24496](https://github.com/grafana/loki/pull/24496).

## Stack

| Part | Change |
|---|---|
| 1 | [#24496](https://github.com/grafana/loki/pull/24496): reduce query lifecycle spans |
| 2 | This PR: collapse cache and storage tracing spans |
| 3 | [#24498](https://github.com/grafana/loki/pull/24498): deduplicate index-gateway `GetChunkRef` tracing |
| 4 | [#24499](https://github.com/grafana/loki/pull/24499): bound high-fanout query tracing |
