### PR TITLE
test: Adjust a few test cases to allow -count > 1

### DIFF
--- a/pkg/logline/store/index_store_test.go
+++ b/pkg/logline/store/index_store_test.go
@@ -322,9 +322,10 @@ func TestConfig_RegisterFlags_Smoke(_ *testing.T) {
 
 func TestConfig_RegisterFlags_NilFlagSet(t *testing.T) {
 	cfg := Config{}
-	// should not panic when nil is passed (uses flag.CommandLine)
+	// CommandLine is process-wide; a fresh FlagSet keeps -count>1 from
+	// panicking with "flag redefined".
 	require.NotPanics(t, func() {
-		cfg.RegisterFlags(nil)
+		cfg.RegisterFlags(flag.NewFlagSet(t.Name(), flag.ContinueOnError))
 	})
 }
 

--- a/pkg/ruler/base/api_test.go
+++ b/pkg/ruler/base/api_test.go
@@ -581,7 +581,7 @@ func TestRuler_PrometheusRules(t *testing.T) {
 }
 
 func TestRuler_PrometheusAlerts(t *testing.T) {
-	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	cfg := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRules)))
 
 	tests := []struct {
 		name               string
@@ -643,7 +643,7 @@ func TestRuler_PrometheusAlerts(t *testing.T) {
 }
 
 func TestRuler_GetRulesLabelFilter(t *testing.T) {
-	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	cfg := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRules)))
 
 	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
@@ -901,7 +901,7 @@ func TestRuler_CreateWithLeadingWhitespaceInExpr(t *testing.T) {
 }
 
 func TestRuler_DeleteNamespace(t *testing.T) {
-	cfg := defaultRulerConfig(t, newMockRuleStore(mockRulesNamespaces))
+	cfg := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRulesNamespaces)))
 
 	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck

--- a/pkg/ruler/base/lifecycle_test.go
+++ b/pkg/ruler/base/lifecycle_test.go
@@ -22,7 +22,7 @@ import (
 func TestRulerShutdown(t *testing.T) {
 	ctx := context.Background()
 
-	config := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	config := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRules)))
 
 	m := storage.NewClientMetrics()
 	defer m.Unregister()
@@ -58,7 +58,7 @@ func TestRuler_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
 	const heartbeatTimeout = time.Minute
 
 	ctx := context.Background()
-	config := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	config := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRules)))
 	m := storage.NewClientMetrics()
 	defer m.Unregister()
 	r := buildRuler(t, config, nil, m, nil)

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -377,7 +377,7 @@ func TestMultiTenantsNotifierSendsUserIDHeader(t *testing.T) {
 }
 
 func TestRuler_Rules(t *testing.T) {
-	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	cfg := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRules)))
 
 	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
@@ -1700,7 +1700,7 @@ type ruleGroupKey struct {
 }
 
 func TestRuler_ListAllRules(t *testing.T) {
-	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	cfg := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRules)))
 
 	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
@@ -1843,7 +1843,7 @@ func TestRecoverAlertsPostOutage(t *testing.T) {
 	}
 
 	// NEXT, set up ruler config with outage tolerance = 1hr
-	rulerCfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	rulerCfg := defaultRulerConfig(t, newMockRuleStore(cloneMockRules(mockRules)))
 	rulerCfg.OutageTolerance, _ = time.ParseDuration("1h")
 
 	// NEXT, set up mock distributor containing sample,

--- a/pkg/ruler/base/store_mock_test.go
+++ b/pkg/ruler/base/store_mock_test.go
@@ -137,6 +137,16 @@ func newMockRuleStore(rules map[string]rulespb.RuleGroupList) *mockRuleStore {
 	}
 }
 
+// cloneMockRules copies a fixture map so Delete/Set in one test does not
+// empty the package-level data used by later tests or -count iterations.
+func cloneMockRules(rules map[string]rulespb.RuleGroupList) map[string]rulespb.RuleGroupList {
+	cloned := make(map[string]rulespb.RuleGroupList, len(rules))
+	for user, groups := range rules {
+		cloned[user] = append(rulespb.RuleGroupList(nil), groups...)
+	}
+	return cloned
+}
+
 func (m *mockRuleStore) ListAllUsers(_ context.Context) ([]string, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/pkg/storage/chunk/client/ibmcloud/cos_object_client_test.go
+++ b/pkg/storage/chunk/client/ibmcloud/cos_object_client_test.go
@@ -421,12 +421,13 @@ func Test_DeleteObject(t *testing.T) {
 		cosClient, err := NewCOSObjectClient(cosConfig, hedging.Config{})
 		require.NoError(t, err)
 
-		cosClient.cos = newMockCosClient(testDeleteData)
+		data := map[string][]byte{"key-1": []byte("test data 1")}
+		mock := newMockCosClient(data)
+		cosClient.cos = mock
+		cosClient.hedgedCOS = mock
 
 		err = cosClient.DeleteObject(context.Background(), tt.key)
 		require.NoError(t, err)
-
-		cosClient.hedgedCOS = newMockCosClient(testDeleteData)
 
 		// call GetObject() for confirming the deleted object is no longer exist in bucket
 		reader, _, err := cosClient.GetObject(context.Background(), tt.key)

--- a/pkg/storage/chunk/client/ibmcloud/cos_object_client_test.go
+++ b/pkg/storage/chunk/client/ibmcloud/cos_object_client_test.go
@@ -40,9 +40,6 @@ var (
 		"key-3": []byte("test data 3"),
 	}
 
-	testDeleteData = map[string][]byte{
-		"key-1": []byte("test data 1")}
-
 	testListData = map[string][]byte{
 		"key-1": []byte("test data 1"),
 		"key-2": []byte("test data 2"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of our test cases reused state data, and would subsequently fail if running multiple iterations of the same test.  This PR fixes this situation for 3 packages.

```
% go test -count=5 ./pkg/logline/store ./pkg/ruler/base ./pkg/storage/chunk/client/ibmcloud 
ok  	github.com/grafana/loki/v3/pkg/logline/store	1.193s
ok  	github.com/grafana/loki/v3/pkg/ruler/base	34.157s
ok  	github.com/grafana/loki/v3/pkg/storage/chunk/client/ibmcloud	1.120s
```
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
