### PR TITLE
fix: extend congestion control to cover object-store writes, not just…

### DIFF
--- a/pkg/storage/chunk/client/congestion/controller.go
+++ b/pkg/storage/chunk/client/congestion/controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
@@ -83,14 +84,32 @@ func (a *AIMDController) withLogger(logger log.Logger) Controller {
 	return a
 }
 
+// PutObject is not retried at this layer: the request body is a single-pass io.Reader, and re-issuing the
+// request after a partial read would silently upload truncated or wrong data. Retries for the write itself are
+// left to the inner client. What congestion control adds here is admission pacing and AIMD feedback: writes wait
+// on the same shared rate limiter as reads, and a throttling error on a write shrinks that limit just like one on
+// a read does, so concurrent writers back off together instead of independently hammering the backend.
 func (a *AIMDController) PutObject(ctx context.Context, objectKey string, object io.Reader) error {
-	return a.inner.PutObject(ctx, objectKey, object)
+	a.metrics.requests.Add(1)
+	a.awaitCapacity()
+
+	err := a.inner.PutObject(ctx, objectKey, object)
+	a.recordOutcome(err)
+	return err
+}
+
+// DeleteObject shares PutObject's reasoning: no retry loop here, just admission pacing and AIMD feedback so
+// deletes and other operations stay coordinated with each other through the shared limiter.
+func (a *AIMDController) DeleteObject(ctx context.Context, objectKey string) error {
+	a.metrics.requests.Add(1)
+	a.awaitCapacity()
+
+	err := a.inner.DeleteObject(ctx, objectKey)
+	a.recordOutcome(err)
+	return err
 }
 
 func (a *AIMDController) GetObject(ctx context.Context, objectKey string) (io.ReadCloser, int64, error) {
-	// Only GetObject implements congestion avoidance; the other methods are either non-idempotent which means they
-	// cannot be retried, or are too low volume to care about
-
 	// TODO(dannyk): use hedging client to handle requests, do NOT hedge retries
 
 	start := time.Now()
@@ -105,15 +124,7 @@ func (a *AIMDController) GetObject(ctx context.Context, objectKey string) (io.Re
 				a.metrics.retries.Add(1)
 			}
 
-			// apply back-pressure while rate-limit has been exceeded
-			//
-			// using Reserve() is slower because it assumes a constant wait time as tokens are replenished, but in experimentation
-			// it's faster to sit in a hot loop and probe every so often if there are tokens available
-			for !a.limiter.Allow() {
-				delay := time.Millisecond * 10
-				time.Sleep(delay)
-				a.metrics.backoffSec.Add(delay.Seconds())
-			}
+			a.awaitCapacity()
 
 			statsCtx.AddCongestionControlLatency(time.Since(start))
 
@@ -133,6 +144,36 @@ func (a *AIMDController) GetObject(ctx context.Context, objectKey string) (io.Re
 	return rc, sz, err
 }
 
+// awaitCapacity blocks until the shared rate limiter has room for another request, applying back-pressure while
+// the throughput limit is exceeded.
+//
+// using Reserve() is slower because it assumes a constant wait time as tokens are replenished, but in
+// experimentation it's faster to sit in a hot loop and probe every so often if there are tokens available.
+func (a *AIMDController) awaitCapacity() {
+	for !a.limiter.Allow() {
+		delay := time.Millisecond * 10
+		time.Sleep(delay)
+		a.metrics.backoffSec.Add(delay.Seconds())
+	}
+}
+
+// recordOutcome feeds a non-retried request's result into the AIMD signal: success grows the shared rate limit,
+// a retryable error shrinks it, and a non-retryable error is left alone since it's not a sign of congestion.
+func (a *AIMDController) recordOutcome(err error) {
+	switch {
+	case err == nil:
+		a.additiveIncrease()
+	case a.IsRetryableErr(err):
+		level.Debug(a.logger).Log("msg", "error is retryable", "err", err)
+		a.multiplicativeDecrease()
+	default:
+		if !errors.Is(err, context.Canceled) {
+			a.metrics.nonRetryableErrors.Add(1)
+			level.Debug(a.logger).Log("msg", "store error is not retryable", "err", err)
+		}
+	}
+}
+
 func (a *AIMDController) GetObjectRange(ctx context.Context, objectKey string, offset, length int64) (io.ReadCloser, error) {
 	return a.inner.GetObjectRange(ctx, objectKey, offset, length)
 }
@@ -147,10 +188,6 @@ func (a *AIMDController) ObjectExists(ctx context.Context, objectKey string) (bo
 
 func (a *AIMDController) GetAttributes(ctx context.Context, objectKey string) (client.ObjectAttributes, error) {
 	return a.inner.GetAttributes(ctx, objectKey)
-}
-
-func (a *AIMDController) DeleteObject(ctx context.Context, objectKey string) error {
-	return a.inner.DeleteObject(ctx, objectKey)
 }
 
 func (a *AIMDController) IsObjectNotFoundErr(err error) bool {

--- a/pkg/storage/chunk/client/congestion/controller.go
+++ b/pkg/storage/chunk/client/congestion/controller.go
@@ -91,7 +91,9 @@ func (a *AIMDController) withLogger(logger log.Logger) Controller {
 // a read does, so concurrent writers back off together instead of independently hammering the backend.
 func (a *AIMDController) PutObject(ctx context.Context, objectKey string, object io.Reader) error {
 	a.metrics.requests.Add(1)
-	a.awaitCapacity()
+	if err := a.awaitCapacity(ctx); err != nil {
+		return err
+	}
 
 	err := a.inner.PutObject(ctx, objectKey, object)
 	a.recordOutcome(err)
@@ -102,7 +104,9 @@ func (a *AIMDController) PutObject(ctx context.Context, objectKey string, object
 // deletes and other operations stay coordinated with each other through the shared limiter.
 func (a *AIMDController) DeleteObject(ctx context.Context, objectKey string) error {
 	a.metrics.requests.Add(1)
-	a.awaitCapacity()
+	if err := a.awaitCapacity(ctx); err != nil {
+		return err
+	}
 
 	err := a.inner.DeleteObject(ctx, objectKey)
 	a.recordOutcome(err)
@@ -124,7 +128,9 @@ func (a *AIMDController) GetObject(ctx context.Context, objectKey string) (io.Re
 				a.metrics.retries.Add(1)
 			}
 
-			a.awaitCapacity()
+			if err := a.awaitCapacity(ctx); err != nil {
+				return nil, 0, err
+			}
 
 			statsCtx.AddCongestionControlLatency(time.Since(start))
 
@@ -145,16 +151,22 @@ func (a *AIMDController) GetObject(ctx context.Context, objectKey string) (io.Re
 }
 
 // awaitCapacity blocks until the shared rate limiter has room for another request, applying back-pressure while
-// the throughput limit is exceeded.
+// the throughput limit is exceeded. It gives up early if ctx is done, since under a shrunk limit this can block
+// for a while and the caller may no longer be waiting for the result.
 //
 // using Reserve() is slower because it assumes a constant wait time as tokens are replenished, but in
 // experimentation it's faster to sit in a hot loop and probe every so often if there are tokens available.
-func (a *AIMDController) awaitCapacity() {
+func (a *AIMDController) awaitCapacity(ctx context.Context) error {
 	for !a.limiter.Allow() {
 		delay := time.Millisecond * 10
-		time.Sleep(delay)
-		a.metrics.backoffSec.Add(delay.Seconds())
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+			a.metrics.backoffSec.Add(delay.Seconds())
+		}
 	}
+	return nil
 }
 
 // recordOutcome feeds a non-retried request's result into the AIMD signal: success grows the shared rate limit,

--- a/pkg/storage/chunk/client/congestion/controller_test.go
+++ b/pkg/storage/chunk/client/congestion/controller_test.go
@@ -224,6 +224,122 @@ func TestAIMDReducedThroughput(t *testing.T) {
 	metrics.Unregister()
 }
 
+func TestPutObjectNotRetried(t *testing.T) {
+	cfg := Config{
+		Controller: ControllerConfig{
+			Strategy: "aimd",
+		},
+		Retry: RetrierConfig{
+			// even with retries configured, PutObject must not use them: it has no way to safely
+			// re-issue a request after the body has been partially consumed.
+			Strategy: "limited",
+			Limit:    2,
+		},
+	}
+
+	metrics := NewMetrics(t.Name(), cfg, nil)
+	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
+
+	// fail every request
+	cli := newMockObjectClient(maxFailer{max: 0})
+	ctrl.Wrap(cli)
+
+	err := ctrl.PutObject(context.Background(), "foo", strings.NewReader("body"))
+	require.ErrorIs(t, err, errFakeFailure)
+
+	// exactly one call reached the inner client; no retries were attempted
+	require.EqualValues(t, 1, testutil.ToFloat64(metrics.requests))
+	require.EqualValues(t, 0, testutil.ToFloat64(metrics.retries))
+	metrics.Unregister()
+}
+
+func TestPutObjectFeedsAIMDSignal(t *testing.T) {
+	cfg := Config{
+		Controller: ControllerConfig{
+			Strategy: "aimd",
+			AIMD: AIMD{
+				Start:         10,
+				UpperBound:    100,
+				BackoffFactor: 0.5,
+			},
+		},
+	}
+
+	metrics := NewMetrics(t.Name(), cfg, nil)
+	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
+	require.EqualValues(t, 10, testutil.ToFloat64(metrics.currentLimit))
+
+	// first call succeeds: limit grows
+	cli := newMockObjectClient(maxFailer{max: 1})
+	ctrl.Wrap(cli)
+
+	require.NoError(t, ctrl.PutObject(context.Background(), "foo", strings.NewReader("body")))
+	require.EqualValues(t, 11, testutil.ToFloat64(metrics.currentLimit))
+
+	// subsequent calls fail with a retryable error: limit shrinks
+	err := ctrl.PutObject(context.Background(), "foo", strings.NewReader("body"))
+	require.ErrorIs(t, err, errFakeFailure)
+	require.EqualValues(t, 6, testutil.ToFloat64(metrics.currentLimit))
+	metrics.Unregister()
+}
+
+func TestPutObjectNonRetryableErrDoesNotAffectLimit(t *testing.T) {
+	cfg := Config{
+		Controller: ControllerConfig{
+			Strategy: "aimd",
+			AIMD: AIMD{
+				Start:      10,
+				UpperBound: 100,
+			},
+		},
+	}
+
+	metrics := NewMetrics(t.Name(), cfg, nil)
+	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
+
+	cli := newMockObjectClient(maxFailer{max: 0})
+	cli.nonRetryableErrs = true
+	ctrl.Wrap(cli)
+
+	err := ctrl.PutObject(context.Background(), "foo", strings.NewReader("body"))
+	require.ErrorIs(t, err, errFakeFailure)
+
+	// the shared limit is untouched, and it's the same signal reads share
+	require.EqualValues(t, 10, testutil.ToFloat64(metrics.currentLimit))
+	require.EqualValues(t, 1, testutil.ToFloat64(metrics.nonRetryableErrors))
+	metrics.Unregister()
+}
+
+func TestPutObjectSharesLimiterWithGetObject(t *testing.T) {
+	cfg := Config{
+		Controller: ControllerConfig{
+			Strategy: "aimd",
+			AIMD: AIMD{
+				Start:         10,
+				UpperBound:    100,
+				BackoffFactor: 0.5,
+			},
+		},
+	}
+
+	metrics := NewMetrics(t.Name(), cfg, nil)
+	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
+
+	// GetObject succeeds via the retrier, PutObject fails directly: both must move the same limit.
+	cli := newMockObjectClient(maxFailer{max: 0})
+	ctrl.Wrap(cli)
+
+	err := ctrl.PutObject(context.Background(), "foo", strings.NewReader("body"))
+	require.ErrorIs(t, err, errFakeFailure)
+	require.EqualValues(t, 5, testutil.ToFloat64(metrics.currentLimit))
+
+	cli.strategy = maxFailer{max: 1000}
+	_, _, err = ctrl.GetObject(context.Background(), "foo")
+	require.NoError(t, err)
+	require.EqualValues(t, 6, testutil.ToFloat64(metrics.currentLimit))
+	metrics.Unregister()
+}
+
 func runAndMeasureRate(ctx context.Context, ctrl Controller, duration time.Duration) (float64, float64) {
 	var count, success float64
 
@@ -253,7 +369,11 @@ type mockObjectClient struct {
 }
 
 func (m *mockObjectClient) PutObject(context.Context, string, io.Reader) error {
-	panic("not implemented")
+	if m.strategy.fail(m.reqCounter.Inc()) {
+		return errFakeFailure
+	}
+
+	return nil
 }
 
 func (m *mockObjectClient) GetObject(context.Context, string) (io.ReadCloser, int64, error) {
@@ -281,7 +401,11 @@ func (m *mockObjectClient) List(context.Context, string, string) ([]client.Stora
 }
 
 func (m *mockObjectClient) DeleteObject(context.Context, string) error {
-	panic("not implemented")
+	if m.strategy.fail(m.reqCounter.Inc()) {
+		return errFakeFailure
+	}
+
+	return nil
 }
 func (m *mockObjectClient) IsObjectNotFoundErr(error) bool { return false }
 func (m *mockObjectClient) IsRetryableErr(error) bool      { return !m.nonRetryableErrs }

--- a/pkg/storage/chunk/client/congestion/controller_test.go
+++ b/pkg/storage/chunk/client/congestion/controller_test.go
@@ -310,6 +310,44 @@ func TestPutObjectNonRetryableErrDoesNotAffectLimit(t *testing.T) {
 	metrics.Unregister()
 }
 
+func TestAwaitCapacityRespectsContextCancellation(t *testing.T) {
+	cfg := Config{
+		Controller: ControllerConfig{
+			Strategy: "aimd",
+			AIMD: AIMD{
+				Start:      1,
+				UpperBound: 1,
+			},
+		},
+	}
+
+	metrics := NewMetrics(t.Name(), cfg, nil)
+	ctrl := NewController(cfg, log.NewNopLogger(), metrics)
+
+	// never fails; we only care about admission pacing here
+	cli := newMockObjectClient(maxFailer{max: 1000})
+	ctrl.Wrap(cli)
+
+	// consume the only token in the bucket
+	require.NoError(t, ctrl.PutObject(context.Background(), "foo", strings.NewReader("body")))
+	require.EqualValues(t, 1, cli.reqCounter.Load())
+
+	// the limiter now has no capacity for ~1s; a context that's about to be cancelled must not
+	// block that long waiting for a token that will arrive well after the caller has given up
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := ctrl.PutObject(ctx, "foo", strings.NewReader("body"))
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, elapsed, 500*time.Millisecond, "must give up once the context is done rather than wait out the full backoff")
+	// the inner client must never see a request we already gave up on
+	require.EqualValues(t, 1, cli.reqCounter.Load())
+	metrics.Unregister()
+}
+
 func TestPutObjectSharesLimiterWithGetObject(t *testing.T) {
 	cfg := Config{
 		Controller: ControllerConfig{

--- a/pkg/storage/chunk/client/congestion/integration_test.go
+++ b/pkg/storage/chunk/client/congestion/integration_test.go
@@ -59,6 +59,10 @@ func isChunkGet(r *http.Request) bool {
 	return r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, testChunkKey)
 }
 
+func isChunkPut(r *http.Request) bool {
+	return r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, testChunkKey)
+}
+
 // writeS3Object writes a well-formed S3 GetObject 200 response. minio-go parses
 // the response headers into ObjectInfo and errors if required headers (ETag,
 // Last-Modified) are missing, so we set them like a real S3 server would.
@@ -175,4 +179,28 @@ func TestCongestionControl_S3Throttling_RecoversAfterRetry(t *testing.T) {
 
 	// 2 throttled attempts + 1 successful attempt.
 	require.EqualValues(t, 3, serverGets.Load())
+}
+
+// TestCongestionControl_S3Throttling_PutObjectNotRetried verifies that a write throttled by S3 is surfaced
+// immediately, with no retry at the congestion-control layer: PutObject's request body is a single-pass
+// io.Reader, and retrying after a partial read would silently upload truncated or wrong data. The resulting
+// error must still be classified as retryable, since that's what makes the shared AIMD limiter react to
+// throttled writes the same way it reacts to throttled reads (counter internals covered in controller_test.go).
+func TestCongestionControl_S3Throttling_PutObjectNotRetried(t *testing.T) {
+	var serverPuts atomic.Int64
+	ctrl := newCongestionControlledS3(t, func(w http.ResponseWriter, r *http.Request) {
+		if isChunkPut(r) {
+			serverPuts.Inc()
+			writeS3Error(w, http.StatusServiceUnavailable, "SlowDown", "Please reduce your request rate.")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := ctrl.PutObject(context.Background(), testChunkKey, strings.NewReader("chunk-bytes"))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, congestion.RetriesExceeded, "PutObject must never go through the retrier")
+	require.True(t, ctrl.IsRetryableErr(err), "SlowDown on a write must still be recognised as retryable so the AIMD limiter reacts to it")
+
+	require.EqualValues(t, 1, serverPuts.Load(), "exactly one PUT should reach S3 — no retry-with-resend of the body")
 }

--- a/pkg/storage/chunk/client/congestion/retry.go
+++ b/pkg/storage/chunk/client/congestion/retry.go
@@ -17,9 +17,19 @@ func NewNoopRetrier(Config) *NoopRetrier {
 	return &NoopRetrier{}
 }
 
-func (n *NoopRetrier) Do(fn DoRequestFunc, _ IsRetryableErrFunc, _ func(), _ func()) (io.ReadCloser, int64, error) {
-	// don't retry, just execute the given function once
-	return fn(0)
+func (n *NoopRetrier) Do(fn DoRequestFunc, isRetryable IsRetryableErrFunc, onSuccess func(), onError func()) (io.ReadCloser, int64, error) {
+	// don't retry, just execute the given function once, but still report the outcome so a
+	// wrapping congestion controller reacts to it — this is what makes it equivalent to
+	// LimitedRetrier with limit=0, per the comment below.
+	rc, sz, err := fn(0)
+	switch {
+	case err == nil:
+		onSuccess()
+	case isRetryable(err):
+		onError()
+	}
+
+	return rc, sz, err
 }
 
 func (n *NoopRetrier) withLogger(log.Logger) Retrier { return n }


### PR DESCRIPTION
What this PR does / why we need it:

AIMDController.PutObject and DeleteObject were pure passthroughs to the inner object client — they never participated in the shared rate limiter or AIMD backoff that GetObject already used. Under sustained S3 throttling (429 SlowDown / 503 StorageFull), writes kept going at full concurrency with no coordination across ingester flush workers, which is what kept the throttling going instead of easing it.

Both methods now wait on the same shared limiter as GetObject and feed their outcome into the same additive-increase/multiplicative-decrease signal, so a throttled write shrinks the send rate for every concurrent reader and writer, not just itself. Neither retries at this layer: the request body is a single-pass io.Reader, and resending it after a partial read would risk uploading truncated data, so the actual retry of the write is still left to the inner client.

Also fixes NoopRetrier.Do, which never invoked its onSuccess/onError callbacks despite being documented as equivalent to LimitedRetrier{limit: 0} (which does invoke them) — without this, the aimd controller strategy alone (without also setting retry.strategy=limited) never adjusted its rate limit on reads either.

Out of scope for this PR, flagged for follow-up:

The legacy aws-sdk-go-v2 S3 client (use_thanos_objstore: false) has the same class of bug on its write path (PutObject/DeleteObject have no retry wrapper at all there) — different files, separate fix.
Congestion control is still opt-in and off by default; this PR doesn't change that.
congestionControlReplacesThanosRetries can still disable the inner client's own retries for writes without this layer replacing them — a pre-existing footgun this PR doesn't close.
Which issue(s) this PR fixes:
Fixes #23754

Special notes for your reviewer:

Verified the regression coverage actually catches the bug: stashing just the fix (controller.go + retry.go) while keeping the new tests causes 4 of 5 new tests to fail, each failing on the exact mechanism being fixed (e.g. the shared rate limit stays at its starting value after a throttled write instead of halving). Also added an end-to-end test in integration_test.go against the real thanos/minio-go stack and a fake S3 server returning 503 SlowDown on PUT, confirming exactly one request reaches the server (no retry-with-resend of the body).

**Special notes for your reviewer**:

**Checklist**
- [✅ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ✅] Tests updated
- [ ✅] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
