### PR TITLE
fix(indexgateway): Deduplicate GetChunkRef tracing

### DIFF
--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -149,8 +149,7 @@ func (g *Gateway) SyncIndexStatusHandler(w http.ResponseWriter, _ *http.Request)
 
 func (g *Gateway) GetChunkRef(ctx context.Context, req *logproto.GetChunkRefRequest) (result *logproto.GetChunkRefResponse, err error) {
 	logger := util_log.WithContext(ctx, g.log)
-	ctx, sp := tracer.Start(ctx, "indexgateway.GetChunkRef")
-	defer sp.End()
+	sp := trace.SpanFromContext(ctx)
 
 	instanceID, err := tenant.TenantID(ctx)
 	if err != nil {


### PR DESCRIPTION
## What this PR does

- Removes the duplicate manual `indexgateway.GetChunkRef` span.
- Reuses the automatic gRPC server span from the request context.
- Preserves the existing index and bloom-filter events on that server span.

## Why

This is part 3 of a four-PR stack reducing Loki trace volume. `GetChunkRef` already has automatic gRPC client/server instrumentation, so the manual server-side span duplicates the operation for every request.

This PR does not change RPC behavior or sampling configuration.

Depends on [#24497](https://github.com/grafana/loki/pull/24497).

## Stack

| Part | Change |
|---|---|
| 1 | [#24496](https://github.com/grafana/loki/pull/24496): reduce query lifecycle spans |
| 2 | [#24497](https://github.com/grafana/loki/pull/24497): collapse cache and storage tracing spans |
| 3 | This PR: deduplicate index-gateway `GetChunkRef` tracing |
| 4 | [#24499](https://github.com/grafana/loki/pull/24499): bound high-fanout query tracing |
