### PR TITLE
fix: Delete counter label values before running tests

### DIFF
--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -110,6 +110,7 @@ func TestRecordBytesProcessedTotal(t *testing.T) {
 	now := time.Now()
 	params.start, params.end = now.Add(-1*time.Hour), now
 
+	bytesProcessedTotal.DeleteLabelValues(tenantID)
 	counter := bytesProcessedTotal.WithLabelValues(tenantID)
 
 	RecordRangeAndInstantQueryMetrics(ctx, util_log.Logger, params, "200", result, nil)
@@ -121,6 +122,8 @@ func TestRecordBytesProcessedTotal(t *testing.T) {
 
 	// Federated multi-tenant queries divide the byte total evenly across tenants.
 	fedA, fedB := "record-bytes-fed-a", "record-bytes-fed-b"
+	bytesProcessedTotal.DeleteLabelValues(fedA)
+	bytesProcessedTotal.DeleteLabelValues(fedB)
 	fedCtx := user.InjectOrgID(context.Background(), fmt.Sprintf("%s|%s", fedA, fedB))
 	RecordRangeAndInstantQueryMetrics(fedCtx, util_log.Logger, params, "200", result, nil)
 	require.Equal(t, float64(50000), testutil.ToFloat64(bytesProcessedTotal.WithLabelValues(fedA)))
@@ -146,7 +149,9 @@ func TestRecordChunkFetchFailuresTotal(t *testing.T) {
 	params.start, params.end = now.Add(-1*time.Hour), now
 
 	ctx := context.Background()
+	chunkFetchFailuresTotal.DeleteLabelValues("200", QueryTypeFilter, string(RangeType))
 	failuresCounter := chunkFetchFailuresTotal.WithLabelValues("200", QueryTypeFilter, string(RangeType))
+	queriesWithChunkFetchFailuresTotal.DeleteLabelValues("200", QueryTypeFilter, string(RangeType))
 	affectedCounter := queriesWithChunkFetchFailuresTotal.WithLabelValues("200", QueryTypeFilter, string(RangeType))
 
 	// No failures: neither counter moves.


### PR DESCRIPTION
These counters were reused in between tests, causing failures if the tests were run multiple times.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
