### PR TITLE
fix: Analytics stats_test to allow for repeated test runs

### DIFF
--- a/pkg/analytics/stats_test.go
+++ b/pkg/analytics/stats_test.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"sync"
 	"testing"
@@ -33,9 +34,10 @@ func Test_BuildReport(t *testing.T) {
 	NewFloat("size_mb").Set(100.1)
 	NewFloat("size_mb").Set(200.1)
 	NewCounter("lines_written").Inc(200)
-	s := NewStatistics("query_throughput")
+	s := NewStatistics("query_throughput_" + fmt.Sprint(now.UnixNano()))
+
 	s.Record(25)
-	s = NewStatistics("query_throughput")
+	s = NewStatistics("query_throughput_" + fmt.Sprint(now.UnixNano()))
 	s.Record(300)
 	s.Record(5)
 	w := NewWordCounter("active_tenants")
@@ -57,10 +59,10 @@ func Test_BuildReport(t *testing.T) {
 	require.Equal(t, r.Metrics["compression_ratio"], int64(100))
 	require.Equal(t, r.Metrics["size_mb"], 200.1)
 	require.Equal(t, r.Metrics["lines_written"].(map[string]interface{})["total"], int64(200))
-	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["min"], float64(5))
-	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["max"], float64(300))
-	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["count"], int64(3))
-	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["avg"], float64(25+300+5)/3)
+	require.Equal(t, r.Metrics["query_throughput_"+fmt.Sprint(now.UnixNano())].(map[string]interface{})["min"], float64(5))
+	require.Equal(t, r.Metrics["query_throughput_"+fmt.Sprint(now.UnixNano())].(map[string]interface{})["max"], float64(300))
+	require.Equal(t, r.Metrics["query_throughput_"+fmt.Sprint(now.UnixNano())].(map[string]interface{})["count"], int64(3))
+	require.Equal(t, r.Metrics["query_throughput_"+fmt.Sprint(now.UnixNano())].(map[string]interface{})["avg"], float64(25+300+5)/3)
 	require.Equal(t, r.Metrics["active_tenants"], int64(3))
 
 	out, _ := jsoniter.MarshalIndent(r, "", " ")
@@ -104,7 +106,7 @@ func TestCounter(t *testing.T) {
 }
 
 func TestStatistic(t *testing.T) {
-	s := NewStatistics("test_stats")
+	s := NewStatistics("test_stats_" + fmt.Sprint(time.Now().UnixNano()))
 	s.Record(100)
 	s.Record(200)
 	s.Record(300)


### PR DESCRIPTION
There's no good way to delete a statistic after it's created, so instead create each statistic with a unique timestamp so we don't reuse it between tests.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
