### PR TITLE
feat(queryrange): Bound high-fanout tracing

### DIFF
--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 )
@@ -134,7 +135,18 @@ func withoutOffset(query logql.DownstreamQuery) (string, time.Time, time.Time) {
 }
 
 func (in instance) Downstream(ctx context.Context, queries []logql.DownstreamQuery, acc logql.Accumulator) ([]logqlmodel.Result, error) {
+	ctx, recorder, owner := startFanout(ctx, len(queries))
+	if recorder != nil {
+		for _, query := range queries {
+			recorder.addShards(len(query.Params.Shards()))
+		}
+		if owner {
+			defer recorder.finish()
+		}
+	}
+
 	return in.For(ctx, queries, acc, func(qry logql.DownstreamQuery) (logqlmodel.Result, error) {
+		start := time.Now()
 		var req queryrangebase.Request
 		if in.splitAlign {
 			qs, newStart, newEnd := withoutOffset(qry)
@@ -155,9 +167,20 @@ func (in instance) Downstream(ctx context.Context, queries []logql.DownstreamQue
 
 		res, err := in.handler.Do(ctx, req)
 		if err != nil {
+			if recorder != nil {
+				recorder.addRequest(time.Since(start), err, nil)
+			}
 			return logqlmodel.Result{}, err
 		}
-		return ResponseToResult(res)
+		result, err := ResponseToResult(res)
+		if recorder != nil {
+			var responseStats *stats.Result
+			if response, ok := statisticsFromResponse(res); ok && owner {
+				responseStats = &response
+			}
+			recorder.addRequest(time.Since(start), err, responseStats)
+		}
+		return result, err
 	})
 }
 

--- a/pkg/querier/queryrange/fanout_tracing.go
+++ b/pkg/querier/queryrange/fanout_tracing.go
@@ -1,0 +1,205 @@
+package queryrange
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
+)
+
+type fanoutContextKey struct{}
+type fanoutResultOwnerKey struct{}
+
+type fanoutRecorder struct {
+	mu sync.Mutex
+
+	parent trace.Span
+	start  time.Time
+
+	activated bool
+	finished  bool
+
+	plannedRequests      int64
+	observedRequests     int64
+	splits               int64
+	shards               int64
+	chunkRefs            int64
+	chunkDownloads       int64
+	chunkFetchFailures   int64
+	cacheRequests        int64
+	cacheHits            int64
+	cacheMisses          int64
+	cacheBytes           int64
+	cacheDuration        int64
+	requestErrors        int64
+	totalRequestDuration int64
+	maxRequestDuration   int64
+}
+
+func startFanout(ctx context.Context, count int) (context.Context, *fanoutRecorder, bool) {
+	if recorder, ok := ctx.Value(fanoutContextKey{}).(*fanoutRecorder); ok {
+		if recorder.reserve(count) {
+			return suppressedFanoutContext(ctx), recorder, false
+		}
+		return ctx, recorder, false
+	}
+
+	parent := trace.SpanFromContext(ctx)
+	spanContext := parent.SpanContext()
+	if !spanContext.IsValid() {
+		return ctx, nil, false
+	}
+
+	recorder := &fanoutRecorder{parent: parent, start: time.Now()}
+	ctx = context.WithValue(ctx, fanoutContextKey{}, recorder)
+	if recorder.reserve(count) {
+		return suppressedFanoutContext(ctx), recorder, true
+	}
+	return ctx, recorder, true
+}
+
+func suppressedFanoutContext(ctx context.Context) context.Context {
+	// Loki's production sampler is parent-based, so clearing this flag suppresses descendants.
+	spanContext := trace.SpanFromContext(ctx).SpanContext()
+	spanContext = trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    spanContext.TraceID(),
+		SpanID:     spanContext.SpanID(),
+		TraceState: spanContext.TraceState(),
+		TraceFlags: spanContext.TraceFlags() &^ trace.FlagsSampled,
+		Remote:     spanContext.IsRemote(),
+	})
+	return trace.ContextWithSpanContext(ctx, spanContext)
+}
+
+func (r *fanoutRecorder) reserve(count int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.finished {
+		return r.activated
+	}
+	r.plannedRequests += int64(count)
+	if !r.activated && r.plannedRequests > DefaultDownstreamConcurrency {
+		r.activated = true
+	}
+	return r.activated
+}
+
+func (r *fanoutRecorder) addSplits(splits int64) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.finished {
+		r.mu.Unlock()
+		return
+	}
+	r.splits += splits
+	r.mu.Unlock()
+}
+
+func (r *fanoutRecorder) addShards(count int) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.finished {
+		r.mu.Unlock()
+		return
+	}
+	r.shards += int64(count)
+	r.mu.Unlock()
+}
+
+func (r *fanoutRecorder) addRequest(duration time.Duration, err error, result *stats.Result) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.finished {
+		return
+	}
+
+	r.observedRequests++
+	d := int64(duration)
+	r.totalRequestDuration += d
+	if d > r.maxRequestDuration {
+		r.maxRequestDuration = d
+	}
+	if err != nil {
+		r.requestErrors++
+	}
+	if result == nil {
+		return
+	}
+
+	r.chunkRefs += result.TotalChunksRef()
+	r.chunkDownloads += result.TotalChunksDownloaded()
+	r.chunkFetchFailures += result.TotalChunkFetchFailures()
+	for _, cache := range []stats.Cache{
+		result.Caches.Chunk,
+		result.Caches.Index,
+		result.Caches.Result,
+		result.Caches.StatsResult,
+		result.Caches.VolumeResult,
+		result.Caches.SeriesResult,
+		result.Caches.LabelResult,
+		result.Caches.InstantMetricResult,
+		result.Caches.LogResult,
+		result.Caches.TaskResult,
+	} {
+		r.cacheRequests += int64(cache.Requests)
+		r.cacheHits += int64(cache.EntriesFound)
+		misses := int64(cache.EntriesRequested) - int64(cache.EntriesFound)
+		if misses < 0 {
+			misses = 0
+		}
+		r.cacheMisses += misses
+		r.cacheBytes += cache.BytesReceived + cache.BytesSent
+		r.cacheDuration += cache.DownloadTime
+	}
+}
+
+func (r *fanoutRecorder) finish() {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	if r.finished {
+		r.mu.Unlock()
+		return
+	}
+	r.finished = true
+	if !r.activated {
+		r.mu.Unlock()
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.Bool("fanout.aggregate_only", true),
+		attribute.Int("fanout.threshold", DefaultDownstreamConcurrency),
+		attribute.Int64("fanout.planned_downstream_requests", r.plannedRequests),
+		attribute.Int64("fanout.observed_downstream_requests", r.observedRequests),
+		attribute.Int64("fanout.split_count", r.splits),
+		attribute.Int64("fanout.shard_count", r.shards),
+		attribute.Int64("fanout.chunk_refs", r.chunkRefs),
+		attribute.Int64("fanout.chunk_downloads", r.chunkDownloads),
+		attribute.Int64("fanout.chunk_fetch_failures", r.chunkFetchFailures),
+		attribute.Int64("fanout.cache_requests", r.cacheRequests),
+		attribute.Int64("fanout.cache_hits", r.cacheHits),
+		attribute.Int64("fanout.cache_misses", r.cacheMisses),
+		attribute.Int64("fanout.cache_bytes", r.cacheBytes),
+		attribute.Int64("fanout.cache_duration_ns", r.cacheDuration),
+		attribute.Int64("fanout.request_errors", r.requestErrors),
+		attribute.Int64("fanout.total_subrequest_duration_ns", r.totalRequestDuration),
+		attribute.Int64("fanout.max_subrequest_duration_ns", r.maxRequestDuration),
+		attribute.Int64("fanout.duration_ns", time.Since(r.start).Nanoseconds()),
+	}
+	parent := r.parent
+	r.mu.Unlock()
+	parent.SetAttributes(attrs...)
+}

--- a/pkg/querier/queryrange/fanout_tracing_test.go
+++ b/pkg/querier/queryrange/fanout_tracing_test.go
@@ -400,7 +400,7 @@ func TestFanoutTracingAggregatesStatsAndPreservesLogTraceID(t *testing.T) {
 	fanout.addRequest(3*time.Millisecond, context.Canceled, nil)
 
 	var output bytes.Buffer
-	log.Logger(util_log.WithContext(suppressed, log.NewLogfmtLogger(&output))).Log("msg", "correlated")
+	util_log.WithContext(suppressed, log.NewLogfmtLogger(&output)).Log("msg", "correlated")
 	require.Contains(t, output.String(), root.SpanContext().TraceID().String())
 
 	fanout.finish()

--- a/pkg/querier/queryrange/fanout_tracing_test.go
+++ b/pkg/querier/queryrange/fanout_tracing_test.go
@@ -1,0 +1,431 @@
+package queryrange
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+func TestFanoutTracingSuppressesChildSpans(t *testing.T) {
+	for _, count := range []int{DefaultDownstreamConcurrency + 1, DefaultDownstreamConcurrency * 4} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(
+				trace.WithSampler(trace.ParentBased(trace.AlwaysSample())),
+				trace.WithSpanProcessor(recorder),
+			)
+			oldTracer := tracer
+			tracer = tp.Tracer("test")
+			t.Cleanup(func() {
+				tracer = oldTracer
+				require.NoError(t, tp.Shutdown(context.Background()))
+			})
+
+			ctx, root := tracer.Start(context.Background(), "root")
+			suppressed, fanout, owner := startFanout(ctx, count)
+			require.True(t, owner)
+			require.NotNil(t, fanout)
+			require.Equal(t, root.SpanContext().TraceID(), oteltrace.SpanFromContext(suppressed).SpanContext().TraceID())
+			require.False(t, oteltrace.SpanFromContext(suppressed).SpanContext().IsSampled())
+			require.Equal(t, root.SpanContext().SpanID(), oteltrace.SpanFromContext(suppressed).SpanContext().SpanID())
+
+			fanout.addSplits(int64(count))
+			fanout.addRequest(time.Millisecond, nil, &stats.Result{})
+			fanout.finish()
+			root.End()
+
+			require.Len(t, recorder.Ended(), 1)
+			attrs := recorder.Ended()[0].Attributes()
+			require.Equal(t, true, attributeValue(attrs, "fanout.aggregate_only"))
+			require.Equal(t, int64(count), attributeValue(attrs, "fanout.planned_downstream_requests"))
+		})
+	}
+}
+
+type fanoutTestSplitter struct{ requests []queryrangebase.Request }
+
+type fanoutCompletionHandler struct {
+	next queryrangebase.Handler
+	done func(queryrangebase.Request)
+}
+
+func (h fanoutCompletionHandler) Do(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+	resp, err := h.next.Do(ctx, req)
+	h.done(req)
+	return resp, err
+}
+
+func (s fanoutTestSplitter) split(time.Time, []string, queryrangebase.Request, time.Duration) []queryrangebase.Request {
+	return s.requests
+}
+
+func TestFanoutTracingThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		count      int
+		suppressed bool
+	}{
+		{name: "below", count: DefaultDownstreamConcurrency, suppressed: false},
+		{name: "above", count: DefaultDownstreamConcurrency + 1, suppressed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+			oldTracer := tracer
+			tracer = tp.Tracer("test")
+			t.Cleanup(func() { tracer = oldTracer; require.NoError(t, tp.Shutdown(context.Background())) })
+
+			ctx, root := tracer.Start(context.Background(), "root")
+			childCtx, child := tracer.Start(startFanoutContext(ctx, tc.count), "child")
+			child.End()
+			root.End()
+			ended := recorder.Ended()
+			if tc.suppressed {
+				require.Len(t, ended, 1)
+				require.Equal(t, true, attributeValue(ended[0].Attributes(), "fanout.aggregate_only"))
+			} else {
+				require.Len(t, ended, 2)
+				require.Nil(t, attributeValue(ended[1].Attributes(), "fanout.aggregate_only"))
+			}
+			require.Equal(t, tc.suppressed, !oteltrace.SpanFromContext(childCtx).SpanContext().IsSampled())
+		})
+	}
+}
+
+func TestFanoutTracingDormantRecorderFinalization(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+	oldTracer := tracer
+	tracer = tp.Tracer("test")
+	t.Cleanup(func() { tracer = oldTracer; require.NoError(t, tp.Shutdown(context.Background())) })
+
+	ctx, root := tracer.Start(context.Background(), "root")
+	_, fanout, owner := startFanout(ctx, DefaultDownstreamConcurrency)
+	require.True(t, owner)
+	require.False(t, fanout.activated)
+	fanout.finish()
+	require.True(t, fanout.finished)
+	require.False(t, fanout.reserve(DefaultDownstreamConcurrency+1))
+	fanout.addSplits(DefaultDownstreamConcurrency + 1)
+	fanout.addShards(DefaultDownstreamConcurrency + 1)
+	fanout.addRequest(time.Millisecond, context.Canceled, nil)
+	fanout.finish()
+	root.End()
+
+	require.Len(t, recorder.Ended(), 1)
+	require.Nil(t, attributeValue(recorder.Ended()[0].Attributes(), "fanout.aggregate_only"))
+}
+
+func startFanoutContext(ctx context.Context, count int) context.Context {
+	ctx, recorder, _ := startFanout(ctx, count)
+	if recorder != nil {
+		defer recorder.finish()
+	}
+	return ctx
+}
+
+func TestComposedFanoutTracingBudget(t *testing.T) {
+	for _, counts := range []struct{ splits, downstream int }{{16, 16}, {32, 32}} {
+		t.Run(strconv.Itoa(counts.splits*counts.downstream), func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+			oldTracer := tracer
+			tracer = tp.Tracer("test")
+			t.Cleanup(func() { tracer = oldTracer; require.NoError(t, tp.Shutdown(context.Background())) })
+
+			params, err := logql.NewLiteralParams(`{app="test"}`, time.Now(), time.Now(), 0, 0, logproto.BACKWARD, 0, nil, nil)
+			require.NoError(t, err)
+			downstreamQueries := make([]logql.DownstreamQuery, counts.downstream)
+			for i := range downstreamQueries {
+				downstreamQueries[i] = logql.DownstreamQuery{Params: params}
+			}
+			downstreamHandler := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				_, child := tracer.Start(ctx, "handler-child")
+				child.AddEvent("handler-event")
+				child.End()
+				return &LokiResponse{}, nil
+			})
+			instance := (&DownstreamHandler{next: downstreamHandler}).Downstreamer(context.Background()).(*instance)
+			handler := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				_, err := instance.Downstream(ctx, downstreamQueries, logql.NewBufferedAccumulator(len(downstreamQueries)))
+				return &LokiResponse{}, err
+			})
+			request := &LokiRequest{StartTs: time.Now().Add(-time.Hour), EndTs: time.Now()}
+			intervals := make([]queryrangebase.Request, counts.splits)
+			for i := range intervals {
+				intervals[i] = request
+			}
+			wrapped := SplitByIntervalMiddleware(nil, fakeLimits{splitDuration: map[string]time.Duration{"test": time.Minute}}, DefaultCodec, fanoutTestSplitter{requests: intervals}, nil).Wrap(handler)
+			ctx := user.InjectOrgID(context.Background(), "test")
+			ctx, root := tracer.Start(ctx, "root")
+			_, err = wrapped.Do(ctx, request)
+			require.NoError(t, err)
+			root.End()
+
+			ended := recorder.Ended()
+			require.LessOrEqual(t, len(ended), 2*DefaultDownstreamConcurrency+1)
+			totalEvents := 0
+			for _, span := range ended {
+				totalEvents += len(span.Events())
+			}
+			require.LessOrEqual(t, totalEvents, 2*DefaultDownstreamConcurrency)
+			rootSpan := ended[len(ended)-1]
+			require.Equal(t, true, attributeValue(rootSpan.Attributes(), "fanout.aggregate_only"))
+			require.Equal(t, int64(counts.splits+counts.splits*counts.downstream), attributeValue(rootSpan.Attributes(), "fanout.planned_downstream_requests"))
+		})
+	}
+}
+
+func TestSplitFanoutTracingEarlyLimitIgnoresCanceledSibling(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+	testTracer := tp.Tracer("test")
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+
+	secondStarted := make(chan struct{})
+	var secondOnce sync.Once
+	siblingDone := make(chan struct{})
+	var siblingDoneOnce sync.Once
+	firstStart := time.Now().Add(-time.Hour)
+	handler := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if req.GetStart().Equal(firstStart) {
+			<-secondStarted
+			return &LokiResponse{
+				Data:       LokiData{Result: []logproto.Stream{{Entries: []logproto.Entry{{Line: "accepted"}}}}},
+				Statistics: stats.Result{Querier: stats.Querier{Store: stats.Store{TotalChunksRef: 7}}},
+			}, nil
+		}
+		secondOnce.Do(func() { close(secondStarted) })
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	request := &LokiRequest{StartTs: firstStart, EndTs: time.Now(), Limit: 1}
+	intervals := make([]queryrangebase.Request, DefaultDownstreamConcurrency+1)
+	for i := range intervals {
+		intervals[i] = &LokiRequest{StartTs: firstStart.Add(time.Duration(i)), EndTs: request.EndTs, Limit: 1}
+	}
+	completedHandler := fanoutCompletionHandler{next: handler, done: func(req queryrangebase.Request) {
+		if !req.GetStart().Equal(firstStart) {
+			siblingDoneOnce.Do(func() { close(siblingDone) })
+		}
+	}}
+	wrapped := SplitByIntervalMiddleware(testSchemas, fakeLimits{
+		maxQueryParallelism: 2,
+		splitDuration:       map[string]time.Duration{"test": time.Minute},
+	}, DefaultCodec, fanoutTestSplitter{requests: intervals}, nil).Wrap(completedHandler)
+	ctx := user.InjectOrgID(context.Background(), "test")
+	ctx, root := testTracer.Start(ctx, "root")
+	_, err := wrapped.Do(ctx, request)
+	require.NoError(t, err)
+	<-siblingDone
+	root.End()
+
+	require.Len(t, recorder.Ended(), 1)
+	attrs := recorder.Ended()[0].Attributes()
+	require.Equal(t, int64(0), attributeValue(attrs, "fanout.request_errors"))
+	require.Equal(t, int64(1), attributeValue(attrs, "fanout.observed_downstream_requests"))
+	require.Equal(t, int64(7), attributeValue(attrs, "fanout.chunk_refs"))
+}
+
+func TestDownstreamFanoutTracingSuppressesHandlerSpans(t *testing.T) {
+	for _, count := range []int{DefaultDownstreamConcurrency + 1, DefaultDownstreamConcurrency * 4} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+			oldTracer := tracer
+			tracer = tp.Tracer("test")
+			t.Cleanup(func() { tracer = oldTracer; require.NoError(t, tp.Shutdown(context.Background())) })
+
+			params, err := logql.NewLiteralParams(`{app="test"}`, time.Now(), time.Now(), 0, 0, logproto.BACKWARD, 0, nil, nil)
+			require.NoError(t, err)
+			queries := make([]logql.DownstreamQuery, count)
+			for i := range queries {
+				queries[i] = logql.DownstreamQuery{Params: params}
+			}
+			handler := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				_, child := tracer.Start(ctx, "handler-child")
+				child.AddEvent("handler-event")
+				child.End()
+				return &LokiResponse{}, nil
+			})
+			instance := (&DownstreamHandler{next: handler}).Downstreamer(context.Background()).(*instance)
+			ctx, root := tracer.Start(context.Background(), "root")
+			_, err = instance.Downstream(ctx, queries, logql.NewBufferedAccumulator(len(queries)))
+			require.NoError(t, err)
+			root.End()
+			require.Len(t, recorder.Ended(), 1)
+			require.Empty(t, recorder.Ended()[0].Events())
+			attrs := recorder.Ended()[0].Attributes()
+			require.Equal(t, true, attributeValue(attrs, "fanout.aggregate_only"))
+			require.Equal(t, int64(count), attributeValue(attrs, "fanout.planned_downstream_requests"))
+		})
+	}
+}
+
+func TestSplitFanoutTracingSuppressesIntervalSpans(t *testing.T) {
+	for _, count := range []int{DefaultDownstreamConcurrency + 1, DefaultDownstreamConcurrency * 4} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+			oldTracer := tracer
+			tracer = tp.Tracer("test")
+			t.Cleanup(func() { tracer = oldTracer; require.NoError(t, tp.Shutdown(context.Background())) })
+
+			request := &LokiRequest{StartTs: time.Now().Add(-time.Hour), EndTs: time.Now()}
+			intervals := make([]queryrangebase.Request, count)
+			for i := range intervals {
+				intervals[i] = request
+			}
+			handler := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				_, child := tracer.Start(ctx, "handler-child")
+				child.AddEvent("handler-event")
+				child.End()
+				return &LokiResponse{}, nil
+			})
+			middleware := SplitByIntervalMiddleware(nil, fakeLimits{splitDuration: map[string]time.Duration{"test": time.Minute}}, DefaultCodec, fanoutTestSplitter{requests: intervals}, nil)
+			wrapped := middleware.Wrap(handler)
+			ctx := user.InjectOrgID(context.Background(), "test")
+			ctx, root := tracer.Start(ctx, "root")
+			_, err := wrapped.Do(ctx, request)
+			require.NoError(t, err)
+			root.End()
+			ended := recorder.Ended()
+			require.Len(t, ended, 1)
+			require.Empty(t, ended[0].Events())
+			attrs := ended[0].Attributes()
+			require.Equal(t, true, attributeValue(attrs, "fanout.aggregate_only"))
+			require.Equal(t, int64(count), attributeValue(attrs, "fanout.planned_downstream_requests"))
+			require.Equal(t, int64(count), attributeValue(attrs, "fanout.split_count"))
+		})
+	}
+}
+
+func TestShardResolverFanoutTracingSuppressesHandlerSpans(t *testing.T) {
+	for _, count := range []int{DefaultDownstreamConcurrency + 1, DefaultDownstreamConcurrency * 4} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+			oldTracer := tracer
+			tracer = tp.Tracer("test")
+			t.Cleanup(func() { tracer = oldTracer; require.NoError(t, tp.Shutdown(context.Background())) })
+
+			matcherGroups := make([]syntax.MatcherRange, count)
+			handler := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				_, child := tracer.Start(ctx, "handler-child")
+				child.AddEvent("handler-event")
+				child.End()
+				return &IndexStatsResponse{Response: &logproto.IndexStatsResponse{}}, nil
+			})
+			ctx, root := tracer.Start(context.Background(), "root")
+			_, err := getStatsForMatchers(ctx, log.NewNopLogger(), handler, model.Time(0), model.Time(1), matcherGroups, 16, time.Minute)
+			require.NoError(t, err)
+			root.End()
+			require.Len(t, recorder.Ended(), 1)
+			require.Empty(t, recorder.Ended()[0].Events())
+			attrs := recorder.Ended()[0].Attributes()
+			require.Equal(t, int64(count), attributeValue(attrs, "fanout.planned_downstream_requests"))
+		})
+	}
+}
+
+func TestShardResolverFanoutTracingCountsResponseTypeErrors(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSampler(trace.ParentBased(trace.AlwaysSample())), trace.WithSpanProcessor(recorder))
+	oldTracer := tracer
+	tracer = tp.Tracer("test")
+	t.Cleanup(func() { tracer = oldTracer; require.NoError(t, tp.Shutdown(context.Background())) })
+
+	matcherGroups := make([]syntax.MatcherRange, DefaultDownstreamConcurrency+1)
+	handler := queryrangebase.HandlerFunc(func(context.Context, queryrangebase.Request) (queryrangebase.Response, error) {
+		return &LokiResponse{}, nil
+	})
+	ctx, root := tracer.Start(context.Background(), "root")
+	_, err := getStatsForMatchers(ctx, log.NewNopLogger(), handler, model.Time(0), model.Time(1), matcherGroups, 1, time.Minute)
+	require.Error(t, err)
+	root.End()
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	require.Equal(t, int64(1), attributeValue(ended[0].Attributes(), "fanout.request_errors"))
+}
+
+func TestFanoutTracingAggregatesStatsAndPreservesLogTraceID(t *testing.T) {
+	spans := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(
+		trace.WithSampler(trace.ParentBased(trace.AlwaysSample())),
+		trace.WithSpanProcessor(spans),
+	)
+	oldTracer := tracer
+	tracer = tp.Tracer("test")
+	t.Cleanup(func() {
+		tracer = oldTracer
+		require.NoError(t, tp.Shutdown(context.Background()))
+	})
+
+	ctx, root := tracer.Start(context.Background(), "root")
+	suppressed, fanout, owner := startFanout(ctx, DefaultDownstreamConcurrency+1)
+	require.True(t, owner)
+	require.False(t, oteltrace.SpanFromContext(suppressed).SpanContext().IsSampled())
+	result := &stats.Result{}
+	result.Querier.Store.TotalChunksRef = 3
+	result.Querier.Store.TotalChunksDownloaded = 2
+	result.Querier.Store.ChunkFetchFailures = 1
+	result.Caches.Chunk.Requests = 4
+	result.Caches.Chunk.EntriesFound = 3
+	result.Caches.Chunk.EntriesRequested = 5
+	result.Caches.Chunk.BytesReceived = 10
+	result.Caches.Chunk.BytesSent = 20
+	result.Caches.Chunk.DownloadTime = int64(7)
+	fanout.addSplits(3)
+	fanout.addShards(4)
+	fanout.addRequest(2*time.Millisecond, nil, result)
+	fanout.addRequest(3*time.Millisecond, context.Canceled, nil)
+
+	var output bytes.Buffer
+	log.Logger(util_log.WithContext(suppressed, log.NewLogfmtLogger(&output))).Log("msg", "correlated")
+	require.Contains(t, output.String(), root.SpanContext().TraceID().String())
+
+	fanout.finish()
+	root.End()
+	require.Len(t, spans.Ended(), 1)
+	attrs := spans.Ended()[0].Attributes()
+	require.Equal(t, int64(DefaultDownstreamConcurrency+1), attributeValue(attrs, "fanout.planned_downstream_requests"))
+	require.Equal(t, int64(3), attributeValue(attrs, "fanout.split_count"))
+	require.Equal(t, int64(4), attributeValue(attrs, "fanout.shard_count"))
+	require.Equal(t, int64(3), attributeValue(attrs, "fanout.chunk_refs"))
+	require.Equal(t, int64(2), attributeValue(attrs, "fanout.chunk_downloads"))
+	require.Equal(t, int64(1), attributeValue(attrs, "fanout.chunk_fetch_failures"))
+	require.Equal(t, int64(4), attributeValue(attrs, "fanout.cache_requests"))
+	require.Equal(t, int64(3), attributeValue(attrs, "fanout.cache_hits"))
+	require.Equal(t, int64(2), attributeValue(attrs, "fanout.cache_misses"))
+	require.Equal(t, int64(30), attributeValue(attrs, "fanout.cache_bytes"))
+	require.Equal(t, int64(7), attributeValue(attrs, "fanout.cache_duration_ns"))
+	require.Equal(t, int64(1), attributeValue(attrs, "fanout.request_errors"))
+}
+
+func attributeValue(attrs []attribute.KeyValue, key string) any {
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsInterface()
+		}
+	}
+	return nil
+}

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -78,9 +78,16 @@ func getStatsForMatchers(
 	defaultLookback time.Duration,
 ) ([]*stats.Stats, error) {
 	startTime := time.Now()
+	ctx, recorder, owner := startFanout(ctx, len(matcherGroups))
+	if recorder != nil {
+		if owner {
+			defer recorder.finish()
+		}
+	}
 
 	results := make([]*stats.Stats, len(matcherGroups))
 	if err := concurrency.ForEachJob(ctx, len(matcherGroups), parallelism, func(ctx context.Context, i int) error {
+		requestStart := time.Now()
 		matchers := syntax.MatchersString(matcherGroups[i].Matchers)
 		diff := matcherGroups[i].Interval + matcherGroups[i].Offset
 		adjustedFrom := start.Add(-diff)
@@ -100,12 +107,22 @@ func getStatsForMatchers(
 			Matchers: matchers,
 		})
 		if err != nil {
+			if recorder != nil {
+				recorder.addRequest(time.Since(requestStart), err, nil)
+			}
 			return err
 		}
 
 		casted, ok := resp.(*IndexStatsResponse)
 		if !ok {
-			return fmt.Errorf("expected *IndexStatsResponse while querying index, got %T", resp)
+			err := fmt.Errorf("expected *IndexStatsResponse while querying index, got %T", resp)
+			if recorder != nil {
+				recorder.addRequest(time.Since(requestStart), err, nil)
+			}
+			return err
+		}
+		if recorder != nil {
+			recorder.addRequest(time.Since(requestStart), nil, nil)
 		}
 
 		results[i] = casted.Response

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -144,8 +144,9 @@ func (h *splitByInterval) Process(
 
 	// per request wrapped handler for limiting the amount of series.
 	next := newSeriesLimiter(maxSeries).Wrap(h.next)
+	requestTracer := tracer
 	for i := 0; i < p; i++ {
-		go h.loop(ctx, ch, next)
+		go h.loop(ctx, ch, next, requestTracer)
 	}
 	recorder, _ := ctx.Value(fanoutContextKey{}).(*fanoutRecorder)
 	recordResults, _ := ctx.Value(fanoutResultOwnerKey{}).(bool)
@@ -205,10 +206,10 @@ func (h *splitByInterval) Process(
 	return responses, nil
 }
 
-func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult, next queryrangebase.Handler) {
+func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult, next queryrangebase.Handler, requestTracer trace.Tracer) {
 	for data := range ch {
 		start := time.Now()
-		ctx, sp := tracer.Start(ctx, "interval")
+		ctx, sp := requestTracer.Start(ctx, "interval")
 		if sp.SpanContext().IsSampled() {
 			data.req.LogToSpan(sp)
 		}

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -29,8 +29,9 @@ type lokiResult struct {
 }
 
 type packedResp struct {
-	resp queryrangebase.Response
-	err  error
+	resp     queryrangebase.Response
+	err      error
+	duration time.Duration
 }
 
 // joinPartialFromResponses keeps the usage of already-completed responses when
@@ -146,6 +147,8 @@ func (h *splitByInterval) Process(
 	for i := 0; i < p; i++ {
 		go h.loop(ctx, ch, next)
 	}
+	recorder, _ := ctx.Value(fanoutContextKey{}).(*fanoutRecorder)
+	recordResults, _ := ctx.Value(fanoutResultOwnerKey{}).(bool)
 
 	for _, x := range input {
 		select {
@@ -156,6 +159,13 @@ func (h *splitByInterval) Process(
 			joinPartialFromResponses(ctx, responses)
 			return nil, context.Cause(ctx)
 		case data := <-x.ch:
+			if recorder != nil {
+				var result *stats.Result
+				if responseStats, ok := statisticsFromResponse(data.resp); ok && recordResults {
+					result = &responseStats
+				}
+				recorder.addRequest(data.duration, data.err, result)
+			}
 			if data.err != nil {
 				// Keep the usage of the intervals that completed before the failure.
 				joinPartialFromResponses(ctx, responses)
@@ -197,7 +207,7 @@ func (h *splitByInterval) Process(
 
 func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult, next queryrangebase.Handler) {
 	for data := range ch {
-
+		start := time.Now()
 		ctx, sp := tracer.Start(ctx, "interval")
 		if sp.SpanContext().IsSampled() {
 			data.req.LogToSpan(sp)
@@ -209,7 +219,7 @@ func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult, next 
 		select {
 		case <-ctx.Done():
 			return
-		case data.ch <- &packedResp{resp, err}:
+		case data.ch <- &packedResp{resp: resp, err: err, duration: time.Since(start)}:
 			// The parent Process method will return on the first error. So stop
 			// processng.
 			if err != nil {
@@ -251,6 +261,17 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrangebase.Request) (que
 
 	if len(intervals) == 1 {
 		return h.next.Do(ctx, intervals[0])
+	}
+
+	var recorder *fanoutRecorder
+	var owner bool
+	ctx, recorder, owner = startFanout(ctx, len(intervals))
+	ctx = context.WithValue(ctx, fanoutResultOwnerKey{}, recorder == nil || owner)
+	if recorder != nil {
+		recorder.addSplits(int64(len(intervals)))
+		if owner {
+			defer recorder.finish()
+		}
 	}
 
 	var limit int64


### PR DESCRIPTION
## What this PR does

- Switches query fanout to aggregate-only tracing after planned work exceeds `DefaultDownstreamConcurrency` (128).
- Preserves trace-ID log correlation while making generated descendant spans non-recording under Loki's parent-based sampler.
- Records bounded `fanout.*` request, split, shard, chunk, cache, error, and duration attributes on the parent span.
- Covers isolated, composed, early-exit, error, threshold, and trace-correlation behavior.
- Captures the tracer before launching split workers to avoid test-time races without changing worker scheduling.

## Why

This is part 4 of a four-PR stack reducing Loki trace volume. A representative 28-day `ops-002` query produced at least 673k Loki spans and a 194 MB trace response. The fanout itself must be bounded so trace size is no longer proportional to generated subrequests.

This PR does not change query results, scheduling semantics, or sampling configuration.

Depends on [#24498](https://github.com/grafana/loki/pull/24498).

## Stack

| Part | Change |
|---|---|
| 1 | [#24496](https://github.com/grafana/loki/pull/24496): reduce query lifecycle spans |
| 2 | [#24497](https://github.com/grafana/loki/pull/24497): collapse cache and storage tracing spans |
| 3 | [#24498](https://github.com/grafana/loki/pull/24498): deduplicate index-gateway `GetChunkRef` tracing |
| 4 | This PR: bound high-fanout query tracing |
